### PR TITLE
T030: Async module support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ module.exports = function(input) {
 ```
 
 Rules:
-- **Synchronous only** — no async/await, no Promises, use `require()` not `import`
+- **Sync or async** — modules can return a value (sync) or a Promise (async). Async modules are awaited with a 4s per-module timeout.
+- Use `require()` not `import`
 - **Return null to pass**, `{decision: "block", reason: "..."}` to block
 - **Alphabetical order** — prefix with `01-` to control execution order
 - **Never edit settings.json** — runners are already registered, just add module files
@@ -83,6 +84,22 @@ Rules:
 Runners log every module invocation to `~/.claude/hooks/hook-log.jsonl`. Each line records the timestamp, event, module name, result (pass/block/error), and context (tool name, command snippet, project). The log auto-rotates at 10MB.
 
 The setup report (`/hook-runner report`) reads the log and shows hit counts and sample triggers per module.
+
+### Async Module Example
+
+```javascript
+// run-modules/SessionStart/backup-config.js
+module.exports = function(input) {
+  return new Promise(function(resolve) {
+    var cp = require("child_process");
+    cp.exec("node /path/to/backup.js", function(err) {
+      resolve(err ? null : { text: "Config backup complete" });
+    });
+  });
+};
+```
+
+Async modules have a 4-second timeout per module. If a module times out, it's logged as an error and the next module runs.
 
 ## Project-Scoped Modules
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -108,7 +108,7 @@ module.exports = function(input) {
 };
 ```
 
-- Modules MUST be synchronous (no async/await)
+- Modules can be sync (return value) or async (return Promise, 4s timeout per module)
 - Use `require()` not `import`
 - Return `null` to pass, `{decision: "block", reason: "..."}` to block
 - Modules run alphabetically — prefix with `01-` for ordering

--- a/TODO.md
+++ b/TODO.md
@@ -31,6 +31,12 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 ## Completed (health check)
 - [x] T029: Health check command — verifies runners, modules, settings, log writability
 
+## Completed (async hooks)
+- [x] T030: Async module support — runners detect Promises, await with 4s timeout, sequential execution preserved
+
+## Pending
+- [ ] T031: Report improvements — show all event types (including empty), clickable rules in flow diagram, link to Claude hook docs, remove "Tool executes" block
+
 ## Moved
 - T026: Moved to chat-export/TODO.md (out of scope for hook-runner)
 

--- a/run-async.js
+++ b/run-async.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+"use strict";
+/**
+ * Async module execution helper for hook-runner.
+ *
+ * Detects whether a module returns a Promise (thenable) and awaits it
+ * with a per-module timeout. Sync modules pass through unchanged.
+ *
+ * Usage:
+ *   var runAsync = require("./run-async");
+ *   runAsync(modules, input, EVENT, handleResult, handleDone);
+ */
+
+var DEFAULT_TIMEOUT = 4000; // 4s per module (Claude Code hook timeout is 5s)
+
+/**
+ * Check if a value is a thenable (Promise-like).
+ */
+function isThenable(val) {
+  return val && typeof val === "object" && typeof val.then === "function";
+}
+
+/**
+ * Wrap a Promise with a timeout. Rejects if the promise doesn't resolve
+ * within `ms` milliseconds.
+ */
+function withTimeout(promise, ms, label) {
+  return new Promise(function (resolve, reject) {
+    var timer = setTimeout(function () {
+      reject(new Error("async timeout (" + ms + "ms) for " + label));
+    }, ms);
+    promise.then(
+      function (val) { clearTimeout(timer); resolve(val); },
+      function (err) { clearTimeout(timer); reject(err); }
+    );
+  });
+}
+
+/**
+ * Run modules sequentially, supporting both sync and async.
+ *
+ * @param {string[]} modulePaths - array of absolute paths to module files
+ * @param {object} input - parsed hook input
+ * @param {function} handleResult - called with (modName, result) for each module.
+ *   Return true to stop iteration (first-block-wins).
+ * @param {function} handleDone - called when all modules have run
+ * @param {number} [timeout] - per-module timeout in ms (default 4000)
+ */
+function runModules(modulePaths, input, handleResult, handleDone, timeout) {
+  timeout = timeout || DEFAULT_TIMEOUT;
+  var hasAsync = false;
+  var i = 0;
+
+  function next() {
+    if (i >= modulePaths.length) {
+      handleDone();
+      return;
+    }
+
+    var modPath = modulePaths[i];
+    var path = require("path");
+    var modName = path.basename(modPath, ".js");
+    i++;
+
+    try {
+      var mod = require(modPath);
+      var result = mod(input);
+
+      if (isThenable(result)) {
+        // Async module — await with timeout
+        hasAsync = true;
+        withTimeout(result, timeout, modName).then(
+          function (val) {
+            if (handleResult(modName, val)) return; // stopped
+            next();
+          },
+          function (err) {
+            handleResult(modName, null, err);
+            next();
+          }
+        );
+      } else {
+        // Sync module — process immediately
+        if (handleResult(modName, result)) return; // stopped
+        next();
+      }
+    } catch (e) {
+      handleResult(modName, null, e);
+      next();
+    }
+  }
+
+  next();
+}
+
+module.exports = { runModules: runModules, isThenable: isThenable, withTimeout: withTimeout, DEFAULT_TIMEOUT: DEFAULT_TIMEOUT };

--- a/run-posttooluse.js
+++ b/run-posttooluse.js
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
 "use strict";
 // hook-runner PostToolUse — loads global + project-scoped modules
+// Supports both sync and async modules (async awaited with 4s timeout)
 var fs = require("fs");
 var path = require("path");
 var loadModules = require("./load-modules");
 var hookLog = require("./hook-log");
+var runAsync = require("./run-async");
 
 var input;
 try {
@@ -16,19 +18,22 @@ try {
 var ctx = hookLog.extractContext("PostToolUse", input);
 var modules = loadModules(path.join(__dirname, "run-modules", "PostToolUse"));
 
-for (var i = 0; i < modules.length; i++) {
-  var modName = path.basename(modules[i], ".js");
-  try {
-    var mod = require(modules[i]);
-    var result = mod(input);
+runAsync.runModules(modules, input,
+  function handleResult(modName, result, err) {
+    if (err) {
+      hookLog.logHook("PostToolUse", modName, "error", Object.assign({}, ctx, { reason: err.message }));
+      process.stderr.write("hook-runner PostToolUse " + modName + " error: " + err.message + "\n");
+      return false;
+    }
     if (result && result.decision) {
       hookLog.logHook("PostToolUse", modName, result.decision, Object.assign({}, ctx, { reason: result.reason }));
       process.stdout.write(JSON.stringify(result));
       process.exit(0);
     }
     hookLog.logHook("PostToolUse", modName, "pass", ctx);
-  } catch (e) {
-    hookLog.logHook("PostToolUse", modName, "error", Object.assign({}, ctx, { reason: e.message }));
-    process.stderr.write("hook-runner PostToolUse " + modName + " error: " + e.message + "\n");
+    return false;
+  },
+  function handleDone() {
+    // No output = allow
   }
-}
+);

--- a/run-pretooluse.js
+++ b/run-pretooluse.js
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
 "use strict";
 // hook-runner PreToolUse — loads global + project-scoped modules
+// Supports both sync and async modules (async awaited with 4s timeout)
 var fs = require("fs");
 var path = require("path");
 var loadModules = require("./load-modules");
 var hookLog = require("./hook-log");
+var runAsync = require("./run-async");
 
 var input;
 try {
@@ -16,20 +18,22 @@ try {
 var ctx = hookLog.extractContext("PreToolUse", input);
 var modules = loadModules(path.join(__dirname, "run-modules", "PreToolUse"));
 
-for (var i = 0; i < modules.length; i++) {
-  var modName = path.basename(modules[i], ".js");
-  try {
-    var mod = require(modules[i]);
-    var result = mod(input);
+runAsync.runModules(modules, input,
+  function handleResult(modName, result, err) {
+    if (err) {
+      hookLog.logHook("PreToolUse", modName, "error", Object.assign({}, ctx, { reason: err.message }));
+      process.stderr.write("hook-runner PreToolUse " + modName + " error: " + err.message + "\n");
+      return false;
+    }
     if (result && result.decision) {
       hookLog.logHook("PreToolUse", modName, result.decision, Object.assign({}, ctx, { reason: result.reason }));
       process.stdout.write(JSON.stringify(result));
       process.exit(0);
     }
     hookLog.logHook("PreToolUse", modName, "pass", ctx);
-  } catch (e) {
-    hookLog.logHook("PreToolUse", modName, "error", Object.assign({}, ctx, { reason: e.message }));
-    process.stderr.write("hook-runner PreToolUse " + modName + " error: " + e.message + "\n");
+    return false;
+  },
+  function handleDone() {
+    // No output = allow
   }
-}
-// No output = allow
+);

--- a/run-sessionstart.js
+++ b/run-sessionstart.js
@@ -2,10 +2,12 @@
 "use strict";
 // hook-runner SessionStart — loads global + project-scoped modules
 // SessionStart hooks output context text (not block/allow decisions)
+// Supports both sync and async modules (async awaited with 4s timeout)
 var fs = require("fs");
 var path = require("path");
 var loadModules = require("./load-modules");
 var hookLog = require("./hook-log");
+var runAsync = require("./run-async");
 
 var input;
 try {
@@ -18,23 +20,24 @@ var ctx = hookLog.extractContext("SessionStart", input);
 var modules = loadModules(path.join(__dirname, "run-modules", "SessionStart"));
 var output = [];
 
-for (var i = 0; i < modules.length; i++) {
-  var modName = path.basename(modules[i], ".js");
-  try {
-    var mod = require(modules[i]);
-    var result = mod(input);
+runAsync.runModules(modules, input,
+  function handleResult(modName, result, err) {
+    if (err) {
+      hookLog.logHook("SessionStart", modName, "error", Object.assign({}, ctx, { reason: err.message }));
+      process.stderr.write("hook-runner SessionStart " + modName + " error: " + err.message + "\n");
+      return false;
+    }
     if (result && result.text) {
       hookLog.logHook("SessionStart", modName, "text", ctx);
       output.push(result.text);
     } else {
       hookLog.logHook("SessionStart", modName, "pass", ctx);
     }
-  } catch (e) {
-    hookLog.logHook("SessionStart", modName, "error", Object.assign({}, ctx, { reason: e.message }));
-    process.stderr.write("hook-runner SessionStart " + modName + " error: " + e.message + "\n");
+    return false; // never stop — collect all text
+  },
+  function handleDone() {
+    if (output.length > 0) {
+      process.stdout.write(output.join("\n"));
+    }
   }
-}
-
-if (output.length > 0) {
-  process.stdout.write(output.join("\n"));
-}
+);

--- a/run-stop.js
+++ b/run-stop.js
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
 "use strict";
 // hook-runner Stop — loads global + project-scoped modules
+// Supports both sync and async modules (async awaited with 4s timeout)
 var fs = require("fs");
 var path = require("path");
 var loadModules = require("./load-modules");
 var hookLog = require("./hook-log");
+var runAsync = require("./run-async");
 
 var input;
 try {
@@ -17,19 +19,22 @@ if (input.stop_hook_active) process.exit(0);
 var ctx = hookLog.extractContext("Stop", input);
 var modules = loadModules(path.join(__dirname, "run-modules", "Stop"));
 
-for (var i = 0; i < modules.length; i++) {
-  var modName = path.basename(modules[i], ".js");
-  try {
-    var mod = require(modules[i]);
-    var result = mod(input);
+runAsync.runModules(modules, input,
+  function handleResult(modName, result, err) {
+    if (err) {
+      hookLog.logHook("Stop", modName, "error", Object.assign({}, ctx, { reason: err.message }));
+      process.stderr.write("hook-runner Stop " + modName + " error: " + err.message + "\n");
+      return false;
+    }
     if (result && result.decision === "block") {
       hookLog.logHook("Stop", modName, "block", Object.assign({}, ctx, { reason: result.reason }));
       process.stdout.write(JSON.stringify(result));
       process.exit(0);
     }
     hookLog.logHook("Stop", modName, "pass", ctx);
-  } catch (e) {
-    hookLog.logHook("Stop", modName, "error", Object.assign({}, ctx, { reason: e.message }));
-    process.stderr.write("hook-runner Stop " + modName + " error: " + e.message + "\n");
+    return false;
+  },
+  function handleDone() {
+    // No output = allow stop
   }
-}
+);

--- a/scripts/test/test-async.sh
+++ b/scripts/test/test-async.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+# Test async module support in hook-runner
+set -euo pipefail
+
+PASS=0
+FAIL=0
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+echo "=== hook-runner: async module tests ==="
+
+# Setup: create temp module dir with sync + async modules
+# Use project-relative dir and convert to Windows path for Node.js compatibility
+SCRIPT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+BASH_TMPDIR="$SCRIPT_DIR/.test-async-tmp"
+mkdir -p "$BASH_TMPDIR"
+trap "rm -rf $BASH_TMPDIR" EXIT
+
+# Node.js on Windows needs C:/... not /c/... paths
+if command -v cygpath &>/dev/null; then
+  NODE_TMPDIR="$(cygpath -w "$BASH_TMPDIR" | sed 's/\\/\//g')"
+else
+  NODE_TMPDIR="$BASH_TMPDIR"
+fi
+
+MODDIR="$BASH_TMPDIR/run-modules/PreToolUse"
+NODE_MODDIR="$NODE_TMPDIR/run-modules/PreToolUse"
+mkdir -p "$MODDIR"
+
+# 1. Sync module that passes
+cat > "$MODDIR/01-sync-pass.js" << 'MODEOF'
+module.exports = function(input) { return null; };
+MODEOF
+
+# 2. Async module that passes (resolves null)
+cat > "$MODDIR/02-async-pass.js" << 'MODEOF'
+module.exports = function(input) {
+  return new Promise(function(resolve) {
+    setTimeout(function() { resolve(null); }, 50);
+  });
+};
+MODEOF
+
+# 3. Sync module that blocks
+cat > "$MODDIR/03-sync-block.js" << 'MODEOF'
+module.exports = function(input) {
+  return { decision: "block", reason: "sync block test" };
+};
+MODEOF
+
+echo "[1] run-async.js loads and exports expected functions"
+node -e "
+var ra = require('./run-async');
+if (typeof ra.runModules !== 'function') throw new Error('runModules not a function');
+if (typeof ra.isThenable !== 'function') throw new Error('isThenable not a function');
+if (typeof ra.withTimeout !== 'function') throw new Error('withTimeout not a function');
+" && pass "run-async exports correct functions" || fail "run-async exports"
+
+echo "[2] isThenable detects Promises"
+node -e "
+var ra = require('./run-async');
+if (!ra.isThenable(Promise.resolve(1))) throw new Error('should detect Promise');
+if (ra.isThenable(null)) throw new Error('null should not be thenable');
+if (ra.isThenable(42)) throw new Error('number should not be thenable');
+if (ra.isThenable({decision:'block'})) throw new Error('plain object should not be thenable');
+" && pass "isThenable works correctly" || fail "isThenable"
+
+echo "[3] Sync modules still work (pass through)"
+RESULT=$(echo '{"tool_name":"Bash","tool_input":{"command":"echo hi"}}' | node -e "
+var path = require('path');
+var runAsync = require('./run-async');
+var fs = require('fs');
+var input = JSON.parse(fs.readFileSync(0, 'utf-8'));
+var mods = ['$NODE_MODDIR/01-sync-pass.js'];
+runAsync.runModules(mods, input,
+  function(name, result, err) {
+    if (err) { console.log('ERROR:' + err.message); return false; }
+    if (result && result.decision) { console.log('BLOCK:' + name); return true; }
+    console.log('PASS:' + name);
+    return false;
+  },
+  function() { console.log('DONE'); }
+);
+")
+echo "$RESULT" | grep -q "PASS:01-sync-pass" && pass "sync module passes" || fail "sync module pass"
+echo "$RESULT" | grep -q "DONE" && pass "done callback fires" || fail "done callback"
+
+echo "[4] Async module resolves and passes"
+RESULT=$(echo '{"tool_name":"Bash","tool_input":{"command":"echo hi"}}' | node -e "
+var path = require('path');
+var runAsync = require('./run-async');
+var fs = require('fs');
+var input = JSON.parse(fs.readFileSync(0, 'utf-8'));
+var mods = ['$NODE_MODDIR/02-async-pass.js'];
+runAsync.runModules(mods, input,
+  function(name, result, err) {
+    if (err) { console.log('ERROR:' + err.message); return false; }
+    if (result && result.decision) { console.log('BLOCK:' + name); return true; }
+    console.log('PASS:' + name);
+    return false;
+  },
+  function() { console.log('DONE'); }
+);
+")
+echo "$RESULT" | grep -q "PASS:02-async-pass" && pass "async module resolves" || fail "async module resolve"
+echo "$RESULT" | grep -q "DONE" && pass "done after async" || fail "done after async"
+
+echo "[5] Mixed sync + async + block — block stops iteration"
+RESULT=$(echo '{"tool_name":"Bash","tool_input":{"command":"echo hi"}}' | node -e "
+var runAsync = require('./run-async');
+var fs = require('fs');
+var input = JSON.parse(fs.readFileSync(0, 'utf-8'));
+var mods = ['$NODE_MODDIR/01-sync-pass.js', '$NODE_MODDIR/02-async-pass.js', '$NODE_MODDIR/03-sync-block.js'];
+runAsync.runModules(mods, input,
+  function(name, result, err) {
+    if (err) { console.log('ERROR:' + name); return false; }
+    if (result && result.decision) { console.log('BLOCK:' + name); return true; }
+    console.log('PASS:' + name);
+    return false;
+  },
+  function() { console.log('DONE'); }
+);
+")
+echo "$RESULT" | grep -q "PASS:01-sync-pass" && pass "sync runs first" || fail "sync first"
+echo "$RESULT" | grep -q "PASS:02-async-pass" && pass "async runs second" || fail "async second"
+echo "$RESULT" | grep -q "BLOCK:03-sync-block" && pass "block stops iteration" || fail "block stops"
+
+echo "[6] Async timeout fires for slow modules"
+cat > "$MODDIR/99-slow.js" << 'MODEOF'
+module.exports = function(input) {
+  return new Promise(function(resolve) {
+    setTimeout(function() { resolve(null); }, 10000);
+  });
+};
+MODEOF
+RESULT=$(echo '{}' | node -e "
+var runAsync = require('./run-async');
+var fs = require('fs');
+var input = JSON.parse(fs.readFileSync(0, 'utf-8'));
+var mods = ['$NODE_MODDIR/99-slow.js'];
+runAsync.runModules(mods, input,
+  function(name, result, err) {
+    if (err) { console.log('TIMEOUT:' + name + ':' + err.message); return false; }
+    console.log('PASS:' + name);
+    return false;
+  },
+  function() { console.log('DONE'); },
+  200  // 200ms timeout for test speed
+);
+")
+echo "$RESULT" | grep -q "TIMEOUT:99-slow" && pass "timeout fires for slow module" || fail "timeout"
+echo "$RESULT" | grep -q "DONE" && pass "done after timeout" || fail "done after timeout"
+
+echo "[7] Async module that resolves with a block decision"
+cat > "$MODDIR/04-async-block.js" << 'MODEOF'
+module.exports = function(input) {
+  return new Promise(function(resolve) {
+    setTimeout(function() {
+      resolve({ decision: "block", reason: "async block test" });
+    }, 50);
+  });
+};
+MODEOF
+RESULT=$(echo '{"tool_name":"Bash","tool_input":{"command":"test"}}' | node -e "
+var runAsync = require('./run-async');
+var fs = require('fs');
+var input = JSON.parse(fs.readFileSync(0, 'utf-8'));
+var mods = ['$NODE_MODDIR/01-sync-pass.js', '$NODE_MODDIR/04-async-block.js', '$NODE_MODDIR/03-sync-block.js'];
+var order = [];
+runAsync.runModules(mods, input,
+  function(name, result, err) {
+    if (err) { order.push('ERROR:' + name); return false; }
+    if (result && result.decision) { order.push('BLOCK:' + name); console.log(order.join(',')); return true; }
+    order.push('PASS:' + name);
+    return false;
+  },
+  function() { console.log(order.join(',')); console.log('DONE'); }
+);
+")
+echo "$RESULT" | grep -q "BLOCK:04-async-block" && pass "async block decision works" || fail "async block"
+# 03-sync-block should NOT appear — iteration stopped at async block
+echo "$RESULT" | grep -q "03-sync-block" && fail "should not reach module after block" || pass "iteration stopped at async block"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary
- New `run-async.js` helper: detects Promise returns from modules, awaits with 4s per-module timeout
- All 4 runners updated to use run-async (backward compatible — sync modules unchanged)
- Enables use cases like running `claude-backup` on SessionStart

## Test plan
- [x] 13 new async-specific tests (sync pass, async pass, mixed, timeout, async block)
- [x] 30 existing tests still pass (43 total)
- [x] Synced to live hooks and skill copy