### PR TITLE
T044: Add secret-scan-gate PreToolUse module

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Full catalog in `modules/` directory:
 | `root-cause-gate` | Blocks retry/cleanup without root cause diagnosis |
 | `archive-not-delete` | Blocks `rm -rf`, forces `mv` to `archive/` |
 | `no-adhoc-commands` | Blocks raw aws/ssh/docker/kubectl, forces scripts/ |
+| `secret-scan-gate` | Blocks git commit if staged diff contains API keys, tokens, or passwords |
 | `aws-tagging-gate` | Enforces required tags on AWS resource creation (env-configurable) |
 
 ### PostToolUse (checks after tool execution)

--- a/TODO.md
+++ b/TODO.md
@@ -58,10 +58,11 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 ## Docs
 - [x] T042: Document --stats command in README
 - [x] T043: Add CLAUDE.md for project context
+- [x] T044: Add secret-scan-gate PreToolUse module
 
 ## Status
 All tasks complete. Project is mature and stable:
-- 43 tasks completed, 0 pending
+- 44 tasks completed, 0 pending
 - 33 tests passing (14 runner + 6 wizard + 13 async)
 - 4 sync targets all identical: repo, live hooks, skill, marketplace
 - Report works for both hook-runner users and standalone hooks users

--- a/modules.example.yaml
+++ b/modules.example.yaml
@@ -25,6 +25,7 @@ modules:
     - root-cause-gate        # blocks retry/cleanup without diagnosis
     - archive-not-delete     # blocks rm -rf, forces archive/ instead
     - no-adhoc-commands      # blocks raw aws/ssh/docker/kubectl, forces scripts/
+    - secret-scan-gate       # blocks git commit if staged diff contains secrets
 
     # Optional / niche
     # - aws-tagging-gate     # enforce AWS resource tags (needs AWS_TAG_REQUIRED_VALUE env)

--- a/modules/PreToolUse/secret-scan-gate.js
+++ b/modules/PreToolUse/secret-scan-gate.js
@@ -1,0 +1,72 @@
+"use strict";
+// PreToolUse: block Bash git-commit if staged diff contains obvious secrets.
+// Catches API keys, tokens, passwords, and connection strings before they reach git history.
+// Only triggers on git commit commands — no overhead on other tool calls.
+var cp = require("child_process");
+
+// Patterns that strongly indicate secrets (high-confidence, low false-positive)
+var SECRET_PATTERNS = [
+  { name: "AWS Access Key", re: /AKIA[0-9A-Z]{16}/ },
+  { name: "AWS Secret Key", re: /[0-9a-zA-Z/+=]{40}(?=\s|"|'|$)/, context: /aws_secret|secret_access|SECRET_KEY/i },
+  { name: "Azure Storage Key", re: /[A-Za-z0-9+/]{86}==/ },
+  { name: "Azure SAS Token", re: /sig=[A-Za-z0-9%+/=]{20,}/ },
+  { name: "GitHub Token", re: /gh[ps]_[A-Za-z0-9_]{36,}/ },
+  { name: "Generic API Key", re: /(?:api[_-]?key|apikey|api[_-]?secret)\s*[:=]\s*["']?[A-Za-z0-9_\-]{20,}/i },
+  { name: "Generic Password", re: /(?:password|passwd|pwd)\s*[:=]\s*\\?["']?[^\s"']{8,}/i },
+  { name: "Generic Token", re: /(?:token|secret|bearer)\s*[:=]\s*\\?["']?[A-Za-z0-9_\-.]{20,}/i },
+  { name: "Private Key", re: /-----BEGIN (?:RSA |EC |DSA )?PRIVATE KEY-----/ },
+  { name: "Connection String", re: /(?:mongodb|postgres|mysql|redis|amqp):\/\/[^\s]{20,}/ },
+];
+
+module.exports = function(input) {
+  if (input.tool_name !== "Bash") return null;
+
+  var cmd = "";
+  try {
+    cmd = (typeof input.tool_input === "string" ? JSON.parse(input.tool_input) : input.tool_input || {}).command || "";
+  } catch(e) { cmd = (input.tool_input || {}).command || ""; }
+
+  // Only gate git commit
+  if (!/^\s*git\s+commit/.test(cmd) && !/&&\s*git\s+commit/.test(cmd)) return null;
+
+  // Get staged diff
+  var diff = "";
+  try {
+    diff = cp.execSync("git diff --cached --diff-filter=ACMR", {
+      encoding: "utf-8", timeout: 10000, maxBuffer: 1024 * 1024
+    });
+  } catch(e) {
+    return null; // can't get diff, don't block
+  }
+
+  if (!diff) return null;
+
+  // Only scan added lines (lines starting with +, excluding file headers)
+  var addedLines = diff.split("\n").filter(function(line) {
+    return line.charAt(0) === "+" && !line.startsWith("+++");
+  });
+  var addedText = addedLines.join("\n");
+
+  var findings = [];
+  for (var i = 0; i < SECRET_PATTERNS.length; i++) {
+    var pat = SECRET_PATTERNS[i];
+    if (pat.re.test(addedText)) {
+      // If pattern has a context requirement, check it
+      if (pat.context && !pat.context.test(addedText)) continue;
+      findings.push(pat.name);
+    }
+  }
+
+  if (findings.length > 0) {
+    return {
+      decision: "block",
+      reason: "SECRET SCAN: Potential secrets detected in staged changes:\n" +
+        findings.map(function(f) { return "  - " + f; }).join("\n") + "\n" +
+        "Review with: git diff --cached\n" +
+        "If intentional (e.g. test fixtures), unstage and re-add after review.\n" +
+        "Use environment variables or credential-manager instead of hardcoded secrets."
+    };
+  }
+
+  return null;
+};


### PR DESCRIPTION
## Summary
- New `secret-scan-gate` module blocks git commit if staged diff contains secrets
- Detects: AWS keys, Azure storage/SAS, GitHub tokens, API keys, passwords, private keys, connection strings
- Only scans added lines in staged changes — zero overhead on non-commit commands

## Test plan
- [x] Detects AWS access key (AKIA...) in staged file
- [x] Detects password assignment in staged file
- [x] Clean commits pass through without blocking
- [x] Non-commit Bash commands pass through
- [x] Non-Bash tools pass through
- [x] Existing 14 runner tests still pass