### PR TITLE
T056: Add --uninstall CLI command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,13 +9,13 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 - **Live hooks**: ~/.claude/hooks/ (run-*.js, load-modules.js, run-modules/)
 
 ## File Layout
-- `setup.js` — CLI entry point (setup wizard, report, health, sync, stats, prune, version)
+- `setup.js` — CLI entry point (setup wizard, report, health, sync, stats, test, uninstall, prune, version)
 - `run-*.js` — event runners (one per event: pretooluse, posttooluse, stop, sessionstart, userpromptsubmit)
 - `load-modules.js` — shared module loader (global + project-scoped discovery)
 - `hook-log.js` — centralized logger (appends JSONL per invocation)
 - `run-async.js` — async module executor (Promise detection, 4s timeout)
 - `modules/` — distributable module catalog organized by event type
-- `scripts/test/` — test scripts (79 tests across 5 files)
+- `scripts/test/` — test scripts (80 tests across 5 files)
 
 ## Sync Targets (must stay identical)
 1. Repo: this directory
@@ -49,6 +49,8 @@ node setup.js --health      # verify runners + modules
 node setup.js --sync        # sync modules from GitHub
 node setup.js --stats       # text summary of hook log
 node setup.js --list        # show catalog vs installed modules
+node setup.js --test        # run all test suites
+node setup.js --uninstall   # remove hook-runner from system
 node setup.js --prune [N]   # prune log entries older than N days (default 7)
 node setup.js --version     # show version
 ```

--- a/TODO.md
+++ b/TODO.md
@@ -78,13 +78,13 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 
 ## CLI & Modules
 - [x] T055: Add --test CLI command (run all test suites from setup.js)
-- [ ] T056: Add --uninstall CLI command (clean removal of hook-runner from settings.json + runners)
+- [x] T056: Add --uninstall CLI command (clean removal of hook-runner from settings.json + runners)
 - [ ] T057: Add PostToolUse commit-message-check module (enforces conventional commit messages)
 - [ ] T058: Marketplace push for T055-T057
 
 ## Status
 - 54 tasks completed, 4 pending
-- 79 tests passing across 5 test files (16 runner + 6 wizard + 13 async + 34 module + 10 sync)
+- 80 tests passing across 5 test files (16 runner + 7 wizard + 13 async + 34 module + 10 sync)
 - CI: GitHub Actions runs all tests on push/PR — badge in README
 - 4 sync targets all identical: repo, live hooks, skill, marketplace
 - 17 modules in catalog (11 PreToolUse, 1 PostToolUse, 1 UserPromptSubmit, 2 SessionStart, 2 Stop)

--- a/scripts/test/test-setup-wizard.sh
+++ b/scripts/test/test-setup-wizard.sh
@@ -73,6 +73,17 @@ console.log(c.length);
 " 2>/dev/null)
 if [ "$CHANGES" -gt 0 ]; then pass "dry-run returned $CHANGES changes"; else fail "no changes returned"; fi
 
+# Test 7: --uninstall --dry-run runs without modifying settings
+echo "[7] --uninstall --dry-run doesn't modify settings"
+BEFORE=$(md5sum ~/.claude/settings.json 2>/dev/null | cut -d' ' -f1)
+OUTPUT=$(node "$REPO_DIR/setup.js" --uninstall --dry-run 2>/dev/null)
+AFTER=$(md5sum ~/.claude/settings.json 2>/dev/null | cut -d' ' -f1)
+if [ "$BEFORE" = "$AFTER" ] && echo "$OUTPUT" | grep -q "Dry-run complete"; then
+  pass "uninstall dry-run safe"
+else
+  fail "uninstall dry-run modified settings or failed"
+fi
+
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/setup.js
+++ b/setup.js
@@ -20,6 +20,9 @@
  *   node setup.js --stats           # quick text summary of hook log
  *   node setup.js --list            # show catalog vs installed modules
  *   node setup.js --test            # run all test suites
+ *   node setup.js --uninstall       # remove hook-runner from system
+ *   node setup.js --uninstall --dry-run  # preview uninstall
+ *   node setup.js --uninstall --force    # also remove non-empty module dirs
  *   node setup.js --prune 7        # prune log entries older than 7 days
  *   node setup.js --prune 7 --dry-run
  *   node setup.js --version        # show version
@@ -1266,10 +1269,110 @@ function main() {
   var statsMode = args.indexOf("--stats") !== -1;
   var listMode = args.indexOf("--list") !== -1;
   var testMode = args.indexOf("--test") !== -1;
+  var uninstallMode = args.indexOf("--uninstall") !== -1;
 
   // --- Version ---
   if (versionMode) {
     console.log("hook-runner v" + VERSION);
+    return;
+  }
+
+  // --- Uninstall mode: remove hook-runner from settings.json and hooks dir ---
+  if (uninstallMode) {
+    console.log("[hook-runner] Uninstall");
+    console.log("========================");
+    if (dryRun) console.log("  (dry-run mode — no changes will be made)");
+    console.log("");
+    var uninstallChanges = [];
+
+    // 1. Remove hook-runner entries from settings.json
+    if (fs.existsSync(SETTINGS_PATH)) {
+      var settings = JSON.parse(fs.readFileSync(SETTINGS_PATH, "utf-8"));
+      if (settings.hooks) {
+        var hookEvents = Object.keys(settings.hooks);
+        var runnerPattern = /run-(pretooluse|posttooluse|stop|sessionstart|userpromptsubmit)\.js/;
+        var keptEvents = {};
+        for (var ui = 0; ui < hookEvents.length; ui++) {
+          var evt = hookEvents[ui];
+          var entries = settings.hooks[evt];
+          if (!Array.isArray(entries)) { keptEvents[evt] = entries; continue; }
+          // Filter out hook-runner entries, keep non-runner entries
+          var kept = entries.filter(function(entry) {
+            var hooks = entry.hooks || [];
+            return !hooks.some(function(h) { return h.command && runnerPattern.test(h.command); });
+          });
+          if (kept.length > 0) {
+            keptEvents[evt] = kept;
+            uninstallChanges.push({ what: "settings.json " + evt, status: "kept " + kept.length + " non-runner entry(s)" });
+          } else {
+            uninstallChanges.push({ what: "settings.json " + evt, status: "removed" });
+          }
+        }
+        settings.hooks = keptEvents;
+        if (Object.keys(keptEvents).length === 0) delete settings.hooks;
+        if (!dryRun) {
+          fs.writeFileSync(SETTINGS_PATH, JSON.stringify(settings, null, 2), "utf-8");
+        }
+      } else {
+        uninstallChanges.push({ what: "settings.json", status: "no hooks section found" });
+      }
+    } else {
+      uninstallChanges.push({ what: "settings.json", status: "not found" });
+    }
+
+    // 2. Remove runner files
+    var runnerFiles = ["run-pretooluse.js", "run-posttooluse.js", "run-stop.js", "run-sessionstart.js", "run-userpromptsubmit.js", "load-modules.js", "hook-log.js", "run-async.js", "setup.js"];
+    for (var uf = 0; uf < runnerFiles.length; uf++) {
+      var fp = path.join(HOOKS_DIR, runnerFiles[uf]);
+      if (fs.existsSync(fp)) {
+        if (!dryRun) fs.unlinkSync(fp);
+        uninstallChanges.push({ what: runnerFiles[uf], status: dryRun ? "would remove" : "removed" });
+      }
+    }
+
+    // 3. Remove run-modules directories (only if empty or --force)
+    var forceMode = args.indexOf("--force") !== -1;
+    var runModulesDir = path.join(HOOKS_DIR, "run-modules");
+    if (fs.existsSync(runModulesDir)) {
+      var eventDirs = ["PreToolUse", "PostToolUse", "Stop", "SessionStart", "UserPromptSubmit"];
+      for (var ud = 0; ud < eventDirs.length; ud++) {
+        var evDir = path.join(runModulesDir, eventDirs[ud]);
+        if (!fs.existsSync(evDir)) continue;
+        var contents = fs.readdirSync(evDir);
+        if (contents.length === 0 || forceMode) {
+          if (!dryRun) fs.rmSync(evDir, { recursive: true });
+          uninstallChanges.push({ what: "run-modules/" + eventDirs[ud], status: (dryRun ? "would remove" : "removed") + (contents.length > 0 ? " (" + contents.length + " files)" : "") });
+        } else {
+          uninstallChanges.push({ what: "run-modules/" + eventDirs[ud], status: "kept (has " + contents.length + " module(s) — use --force to remove)" });
+        }
+      }
+      // Remove run-modules dir itself if empty
+      try {
+        var remaining = fs.readdirSync(runModulesDir);
+        if (remaining.length === 0) {
+          if (!dryRun) fs.rmdirSync(runModulesDir);
+          uninstallChanges.push({ what: "run-modules/", status: dryRun ? "would remove" : "removed" });
+        }
+      } catch(e) {}
+    }
+
+    // 4. Remove log files
+    var logFile = path.join(HOOKS_DIR, "hook-log.jsonl");
+    var logFile1 = logFile + ".1";
+    for (var lf = 0; lf < 2; lf++) {
+      var lfp = lf === 0 ? logFile : logFile1;
+      if (fs.existsSync(lfp)) {
+        if (!dryRun) fs.unlinkSync(lfp);
+        uninstallChanges.push({ what: path.basename(lfp), status: dryRun ? "would remove" : "removed" });
+      }
+    }
+
+    // Display results
+    for (var uc = 0; uc < uninstallChanges.length; uc++) {
+      console.log("  " + uninstallChanges[uc].what + ": " + uninstallChanges[uc].status);
+    }
+    console.log("");
+    console.log("[hook-runner] " + (dryRun ? "Dry-run complete. No changes made." : "Uninstall complete."));
     return;
   }
 


### PR DESCRIPTION
## Summary
- Adds `node setup.js --uninstall` for clean hook-runner removal
- Removes runner entries from settings.json, runner files, log files
- Preserves non-empty module dirs unless `--force` is used
- Supports `--dry-run` for preview
- New test: uninstall dry-run safety check (80 tests total)

## Test plan
- [x] `node setup.js --uninstall --dry-run` shows what would be removed without changes
- [x] `node setup.js --test` — 80 tests pass