### PR TITLE
T040: Document prune and version commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ No installation required — just clone and run `node setup.js --report`.
 /hook-runner dry-run      # preview changes without modifying anything
 /hook-runner health       # verify all runners and modules load correctly
 /hook-runner sync         # sync modules from GitHub per modules.yaml
+/hook-runner prune        # prune log entries older than 7 days
+/hook-runner version      # show hook-runner version
 ```
 
 The setup wizard will:
@@ -101,7 +103,13 @@ Rules:
 
 ## Logging
 
-Runners log every module invocation to `~/.claude/hooks/hook-log.jsonl`. Each line records the timestamp, event, module name, result (pass/block/error), and context (tool name, command snippet, project). The log auto-rotates at 10MB.
+Runners log every module invocation to `~/.claude/hooks/hook-log.jsonl`. Each line records the timestamp, event, module name, result (pass/block/error), and context (tool name, command snippet, project). The log auto-rotates at 10MB. Stats include both current and rotated log files.
+
+```bash
+/hook-runner prune             # prune entries older than 7 days
+node setup.js --prune 3        # keep only last 3 days
+node setup.js --prune 7 --dry-run  # preview without deleting
+```
 
 The setup report (`/hook-runner report`) reads the log and shows hit counts and sample triggers per module.
 

--- a/TODO.md
+++ b/TODO.md
@@ -52,10 +52,11 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 
 ## Enhancements
 - [x] T039: Log rotation in stats, --prune command, --version flag
+- [x] T040: README — document prune and version commands
 
 ## Status
 All tasks complete. Project is mature and stable:
-- 39 tasks completed, 0 pending
+- 40 tasks completed, 0 pending
 - 33 tests passing (14 runner + 6 wizard + 13 async)
 - 4 sync targets all identical: repo, live hooks, skill, marketplace
 - Report works for both hook-runner users and standalone hooks users


### PR DESCRIPTION
## Summary
- Added `/hook-runner prune` and `/hook-runner version` to Quick Start commands
- Added log pruning examples to Logging section