### PR TITLE
T060: Add --help command and bump to v1.1.0

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -82,9 +82,10 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 - [x] T057: Add PostToolUse commit-message-check module (enforces conventional commit messages)
 - [x] T058: Marketplace push for T055-T057 + SKILL.md update with test/uninstall commands
 - [x] T059: Update README with test/uninstall commands and commit-msg-check module
+- [x] T060: Add --help command and bump version to 1.1.0
 
 ## Status
-- 59 tasks completed, 0 pending
+- 60 tasks completed, 0 pending
 - 82 tests passing across 5 test files (16 runner + 7 wizard + 13 async + 36 module + 10 sync)
 - CI: GitHub Actions runs all tests on push/PR — badge in README
 - 4 sync targets all identical: repo, live hooks, skill, marketplace

--- a/setup.js
+++ b/setup.js
@@ -46,7 +46,7 @@ var SCRIPT_DIR = __dirname;
 var REPO_DIR = SCRIPT_DIR;
 
 var HOOK_LOG_PATH = path.join(HOOKS_DIR, "hook-log.jsonl");
-var VERSION = "1.0.0";
+var VERSION = "1.1.0";
 
 // ============================================================
 // 0. Hook Log Stats
@@ -1270,6 +1270,39 @@ function main() {
   var listMode = args.indexOf("--list") !== -1;
   var testMode = args.indexOf("--test") !== -1;
   var uninstallMode = args.indexOf("--uninstall") !== -1;
+  var helpMode = args.indexOf("--help") !== -1 || args.indexOf("-h") !== -1;
+
+  // --- Help ---
+  if (helpMode) {
+    console.log("hook-runner v" + VERSION + " — modular hook runner for Claude Code");
+    console.log("");
+    console.log("Usage: node setup.js [command] [options]");
+    console.log("");
+    console.log("Commands:");
+    console.log("  (none)          Full setup wizard (scan → report → backup → install)");
+    console.log("  --report        Generate HTML hooks report (works without installing)");
+    console.log("  --health        Verify runners, modules, and settings are correct");
+    console.log("  --sync          Sync modules from GitHub per ~/.claude/hooks/modules.yaml");
+    console.log("  --list          Show catalog vs installed modules with status");
+    console.log("  --stats         Quick text summary of hook log activity");
+    console.log("  --test          Run all test suites");
+    console.log("  --uninstall     Remove hook-runner from settings.json and hooks dir");
+    console.log("  --prune [N]     Prune log entries older than N days (default 7)");
+    console.log("  --version, -v   Show version");
+    console.log("  --help, -h      Show this help");
+    console.log("");
+    console.log("Options:");
+    console.log("  --dry-run       Preview changes without modifying anything");
+    console.log("  --install       Skip report, just install runners");
+    console.log("  --force         With --uninstall: also remove non-empty module dirs");
+    console.log("");
+    console.log("Examples:");
+    console.log("  node setup.js                    # first-time setup");
+    console.log("  node setup.js --report           # see your hooks without installing");
+    console.log("  node setup.js --sync --dry-run   # preview module sync");
+    console.log("  node setup.js --uninstall --dry-run  # preview removal");
+    return;
+  }
 
   // --- Version ---
   if (versionMode) {


### PR DESCRIPTION
## Summary
- Adds `--help` / `-h` flag with clean usage output
- Bumps version from 1.0.0 to 1.1.0 (reflects T055-T060 features)
- Previously `--help` fell through to the setup wizard — now shows proper help

## Test plan
- [x] `node setup.js --help` shows clean usage
- [x] `node setup.js -h` works as alias
- [x] `node setup.js --version` shows 1.1.0