### PR TITLE
T051: Fix --list to scan project-scoped modules in all events

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -71,10 +71,11 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 
 ## CLI Enhancement
 - [x] T050: Add --list command (catalog vs installed modules comparison)
+- [x] T051: Fix --list to scan project-scoped modules in all events (not just PreToolUse)
 
 ## Status
 All tasks complete. Project is mature and stable:
-- 50 tasks completed, 0 pending
+- 51 tasks completed, 0 pending
 - 79 tests passing across 5 test files (16 runner + 6 wizard + 13 async + 34 module + 10 sync)
 - 4 sync targets all identical: repo, live hooks, skill, marketplace
 - 17 modules in catalog (11 PreToolUse, 1 PostToolUse, 1 UserPromptSubmit, 2 SessionStart, 2 Stop)

--- a/setup.js
+++ b/setup.js
@@ -1384,22 +1384,29 @@ function main() {
       }
     }
 
-    // Also check for project-scoped modules in live
-    try {
-      var liveEntries = fs.readdirSync(path.join(liveDir, "PreToolUse"), { withFileTypes: true });
-      var projDirs = liveEntries.filter(function(e) { return e.isDirectory(); });
-      if (projDirs.length > 0) {
-        console.log("");
-        console.log("  Project-scoped:");
+    // Also check for project-scoped modules in all event directories
+    var projScoped = [];
+    for (var pe = 0; pe < events.length; pe++) {
+      try {
+        var liveEvtDir = path.join(liveDir, events[pe]);
+        var liveEntries = fs.readdirSync(liveEvtDir, { withFileTypes: true });
+        var projDirs = liveEntries.filter(function(e) { return e.isDirectory(); });
         for (var pd = 0; pd < projDirs.length; pd++) {
-          var projPath = path.join(liveDir, "PreToolUse", projDirs[pd].name);
+          var projPath = path.join(liveEvtDir, projDirs[pd].name);
           var projMods = fs.readdirSync(projPath).filter(function(f) { return f.endsWith(".js"); });
           for (var pm = 0; pm < projMods.length; pm++) {
-            console.log("    PreToolUse/" + projDirs[pd].name + "/" + projMods[pm].replace(".js", "") + " [installed]");
+            projScoped.push(events[pe] + "/" + projDirs[pd].name + "/" + projMods[pm].replace(".js", ""));
           }
         }
+      } catch(e) {}
+    }
+    if (projScoped.length > 0) {
+      console.log("");
+      console.log("  Project-scoped:");
+      for (var ps = 0; ps < projScoped.length; ps++) {
+        console.log("    " + projScoped[ps] + " [installed]");
       }
-    } catch(e) {}
+    }
 
     console.log("");
     console.log("[hook-runner] " + installedCount + " installed, " + catalogCount + " in catalog");


### PR DESCRIPTION
## Summary
- Fix `--list` command to scan project-scoped modules across all event types (PreToolUse, PostToolUse, etc.), not just PreToolUse

## Test plan
- [x] `node setup.js --list` correctly shows project-scoped modules from all events