### PR TITLE
T037: Fix double-count bug in stats and add missing files to installer

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -46,9 +46,12 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 - [x] T035: Report v2 — standalone hooks support, search/filter, expand/collapse, block-only stats
 - [x] T036: README — highlight report as standalone tool, add health/sync commands, add backup-check module
 
+## Bug Fixes
+- [x] T037: Fix double-count bug in readHookStats (block result incremented twice) + add hook-log.js and run-async.js to installer
+
 ## Status
 All tasks complete. Project is mature and stable:
-- 36 tasks completed, 0 pending
+- 37 tasks completed, 0 pending
 - 33 tests passing (14 runner + 6 wizard + 13 async)
 - 4 sync targets all identical: repo, live hooks, skill, marketplace
 - Report works for both hook-runner users and standalone hooks users

--- a/setup.js
+++ b/setup.js
@@ -69,7 +69,8 @@ function readHookStats(maxSamples) {
     s.total++;
     var r = entry.result || "pass";
     if (r === "pass") s.pass++;
-    else if (r === "block" || r === "deny") { s.block++; s[r]++; }
+    else if (r === "block") s.block++;
+    else if (r === "deny") { s.block++; s.deny++; }
     else if (r === "error") s.error++;
     else if (r === "text") s.text++;
 
@@ -865,7 +866,7 @@ function installRunners(dryRun) {
   if (!dryRun) fs.mkdirSync(HOOKS_DIR, { recursive: true });
 
   // Copy runner scripts + load-modules.js
-  var runnerFiles = ["run-pretooluse.js", "run-posttooluse.js", "run-stop.js", "run-sessionstart.js", "load-modules.js"];
+  var runnerFiles = ["run-pretooluse.js", "run-posttooluse.js", "run-stop.js", "run-sessionstart.js", "load-modules.js", "hook-log.js", "run-async.js"];
   for (var i = 0; i < runnerFiles.length; i++) {
     var src = path.join(REPO_DIR, runnerFiles[i]);
     var dest = path.join(HOOKS_DIR, runnerFiles[i]);


### PR DESCRIPTION
## Summary
- **Stats bug**: `readHookStats` double-counted block results (s.block++ then s["block"]++ via s[r]++), inflating block counts 2x
- **Installer bug**: `hook-log.js` and `run-async.js` missing from `installRunners` copy list — fresh installs lacked logging and async support

## Test plan
- [x] All 33 tests pass (14 runner + 13 async + 6 wizard)
- [x] Wizard test 6 now returns 12 changes (was 10) reflecting 2 additional files