### PR TITLE
T055: Add --test CLI command

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -76,15 +76,19 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 - [x] T053: Add GitHub Actions CI test workflow + cross-platform path fix in test scripts
 - [x] T054: Add CI badge to README + marketplace sync
 
+## CLI & Modules
+- [x] T055: Add --test CLI command (run all test suites from setup.js)
+- [ ] T056: Add --uninstall CLI command (clean removal of hook-runner from settings.json + runners)
+- [ ] T057: Add PostToolUse commit-message-check module (enforces conventional commit messages)
+- [ ] T058: Marketplace push for T055-T057
+
 ## Status
-All tasks complete. Project is mature and stable:
-- 54 tasks completed, 0 pending
+- 54 tasks completed, 4 pending
 - 79 tests passing across 5 test files (16 runner + 6 wizard + 13 async + 34 module + 10 sync)
 - CI: GitHub Actions runs all tests on push/PR — badge in README
 - 4 sync targets all identical: repo, live hooks, skill, marketplace
 - 17 modules in catalog (11 PreToolUse, 1 PostToolUse, 1 UserPromptSubmit, 2 SessionStart, 2 Stop)
 - CLI commands: setup, report, dry-run, health, sync, stats, list, prune, version
-- Next session ideas: --uninstall command, --test CLI command, PostToolUse commit-message-check module, marketplace push for T048-T054
 
 ## Moved
 - T026: Moved to chat-export/TODO.md (out of scope for hook-runner)

--- a/setup.js
+++ b/setup.js
@@ -19,6 +19,7 @@
  *   node setup.js --sync --dry-run # preview sync without installing
  *   node setup.js --stats           # quick text summary of hook log
  *   node setup.js --list            # show catalog vs installed modules
+ *   node setup.js --test            # run all test suites
  *   node setup.js --prune 7        # prune log entries older than 7 days
  *   node setup.js --prune 7 --dry-run
  *   node setup.js --version        # show version
@@ -1264,6 +1265,7 @@ function main() {
   var pruneMode = args.indexOf("--prune") !== -1;
   var statsMode = args.indexOf("--stats") !== -1;
   var listMode = args.indexOf("--list") !== -1;
+  var testMode = args.indexOf("--test") !== -1;
 
   // --- Version ---
   if (versionMode) {
@@ -1410,6 +1412,73 @@ function main() {
 
     console.log("");
     console.log("[hook-runner] " + installedCount + " installed, " + catalogCount + " in catalog");
+    return;
+  }
+
+  // --- Test mode: run all test suites ---
+  if (testMode) {
+    console.log("[hook-runner] Test Suite");
+    console.log("========================");
+    var testDir = path.join(REPO_DIR, "scripts", "test");
+    var testFiles;
+    try {
+      testFiles = fs.readdirSync(testDir).filter(function(f) { return f.startsWith("test-") && f.endsWith(".sh"); }).sort();
+    } catch(e) {
+      console.log("  ERROR: test directory not found: " + testDir);
+      process.exit(1);
+    }
+    if (testFiles.length === 0) {
+      console.log("  No test scripts found in " + testDir);
+      process.exit(1);
+    }
+    var totalPass = 0, totalFail = 0, suiteFail = 0;
+    for (var ti = 0; ti < testFiles.length; ti++) {
+      var testPath = path.join(testDir, testFiles[ti]);
+      var suiteName = testFiles[ti].replace("test-", "").replace(".sh", "");
+      console.log("");
+      console.log("  [" + suiteName + "] " + testFiles[ti]);
+      try {
+        var result = cp.execSync("bash " + JSON.stringify(testPath), {
+          cwd: REPO_DIR,
+          encoding: "utf-8",
+          stdio: ["pipe", "pipe", "pipe"],
+          timeout: 60000
+        });
+        // Parse results line: "=== Results: N passed, N failed ==="
+        var match = result.match(/(\d+) passed, (\d+) failed/);
+        if (match) {
+          totalPass += parseInt(match[1], 10);
+          totalFail += parseInt(match[2], 10);
+          if (parseInt(match[2], 10) > 0) suiteFail++;
+        }
+        // Show last few lines (results summary)
+        var lines = result.trim().split("\n");
+        var summaryLines = lines.slice(-3);
+        for (var sl = 0; sl < summaryLines.length; sl++) {
+          console.log("    " + summaryLines[sl]);
+        }
+      } catch(e) {
+        suiteFail++;
+        var errOut = (e.stdout || "") + (e.stderr || "");
+        var errLines = errOut.trim().split("\n").slice(-5);
+        for (var el = 0; el < errLines.length; el++) {
+          console.log("    " + errLines[el]);
+        }
+        // Try to parse partial results
+        var partMatch = errOut.match(/(\d+) passed, (\d+) failed/);
+        if (partMatch) {
+          totalPass += parseInt(partMatch[1], 10);
+          totalFail += parseInt(partMatch[2], 10);
+        }
+      }
+    }
+    console.log("");
+    console.log("========================");
+    console.log("[hook-runner] " + testFiles.length + " suites, " + totalPass + " passed, " + totalFail + " failed");
+    if (suiteFail > 0) {
+      console.log("[hook-runner] " + suiteFail + " suite(s) had failures");
+      process.exit(1);
+    }
     return;
   }
 


### PR DESCRIPTION
## Summary
- Adds `node setup.js --test` to discover and run all test scripts in `scripts/test/`
- Shows per-suite results with pass/fail counts and aggregate totals
- Exits non-zero if any suite fails (CI-friendly)

## Test plan
- [x] `node setup.js --test` runs all 5 suites (79 tests pass)