### PR TITLE
T027: Document hook-log.jsonl in config and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ Rules:
 | PostToolUse | run-posttooluse.js | Edit, Write | `{decision: "block"}` or `null` |
 | Stop | run-stop.js | none | `{decision: "block"}` or `null` |
 
+## Logging
+
+Runners log every module invocation to `~/.claude/hooks/hook-log.jsonl`. Each line records the timestamp, event, module name, result (pass/block/error), and context (tool name, command snippet, project). The log auto-rotates at 10MB.
+
+The setup report (`/hook-runner report`) reads the log and shows hit counts and sample triggers per module.
+
 ## Project-Scoped Modules
 
 Modules in a subfolder matching your project name only run for that project:

--- a/modules.example.yaml
+++ b/modules.example.yaml
@@ -4,6 +4,9 @@
 # source: GitHub repo to pull modules from
 # modules: which modules to install per event type
 # Each module name maps to modules/<Event>/<name>.js in the source repo
+#
+# Logging: runners write to ~/.claude/hooks/hook-log.jsonl (auto-rotates at 10MB)
+# Add hook-log.jsonl to .gitignore if you symlink or copy logs into a project
 
 source: grobomo/hook-runner
 branch: main


### PR DESCRIPTION
## Summary
- Added logging location note to modules.example.yaml header
- Added Logging section to README explaining the JSONL log, auto-rotation, and report integration

## Test plan
- [ ] Verify modules.example.yaml renders correctly
- [ ] Verify README Logging section is accurate