### PR TITLE
T041: Add --stats command for quick text hook log summary

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -31,6 +31,9 @@ custom_commands:
   - name: health
     command: "node $SKILL_DIR/setup.js --health"
     description: "Verify all runners and modules load correctly"
+  - name: stats
+    command: "node $SKILL_DIR/setup.js --stats"
+    description: "Quick text summary of hook log — blocks, errors, active hooks"
   - name: prune
     command: "node $SKILL_DIR/setup.js --prune 7"
     description: "Prune hook log entries older than 7 days"

--- a/TODO.md
+++ b/TODO.md
@@ -53,10 +53,11 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 ## Enhancements
 - [x] T039: Log rotation in stats, --prune command, --version flag
 - [x] T040: README — document prune and version commands
+- [x] T041: Add --stats command for quick text summary of hook log
 
 ## Status
 All tasks complete. Project is mature and stable:
-- 40 tasks completed, 0 pending
+- 41 tasks completed, 0 pending
 - 33 tests passing (14 runner + 6 wizard + 13 async)
 - 4 sync targets all identical: repo, live hooks, skill, marketplace
 - Report works for both hook-runner users and standalone hooks users

--- a/setup.js
+++ b/setup.js
@@ -17,6 +17,7 @@
  *   node setup.js --install        # skip report, just install
  *   node setup.js --sync           # sync modules from GitHub per modules.yaml
  *   node setup.js --sync --dry-run # preview sync without installing
+ *   node setup.js --stats           # quick text summary of hook log
  *   node setup.js --prune 7        # prune log entries older than 7 days
  *   node setup.js --prune 7 --dry-run
  *   node setup.js --version        # show version
@@ -1257,6 +1258,7 @@ function main() {
   var healthMode = args.indexOf("--health") !== -1;
   var versionMode = args.indexOf("--version") !== -1 || args.indexOf("-v") !== -1;
   var pruneMode = args.indexOf("--prune") !== -1;
+  var statsMode = args.indexOf("--stats") !== -1;
 
   // --- Version ---
   if (versionMode) {
@@ -1278,6 +1280,43 @@ function main() {
     if (pruneResult.rotatedRemoved) console.log("  Rotated log (.1): " + (dryRun ? "would remove" : "removed"));
     console.log("");
     console.log("[hook-runner] " + (dryRun ? "Dry-run complete." : "Prune complete."));
+    return;
+  }
+
+  // --- Stats mode: quick text summary of hook log ---
+  if (statsMode) {
+    console.log("[hook-runner] Log Stats");
+    console.log("========================");
+    var hs = readHookStats(3);
+    var hsKeys = Object.keys(hs).sort();
+    if (hsKeys.length === 0) {
+      console.log("  No hook log data found.");
+      return;
+    }
+    var totalInv = 0, totalBlk = 0, totalErr = 0;
+    for (var si = 0; si < hsKeys.length; si++) {
+      totalInv += hs[hsKeys[si]].total;
+      totalBlk += hs[hsKeys[si]].block;
+      totalErr += hs[hsKeys[si]].error;
+    }
+    console.log("  Total invocations: " + totalInv);
+    console.log("  Total blocks: " + totalBlk + " (" + (totalInv > 0 ? ((totalBlk / totalInv) * 100).toFixed(1) : "0") + "%)");
+    if (totalErr > 0) console.log("  Total errors: " + totalErr);
+    console.log("");
+    // Show modules with blocks or errors
+    var hasActivity = false;
+    for (var sj = 0; sj < hsKeys.length; sj++) {
+      var ms = hs[hsKeys[sj]];
+      if (ms.block > 0 || ms.error > 0) {
+        if (!hasActivity) { console.log("  Active hooks:"); hasActivity = true; }
+        var parts = "    " + hsKeys[sj];
+        if (ms.block > 0) parts += "  " + ms.block + " blocked";
+        if (ms.error > 0) parts += "  " + ms.error + " errors";
+        console.log(parts);
+      }
+    }
+    if (!hasActivity) console.log("  No blocks or errors recorded.");
+    console.log("");
     return;
   }
 


### PR DESCRIPTION
## Summary
- `--stats`: prints total invocations, block rate, and per-module block/error counts to stdout
- Useful for CI, terminal checks, or quick monitoring without opening the HTML report

## Test plan
- [x] All 33 tests pass
- [x] `--stats` shows correct counts matching the HTML report