### PR TITLE
T050: Add --list command for catalog vs installed modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ node setup.js --dry-run     # preview changes
 node setup.js --health      # verify runners + modules
 node setup.js --sync        # sync modules from GitHub
 node setup.js --stats       # text summary of hook log
+node setup.js --list        # show catalog vs installed modules
 node setup.js --prune [N]   # prune log entries older than N days (default 7)
 node setup.js --version     # show version
 ```

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ No installation required — just clone and run `node setup.js --report`.
 /hook-runner health       # verify all runners and modules load correctly
 /hook-runner sync         # sync modules from GitHub per modules.yaml
 /hook-runner stats        # quick text summary of hook log activity
+/hook-runner list         # show catalog vs installed modules
 /hook-runner prune        # prune log entries older than 7 days
 /hook-runner version      # show hook-runner version
 ```
@@ -181,6 +182,11 @@ Full catalog in `modules/` directory:
 | `no-adhoc-commands` | Blocks raw aws/ssh/docker/kubectl, forces scripts/ |
 | `secret-scan-gate` | Blocks git commit if staged diff contains API keys, tokens, or passwords |
 | `aws-tagging-gate` | Enforces required tags on AWS resource creation (env-configurable) |
+
+### UserPromptSubmit (processes user prompts)
+| Module | Description |
+|--------|-------------|
+| `prompt-logger` | Logs prompts to `~/.claude/hooks/prompt-log.jsonl` for audit (never blocks) |
 
 ### PostToolUse (checks after tool execution)
 | Module | Description |

--- a/TODO.md
+++ b/TODO.md
@@ -69,13 +69,16 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 ## UserPromptSubmit Modules
 - [x] T049: Add prompt-logger UserPromptSubmit module (logs prompts to JSONL for audit)
 
+## CLI Enhancement
+- [x] T050: Add --list command (catalog vs installed modules comparison)
+
 ## Status
 All tasks complete. Project is mature and stable:
-- 49 tasks completed, 0 pending
+- 50 tasks completed, 0 pending
 - 79 tests passing across 5 test files (16 runner + 6 wizard + 13 async + 34 module + 10 sync)
 - 4 sync targets all identical: repo, live hooks, skill, marketplace
 - 17 modules in catalog (11 PreToolUse, 1 PostToolUse, 1 UserPromptSubmit, 2 SessionStart, 2 Stop)
-- CLI commands: setup, report, dry-run, health, sync, stats, prune, version
+- CLI commands: setup, report, dry-run, health, sync, stats, list, prune, version
 
 ## Moved
 - T026: Moved to chat-export/TODO.md (out of scope for hook-runner)

--- a/setup.js
+++ b/setup.js
@@ -18,6 +18,7 @@
  *   node setup.js --sync           # sync modules from GitHub per modules.yaml
  *   node setup.js --sync --dry-run # preview sync without installing
  *   node setup.js --stats           # quick text summary of hook log
+ *   node setup.js --list            # show catalog vs installed modules
  *   node setup.js --prune 7        # prune log entries older than 7 days
  *   node setup.js --prune 7 --dry-run
  *   node setup.js --version        # show version
@@ -1262,6 +1263,7 @@ function main() {
   var versionMode = args.indexOf("--version") !== -1 || args.indexOf("-v") !== -1;
   var pruneMode = args.indexOf("--prune") !== -1;
   var statsMode = args.indexOf("--stats") !== -1;
+  var listMode = args.indexOf("--list") !== -1;
 
   // --- Version ---
   if (versionMode) {
@@ -1320,6 +1322,87 @@ function main() {
     }
     if (!hasActivity) console.log("  No blocks or errors recorded.");
     console.log("");
+    return;
+  }
+
+  // --- List mode: show catalog vs installed modules ---
+  if (listMode) {
+    console.log("[hook-runner] Module List");
+    console.log("========================");
+
+    // Catalog modules (from repo modules/ directory)
+    var catalogDir = path.join(REPO_DIR, "modules");
+    var events = ["PreToolUse", "PostToolUse", "UserPromptSubmit", "Stop", "SessionStart"];
+    var catalog = {};
+    var catalogCount = 0;
+    for (var li = 0; li < events.length; li++) {
+      var evDir = path.join(catalogDir, events[li]);
+      catalog[events[li]] = [];
+      try {
+        var files = fs.readdirSync(evDir).filter(function(f) { return f.endsWith(".js"); }).sort();
+        catalog[events[li]] = files;
+        catalogCount += files.length;
+      } catch(e) {}
+    }
+
+    // Installed modules (from live run-modules/)
+    var liveDir = path.join(HOOKS_DIR, "run-modules");
+    var installed = {};
+    var installedCount = 0;
+    for (var lj = 0; lj < events.length; lj++) {
+      var livEvDir = path.join(liveDir, events[lj]);
+      installed[events[lj]] = [];
+      try {
+        var livFiles = fs.readdirSync(livEvDir).filter(function(f) { return f.endsWith(".js"); }).sort();
+        installed[events[lj]] = livFiles;
+        installedCount += livFiles.length;
+      } catch(e) {}
+    }
+
+    // Display
+    for (var lk = 0; lk < events.length; lk++) {
+      var ev = events[lk];
+      var catMods = catalog[ev];
+      var instMods = installed[ev];
+      if (catMods.length === 0 && instMods.length === 0) continue;
+
+      console.log("");
+      console.log("  " + ev + ":");
+      var allMods = {};
+      for (var cm = 0; cm < catMods.length; cm++) allMods[catMods[cm]] = { catalog: true, installed: false };
+      for (var im = 0; im < instMods.length; im++) {
+        if (!allMods[instMods[im]]) allMods[instMods[im]] = { catalog: false, installed: false };
+        allMods[instMods[im]].installed = true;
+      }
+      var modNames = Object.keys(allMods).sort();
+      for (var mn = 0; mn < modNames.length; mn++) {
+        var m = allMods[modNames[mn]];
+        var status = m.installed && m.catalog ? " [installed]" :
+                     m.installed && !m.catalog ? " [installed, custom]" :
+                     " [available]";
+        console.log("    " + modNames[mn].replace(".js", "") + status);
+      }
+    }
+
+    // Also check for project-scoped modules in live
+    try {
+      var liveEntries = fs.readdirSync(path.join(liveDir, "PreToolUse"), { withFileTypes: true });
+      var projDirs = liveEntries.filter(function(e) { return e.isDirectory(); });
+      if (projDirs.length > 0) {
+        console.log("");
+        console.log("  Project-scoped:");
+        for (var pd = 0; pd < projDirs.length; pd++) {
+          var projPath = path.join(liveDir, "PreToolUse", projDirs[pd].name);
+          var projMods = fs.readdirSync(projPath).filter(function(f) { return f.endsWith(".js"); });
+          for (var pm = 0; pm < projMods.length; pm++) {
+            console.log("    PreToolUse/" + projDirs[pd].name + "/" + projMods[pm].replace(".js", "") + " [installed]");
+          }
+        }
+      }
+    } catch(e) {}
+
+    console.log("");
+    console.log("[hook-runner] " + installedCount + " installed, " + catalogCount + " in catalog");
     return;
   }
 


### PR DESCRIPTION
## Summary
- New `--list` CLI command shows all catalog modules vs installed modules
- Each module displays status: `[installed]`, `[available]`, or `[installed, custom]`
- Shows project-scoped modules separately
- Also documents `prompt-logger` in README Available Modules table

## Test plan
- [x] `node setup.js --list` shows correct output
- [x] All 79 tests pass (6 wizard tests cover CLI args)