### PR TITLE
T049: Add prompt-logger UserPromptSubmit module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 - `hook-log.js` — centralized logger (appends JSONL per invocation)
 - `run-async.js` — async module executor (Promise detection, 4s timeout)
 - `modules/` — distributable module catalog organized by event type
-- `scripts/test/` — test scripts (77 tests across 5 files)
+- `scripts/test/` — test scripts (79 tests across 5 files)
 
 ## Sync Targets (must stay identical)
 1. Repo: this directory

--- a/TODO.md
+++ b/TODO.md
@@ -66,12 +66,15 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 ## Test Count Fix
 - [x] T048: Fix CLAUDE.md test counts (77 total: 16 runner + 6 wizard + 13 async + 32 module + 10 sync)
 
+## UserPromptSubmit Modules
+- [x] T049: Add prompt-logger UserPromptSubmit module (logs prompts to JSONL for audit)
+
 ## Status
 All tasks complete. Project is mature and stable:
-- 48 tasks completed, 0 pending
-- 77 tests passing across 5 test files
+- 49 tasks completed, 0 pending
+- 79 tests passing across 5 test files (16 runner + 6 wizard + 13 async + 34 module + 10 sync)
 - 4 sync targets all identical: repo, live hooks, skill, marketplace
-- Report works for both hook-runner users and standalone hooks users
+- 17 modules in catalog (11 PreToolUse, 1 PostToolUse, 1 UserPromptSubmit, 2 SessionStart, 2 Stop)
 - CLI commands: setup, report, dry-run, health, sync, stats, prune, version
 
 ## Moved

--- a/modules.example.yaml
+++ b/modules.example.yaml
@@ -31,8 +31,8 @@ modules:
     # - aws-tagging-gate     # enforce AWS resource tags (needs AWS_TAG_REQUIRED_VALUE env)
 
   UserPromptSubmit:
-    # Prompt validation (optional)
-    # - prompt-logger        # example: log prompts for audit
+    # Prompt audit (optional)
+    - prompt-logger          # log prompts to ~/.claude/hooks/prompt-log.jsonl
 
   PostToolUse:
     - rule-hygiene           # validates rule files are granular

--- a/modules/UserPromptSubmit/prompt-logger.js
+++ b/modules/UserPromptSubmit/prompt-logger.js
@@ -1,0 +1,46 @@
+// UserPromptSubmit: log user prompts to JSONL for audit and review
+// Logs prompt text, timestamp, and project context to ~/.claude/hooks/prompt-log.jsonl
+// Never blocks — always returns null (allow)
+var fs = require("fs");
+var path = require("path");
+var os = require("os");
+
+var LOG_PATH = path.join(os.homedir(), ".claude", "hooks", "prompt-log.jsonl");
+var MAX_SIZE = 5 * 1024 * 1024; // 5MB rotation
+
+module.exports = function(input) {
+  try {
+    var prompt = "";
+    if (input && input.message && typeof input.message === "string") {
+      prompt = input.message;
+    } else if (input && input.prompt && typeof input.prompt === "string") {
+      prompt = input.prompt;
+    }
+    if (!prompt) return null;
+
+    var project = process.env.CLAUDE_PROJECT_DIR || "";
+    var projectName = project ? path.basename(project) : "unknown";
+
+    var entry = JSON.stringify({
+      ts: new Date().toISOString(),
+      project: projectName,
+      length: prompt.length,
+      preview: prompt.substring(0, 200)
+    }) + "\n";
+
+    // Rotate if too large
+    try {
+      var stat = fs.statSync(LOG_PATH);
+      if (stat.size > MAX_SIZE) {
+        var bak = LOG_PATH + ".bak";
+        try { fs.unlinkSync(bak); } catch(e) {}
+        fs.renameSync(LOG_PATH, bak);
+      }
+    } catch(e) { /* file doesn't exist yet */ }
+
+    fs.appendFileSync(LOG_PATH, entry);
+  } catch(e) {
+    // Never fail — logging is best-effort
+  }
+  return null;
+};

--- a/scripts/test/test-modules.sh
+++ b/scripts/test/test-modules.sh
@@ -33,7 +33,7 @@ get_mock_input() {
 # Find all module .js files in modules/
 for event_dir in "$REPO_DIR"/modules/*/; do
   event=$(basename "$event_dir")
-  [ "$event" = "UserPromptSubmit" ] && continue  # no modules yet
+  # All event directories with .js modules are tested
 
   shopt -s nullglob
   for mod_file in "$event_dir"*.js; do


### PR DESCRIPTION
## Summary
- New `prompt-logger` module for UserPromptSubmit event
- Logs prompts to `~/.claude/hooks/prompt-log.jsonl` (timestamp, project, length, 200-char preview)
- 5MB rotation, never blocks
- Updated test-modules.sh to include UserPromptSubmit modules (34 tests, 79 total)
- Uncommented prompt-logger in modules.example.yaml

## Test plan
- [x] Module loads and returns null (validated by test-modules.sh)
- [x] Writes correct JSONL format to log file
- [x] All 79 tests pass