### PR TITLE
T048: Fix CLAUDE.md test counts (77 total across 5 files)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 - `hook-log.js` — centralized logger (appends JSONL per invocation)
 - `run-async.js` — async module executor (Promise detection, 4s timeout)
 - `modules/` — distributable module catalog organized by event type
-- `scripts/test/` — test scripts (35 tests across 4 files)
+- `scripts/test/` — test scripts (77 tests across 5 files)
 
 ## Sync Targets (must stay identical)
 1. Repo: this directory
@@ -30,7 +30,8 @@ After any code change, copy to all 4 locations. The sync command in setup.js han
 bash scripts/test/test-runners.sh      # 16 runner tests
 bash scripts/test/test-setup-wizard.sh # 6 wizard tests
 bash scripts/test/test-async.sh        # 13 async tests
-bash scripts/test/test-module-sync.sh  # module sync tests
+bash scripts/test/test-modules.sh      # 32 module validation tests
+bash scripts/test/test-module-sync.sh  # 10 sync tests
 ```
 
 ## Module Contract

--- a/TODO.md
+++ b/TODO.md
@@ -63,14 +63,16 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 - [x] T046: Update CLAUDE.md with accurate test counts and runner list
 - [x] T047: Add module validation test (loads + calls every module with mock input)
 
+## Test Count Fix
+- [x] T048: Fix CLAUDE.md test counts (77 total: 16 runner + 6 wizard + 13 async + 32 module + 10 sync)
+
 ## Status
 All tasks complete. Project is mature and stable:
-- 47 tasks completed, 0 pending
-- 33 tests passing (14 runner + 6 wizard + 13 async)
+- 48 tasks completed, 0 pending
+- 77 tests passing across 5 test files
 - 4 sync targets all identical: repo, live hooks, skill, marketplace
 - Report works for both hook-runner users and standalone hooks users
 - CLI commands: setup, report, dry-run, health, sync, stats, prune, version
-- Next session: update CLAUDE.md test count (now 67 total: 16 runner + 6 wizard + 13 async + 32 module), marketplace sync for T045-T047, or new UserPromptSubmit module development
 
 ## Moved
 - T026: Moved to chat-export/TODO.md (out of scope for hook-runner)


### PR DESCRIPTION
## Summary
- Fix stale test count in CLAUDE.md (was 35, now 77)
- Add test-modules.sh (32 tests) and test-module-sync.sh (10 tests) to documented test list
- Update TODO.md task count to 48