### PR TITLE
T006: Local skill install and e2e test

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,6 +9,10 @@ This repo tracks development, publishes to grobomo GitHub, and provides a market
 - [x] T001: Create specs and project structure
 - [x] T002: Sync repo runners with live system (load-modules.js)
 - [x] T003: Build setup.js wizard (scan → report → backup → install → verify)
-- [ ] T004: Create marketplace plugin entry in grobomo/claude-code-skills
-- [ ] T005: Update README.md and push all to grobomo/hook-runner
-- [ ] T006: Install skill locally and test end-to-end
+- [x] T004: Create marketplace plugin entry in grobomo/claude-code-skills
+- [x] T005: Update README.md and push all to grobomo/hook-runner
+- [x] T006: Install skill locally and test end-to-end
+
+## Also Done (gate improvements)
+- [x] Fixed continuous-claude-gate.js → renamed to "Tracked Workflow Gate", removed CONTINUOUS_CLAUDE=1 bypass, added bootstrap detection
+- [x] Fixed spec-gate.js, branch-pr-gate.js — replaced hackathon-specific language with generic dev-team language, kept WHY reasoning

--- a/specs/setup-wizard/tasks.md
+++ b/specs/setup-wizard/tasks.md
@@ -1,27 +1,27 @@
 # Setup Wizard — Tasks
 
 ## Phase 1: Project Sync
-- [ ] T001: Sync repo runners with live system (load-modules.js, updated runners)
-- [ ] T002: Add .gitignore and secret-scan CI
+- [x] T001: Sync repo runners with live system (load-modules.js, updated runners)
+- [x] T002: Add .gitignore and secret-scan CI
 
 **Checkpoint**: `bash scripts/test/test-runners.sh` — verify runners load modules correctly
 
 ---
 
 ## Phase 2: Setup Wizard Core
-- [ ] T003: Build hook scanner (reads settings.json, resolves scripts, categorizes)
-- [ ] T004: Build HTML report generator (styled report showing current hooks)
-- [ ] T005: Build backup engine (archive existing hooks before changes)
-- [ ] T006: Build installer (copy runners, create dirs, update settings.json)
-- [ ] T007: Build setup.js orchestrator (scan → report → preview → confirm → backup → install → verify)
+- [x] T003: Build hook scanner (reads settings.json, resolves scripts, categorizes)
+- [x] T004: Build HTML report generator (styled report showing current hooks)
+- [x] T005: Build backup engine (archive existing hooks before changes)
+- [x] T006: Build installer (copy runners, create dirs, update settings.json)
+- [x] T007: Build setup.js orchestrator (scan → report → preview → confirm → backup → install → verify)
 
 **Checkpoint**: `bash scripts/test/test-setup-wizard.sh` — run setup in dry-run mode, verify report + backup + install
 
 ---
 
 ## Phase 3: Skill & Marketplace
-- [ ] T008: Create SKILL.md for hook-runner skill
-- [ ] T009: Create marketplace plugin entry in grobomo/claude-code-skills
-- [ ] T010: Update README.md with setup wizard docs
+- [x] T008: Create SKILL.md for hook-runner skill
+- [x] T009: Create marketplace plugin entry in grobomo/claude-code-skills
+- [x] T010: Update README.md with setup wizard docs
 
 **Checkpoint**: `bash scripts/test/test-skill-install.sh` — verify skill installs and setup.js runs


### PR DESCRIPTION
## Summary
- Installed hook-runner skill locally to ~/.claude/skills/hook-runner/
- Tested report mode: generates styled HTML, opens in browser, correctly detects runner system
- Tested dry-run mode: shows current state, proposed changes, doesn't modify anything
- Updated all spec tasks to complete

## Test plan
- [x] `node setup.js --report` — generates report, opens browser
- [x] `node setup.js --dry-run` — shows changes, doesn't modify settings.json
- [x] Skill appears in Claude Code skill list