### PR TITLE
T063: Add --upgrade command, make report --open opt-in

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ node setup.js --list        # show catalog vs installed modules
 node setup.js --test        # run all test suites
 node setup.js --uninstall   # remove hook-runner from system
 node setup.js --prune [N]   # prune log entries older than N days (default 7)
+node setup.js --upgrade     # fetch latest from GitHub
 node setup.js --version     # show version
 ```
 

--- a/TODO.md
+++ b/TODO.md
@@ -87,7 +87,7 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 ## Refactor & New Features
 - [x] T061: Extract generateReport + helpers into report.js (setup.js 1846→1261 lines, report.js 620 lines)
 - [x] T062: Add no-hardcoded-paths PreToolUse module (blocks Write/Edit with absolute paths)
-- [ ] T063: Add --upgrade command (self-updater from GitHub)
+- [x] T063: Add --upgrade command (self-updater from GitHub, --dry-run/--force supported)
 
 ## Status
 - 60 tasks completed, 3 pending
@@ -96,7 +96,7 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 - CI: GitHub Actions runs all tests on push/PR — badge in README
 - 4 sync targets all identical: repo, live hooks, skill, marketplace
 - 19 modules in catalog (12 PreToolUse, 2 PostToolUse, 1 UserPromptSubmit, 2 SessionStart, 2 Stop)
-- CLI commands: setup, report, dry-run, health, sync, stats, list, test, uninstall, prune, version, help
+- CLI commands: setup, report, dry-run, health, sync, stats, list, test, upgrade, uninstall, prune, version, help
 
 ## Session Handoff (2026-03-30)
 Completed T055-T060 this session. Project is v1.1.0, very mature (60 tasks, 82 tests, 18 modules, 13 CLI commands).

--- a/setup.js
+++ b/setup.js
@@ -685,6 +685,8 @@ function main() {
   var listMode = args.indexOf("--list") !== -1;
   var testMode = args.indexOf("--test") !== -1;
   var uninstallMode = args.indexOf("--uninstall") !== -1;
+  var upgradeMode = args.indexOf("--upgrade") !== -1;
+  var openMode = args.indexOf("--open") !== -1;
   var helpMode = args.indexOf("--help") !== -1 || args.indexOf("-h") !== -1;
 
   // --- Help ---
@@ -701,6 +703,7 @@ function main() {
     console.log("  --list          Show catalog vs installed modules with status");
     console.log("  --stats         Quick text summary of hook log activity");
     console.log("  --test          Run all test suites");
+    console.log("  --upgrade       Fetch latest runners from GitHub and update local copies");
     console.log("  --uninstall     Remove hook-runner from settings.json and hooks dir");
     console.log("  --prune [N]     Prune log entries older than N days (default 7)");
     console.log("  --version, -v   Show version");
@@ -709,6 +712,7 @@ function main() {
     console.log("Options:");
     console.log("  --dry-run       Preview changes without modifying anything");
     console.log("  --install       Skip report, just install runners");
+    console.log("  --open          Open report in browser (default: don't open)");
     console.log("  --force         With --uninstall: also remove non-empty module dirs");
     console.log("");
     console.log("Examples:");
@@ -722,6 +726,68 @@ function main() {
   // --- Version ---
   if (versionMode) {
     console.log("hook-runner v" + VERSION);
+    return;
+  }
+
+  // --- Upgrade mode: fetch latest from GitHub and update local copies ---
+  if (upgradeMode) {
+    console.log("[hook-runner] Upgrade");
+    console.log("========================");
+    var source = "grobomo/hook-runner";
+    var branch = "main";
+
+    // Core files to upgrade
+    var coreFiles = [
+      "setup.js", "report.js",
+      "run-pretooluse.js", "run-posttooluse.js", "run-stop.js",
+      "run-sessionstart.js", "run-userpromptsubmit.js",
+      "load-modules.js", "hook-log.js", "run-async.js"
+    ];
+
+    // Check remote version first
+    var remoteSetup = fetchFromGitHub(source, branch, "setup.js");
+    if (!remoteSetup) {
+      console.log("  ERROR: Could not fetch from GitHub. Check network connection.");
+      return;
+    }
+    var remoteVersionMatch = remoteSetup.match(/var VERSION\s*=\s*"([^"]+)"/);
+    var remoteVersion = remoteVersionMatch ? remoteVersionMatch[1] : "unknown";
+    console.log("  Local version:  " + VERSION);
+    console.log("  Remote version: " + remoteVersion);
+    console.log("");
+
+    if (remoteVersion === VERSION && !args.includes("--force")) {
+      console.log("  Already up to date. Use --force to re-download anyway.");
+      return;
+    }
+
+    var updated = 0, skipped = 0;
+    for (var ui = 0; ui < coreFiles.length; ui++) {
+      var fileName = coreFiles[ui];
+      var content = fileName === "setup.js" ? remoteSetup : fetchFromGitHub(source, branch, fileName);
+      if (!content) {
+        console.log("  SKIP: " + fileName + " (not found on remote)");
+        skipped++;
+        continue;
+      }
+      var dest = path.join(HOOKS_DIR, fileName);
+      if (dryRun) {
+        var exists = fs.existsSync(dest);
+        console.log("  " + (exists ? "UPDATE" : "CREATE") + ": " + fileName);
+      } else {
+        fs.writeFileSync(dest, content, "utf-8");
+        console.log("  Updated: " + fileName);
+      }
+      updated++;
+    }
+
+    console.log("");
+    if (dryRun) {
+      console.log("  Dry-run complete. " + updated + " file(s) would be updated.");
+    } else {
+      console.log("  Upgrade complete: " + updated + " file(s) updated" + (skipped ? ", " + skipped + " skipped" : "") + ".");
+      console.log("  Run 'node setup.js --health' to verify.");
+    }
     return;
   }
 
@@ -1099,7 +1165,7 @@ function main() {
   var beforeReport = path.join(REPORT_DIR, "hooks-report-before.html");
   generateReport(scan, beforeReport, hookStats);
   console.log("  Report: " + beforeReport);
-  openFile(beforeReport);
+  if (openMode) openFile(beforeReport);
 
   if (reportOnly) {
     console.log("\n[hook-runner] Report-only mode. Done.");
@@ -1139,7 +1205,7 @@ function main() {
   var afterReport = path.join(REPORT_DIR, "hooks-report.html");
   generateReport(afterScan, afterReport, hookStats);
   console.log("  Report: " + afterReport);
-  openFile(afterReport);
+  if (openMode) openFile(afterReport);
 
   // Summary
   console.log("");


### PR DESCRIPTION
## Summary
- `--upgrade` command fetches latest core files from GitHub (supports `--dry-run`, `--force`)
- Reports no longer auto-open in browser — pass `--open` to open
- Fixes unwanted tab spam during stop hook loops

## Test plan
- [x] `node setup.js --test` — 84/84 pass
- [x] `node setup.js --upgrade --dry-run` — shows version comparison
- [x] `node setup.js --upgrade --dry-run --force` — lists all 10 files
- [x] `node setup.js --report` — no browser tab opened