### PR TITLE
T042: Document --stats command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ No installation required — just clone and run `node setup.js --report`.
 /hook-runner dry-run      # preview changes without modifying anything
 /hook-runner health       # verify all runners and modules load correctly
 /hook-runner sync         # sync modules from GitHub per modules.yaml
+/hook-runner stats        # quick text summary of hook log activity
 /hook-runner prune        # prune log entries older than 7 days
 /hook-runner version      # show hook-runner version
 ```
@@ -106,10 +107,13 @@ Rules:
 Runners log every module invocation to `~/.claude/hooks/hook-log.jsonl`. Each line records the timestamp, event, module name, result (pass/block/error), and context (tool name, command snippet, project). The log auto-rotates at 10MB. Stats include both current and rotated log files.
 
 ```bash
+/hook-runner stats             # quick text summary to stdout
 /hook-runner prune             # prune entries older than 7 days
 node setup.js --prune 3        # keep only last 3 days
 node setup.js --prune 7 --dry-run  # preview without deleting
 ```
+
+The `--stats` command shows total invocations, block rate, and per-module hit counts — useful for CI or quick terminal checks without opening the HTML report.
 
 The setup report (`/hook-runner report`) reads the log and shows hit counts and sample triggers per module.
 

--- a/TODO.md
+++ b/TODO.md
@@ -55,14 +55,17 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 - [x] T040: README — document prune and version commands
 - [x] T041: Add --stats command for quick text summary of hook log
 
+## Docs
+- [x] T042: Document --stats command in README
+
 ## Status
 All tasks complete. Project is mature and stable:
-- 41 tasks completed, 0 pending
+- 42 tasks completed, 0 pending
 - 33 tests passing (14 runner + 6 wizard + 13 async)
 - 4 sync targets all identical: repo, live hooks, skill, marketplace
 - Report works for both hook-runner users and standalone hooks users
 - CLI commands: setup, report, dry-run, health, sync, stats, prune, version
-- Next session: README update for --stats, marketplace promotion, or new module development
+- Next session: marketplace promotion or new module development
 
 ## Moved
 - T026: Moved to chat-export/TODO.md (out of scope for hook-runner)


### PR DESCRIPTION
## Summary
- Add `/hook-runner stats` to the Quick Start commands list
- Add `--stats` example and description in the Logging section

## Test plan
- [x] README renders correctly with new section