### PR TITLE
T065: Bump version to 1.2.0

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -91,11 +91,11 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 
 ## Docs & Marketplace
 - [x] T064: Update README + SKILL.md with --upgrade, --open, no-hardcoded-paths, report.js
-- [ ] T065: Marketplace push + version bump to 1.2.0
+- [x] T065: Marketplace push + version bump to 1.2.0
 
 ## Status
-- 63 tasks completed, 2 pending
-- Version: 1.1.0
+- 65 tasks completed, 0 pending
+- Version: 1.2.0
 - 84 tests passing across 5 test files (16 runner + 7 wizard + 13 async + 38 module + 10 sync)
 - CI: GitHub Actions runs all tests on push/PR — badge in README
 - 4 sync targets all identical: repo, live hooks, skill, marketplace

--- a/setup.js
+++ b/setup.js
@@ -46,7 +46,7 @@ var SCRIPT_DIR = __dirname;
 var REPO_DIR = SCRIPT_DIR;
 
 var HOOK_LOG_PATH = path.join(HOOKS_DIR, "hook-log.jsonl");
-var VERSION = "1.1.0";
+var VERSION = "1.2.0";
 
 // ============================================================
 // 0. Hook Log Stats


### PR DESCRIPTION
Version bump to 1.2.0. New: report.js extraction, --upgrade, --open, no-hardcoded-paths.