### PR TITLE
T038: Fix updateSettings losing custom hook events on install

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -48,10 +48,11 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 
 ## Bug Fixes
 - [x] T037: Fix double-count bug in readHookStats (block result incremented twice) + add hook-log.js and run-async.js to installer
+- [x] T038: Fix updateSettings losing custom events (detected but not preserved due to overwrite)
 
 ## Status
 All tasks complete. Project is mature and stable:
-- 37 tasks completed, 0 pending
+- 38 tasks completed, 0 pending
 - 33 tests passing (14 runner + 6 wizard + 13 async)
 - 4 sync targets all identical: repo, live hooks, skill, marketplace
 - Report works for both hook-runner users and standalone hooks users

--- a/setup.js
+++ b/setup.js
@@ -925,25 +925,14 @@ function updateSettings(dryRun) {
     ]
   };
 
-  // Preserve existing matchers the user has that we don't define
+  // Preserve custom events that hook-runner doesn't define
   var existingEvents = Object.keys(settings.hooks);
   for (var i = 0; i < existingEvents.length; i++) {
     var evt = existingEvents[i];
     if (!runnerConfig[evt]) {
-      // Unknown event — check if it's already a runner, preserve if so
-      var entries = settings.hooks[evt];
-      if (Array.isArray(entries)) {
-        var hasRunner = false;
-        for (var j = 0; j < entries.length; j++) {
-          var h = (entries[j].hooks || [])[0] || {};
-          if (h.command && /run-\w+\.js/.test(h.command)) hasRunner = true;
-        }
-        if (!hasRunner) {
-          // Create a runner entry for this unknown event
-          var runnerName = "run-" + evt.toLowerCase() + ".js";
-          changes.push({ action: "note", file: evt, reason: "custom event — preserving existing config" });
-        }
-      }
+      // Custom event — preserve its existing config
+      runnerConfig[evt] = settings.hooks[evt];
+      changes.push({ action: "preserved", file: evt, reason: "custom event — kept existing config" });
     }
   }
 


### PR DESCRIPTION
## Summary
- `updateSettings` detected custom events (e.g. UserPromptSubmit) and logged "preserving existing config" but then `settings.hooks = runnerConfig` overwrote everything
- Now merges custom events into `runnerConfig` before the assignment

## Test plan
- [x] All 33 tests pass
- [x] Custom events in settings.json are preserved through install