### PR TITLE
T034: Async backup-check SessionStart module

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -37,10 +37,10 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 ## Completed (report + async)
 - [x] T031: Report improvements — all events shown, clickable flow, Claude event labels, docs link
 
-## Pending
-- [ ] T032: Marketplace sync — push T030 (async) + T031 (report) to claude-code-skills
-- [ ] T033: Update global rule hooks-must-be-sync.md — now async is supported, update the rule
-- [ ] T034: Create example async SessionStart module for claude-backup integration
+## Completed (marketplace + rules + examples)
+- [x] T032: Marketplace sync — push T030 (async) + T031 (report) to claude-code-skills
+- [x] T033: Update global rule hooks-must-be-sync.md → hooks-module-contract (async now supported)
+- [x] T034: Create example async SessionStart module for claude-backup integration
 
 ## Moved
 - T026: Moved to chat-export/TODO.md (out of scope for hook-runner)

--- a/modules.example.yaml
+++ b/modules.example.yaml
@@ -38,6 +38,7 @@ modules:
 
   SessionStart:
     - load-instructions      # inject working instructions at session start
+    # - backup-check         # async: warn if claude-backup is stale (>72h)
 
 # Project-scoped modules (optional)
 # These only run when CLAUDE_PROJECT_DIR basename matches the key

--- a/modules/SessionStart/backup-check.js
+++ b/modules/SessionStart/backup-check.js
@@ -1,0 +1,42 @@
+// SessionStart: async example — check backup freshness at session start
+// Demonstrates async module support (hook-runner T030)
+// Requires: claude-backup skill installed at ~/.claude/skills/claude-backup/
+var fs = require("fs");
+var path = require("path");
+
+module.exports = async function(input) {
+  var backupDir = path.join(process.env.HOME || process.env.USERPROFILE, ".claude", "backups");
+
+  // Check if backup directory exists
+  try {
+    fs.accessSync(backupDir);
+  } catch (e) {
+    return { text: "WARNING: No claude-backup directory found. Run /claude-backup to create your first backup." };
+  }
+
+  // Find most recent backup
+  var entries;
+  try {
+    entries = fs.readdirSync(backupDir).filter(function(name) {
+      return fs.statSync(path.join(backupDir, name)).isDirectory();
+    }).sort().reverse();
+  } catch (e) {
+    return null; // can't read, skip silently
+  }
+
+  if (entries.length === 0) {
+    return { text: "WARNING: Backup directory is empty. Run /claude-backup to create a backup." };
+  }
+
+  // Check age of most recent backup
+  var latest = entries[0];
+  var latestPath = path.join(backupDir, latest);
+  var stat = fs.statSync(latestPath);
+  var ageHours = (Date.now() - stat.mtimeMs) / (1000 * 60 * 60);
+
+  if (ageHours > 72) {
+    return { text: "REMINDER: Last claude-backup is " + Math.round(ageHours) + "h old. Consider running /claude-backup." };
+  }
+
+  return null; // backup is fresh, nothing to report
+};


### PR DESCRIPTION
## Summary
- Add `backup-check.js` async SessionStart module — warns if claude-backup is stale (>72h) or missing
- Demonstrates async module support from T030
- Added to `modules.example.yaml` (commented out by default)

## Test plan
- [x] Module returns warning when backup dir is empty
- [x] Module returns null when backup is fresh
- [x] All existing tests still pass (43/43)