### PR TITLE
T067: Add test-coverage-check PostToolUse module

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -95,7 +95,7 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 
 ## New Modules & Refactor
 - [x] T066: Add SessionStart module: `project-health` (runs --health on session start, warns about issues)
-- [ ] T067: Add PostToolUse module: `test-coverage-check` (warns if test files modified without running tests)
+- [x] T067: Add PostToolUse module: `test-coverage-check` (warns if test files modified without running tests)
 - [ ] T068: Extract main() dispatch into command handler functions (main() is 491 lines)
 
 ## Status

--- a/modules.example.yaml
+++ b/modules.example.yaml
@@ -38,6 +38,7 @@ modules:
   PostToolUse:
     - rule-hygiene           # validates rule files are granular
     - commit-msg-check       # blocks WIP/fixup commits and over-long first lines
+    - test-coverage-check    # warns when source files with tests are modified
 
   Stop:
     - auto-continue          # never stop, always find next task

--- a/modules/PostToolUse/test-coverage-check.js
+++ b/modules/PostToolUse/test-coverage-check.js
@@ -1,0 +1,85 @@
+// PostToolUse: warn when source files are modified but tests exist that should be run
+// Triggers after Edit or Write tool completions.
+// If the modified file has a corresponding test file, reminds to run it.
+var path = require("path");
+var fs = require("fs");
+
+// Common test directory patterns
+var TEST_DIRS = ["scripts/test", "test", "tests", "__tests__", "spec"];
+// Common test file patterns
+var TEST_PREFIXES = ["test-", "test_"];
+var TEST_SUFFIXES = [".test.js", ".test.ts", ".spec.js", ".spec.ts", "_test.go", "_test.py"];
+
+module.exports = function(input) {
+  var toolName = input.tool_name || "";
+  if (toolName !== "Edit" && toolName !== "Write") return null;
+
+  var filePath = (input.tool_input || {}).file_path || "";
+  if (!filePath) return null;
+
+  var basename = path.basename(filePath);
+  var dirName = path.dirname(filePath);
+
+  // Skip if the file itself is a test file — no need to remind
+  var isTestFile = TEST_PREFIXES.some(function(p) { return basename.startsWith(p); }) ||
+    TEST_SUFFIXES.some(function(s) { return basename.endsWith(s); }) ||
+    TEST_DIRS.some(function(d) { return filePath.replace(/\\/g, "/").indexOf("/" + d + "/") !== -1; });
+
+  if (isTestFile) return null;
+
+  // Skip non-code files
+  var ext = path.extname(basename).toLowerCase();
+  var codeExts = [".js", ".ts", ".py", ".go", ".rs", ".java", ".sh", ".bash"];
+  if (codeExts.indexOf(ext) === -1) return null;
+
+  // Look for corresponding test files
+  var projectDir = process.env.CLAUDE_PROJECT_DIR || dirName;
+  var nameNoExt = basename.replace(/\.[^.]+$/, "");
+  var found = [];
+
+  // Check scripts/test/ for test-<name>* pattern
+  for (var di = 0; di < TEST_DIRS.length; di++) {
+    var testDir = path.join(projectDir, TEST_DIRS[di]);
+    if (!fs.existsSync(testDir)) continue;
+    var files;
+    try { files = fs.readdirSync(testDir); } catch(e) { continue; }
+    for (var fi = 0; fi < files.length; fi++) {
+      var lower = files[fi].toLowerCase();
+      var nameCheck = nameNoExt.toLowerCase();
+      if (lower.indexOf(nameCheck) !== -1) {
+        found.push(path.join(TEST_DIRS[di], files[fi]));
+      }
+    }
+  }
+
+  // Check same directory for <name>.test.* or test_<name>.*
+  try {
+    var siblings = fs.readdirSync(dirName);
+    for (var si = 0; si < siblings.length; si++) {
+      var sib = siblings[si];
+      if (sib === basename) continue;
+      var sibLower = sib.toLowerCase();
+      if ((sibLower.startsWith("test-" + nameNoExt.toLowerCase()) ||
+           sibLower.startsWith("test_" + nameNoExt.toLowerCase()) ||
+           sibLower === nameNoExt.toLowerCase() + ".test.js" ||
+           sibLower === nameNoExt.toLowerCase() + ".test.ts" ||
+           sibLower === nameNoExt.toLowerCase() + ".spec.js" ||
+           sibLower === nameNoExt.toLowerCase() + ".spec.ts")) {
+        found.push(path.join(path.relative(projectDir, dirName) || ".", sib));
+      }
+    }
+  } catch(e) { /* ignore */ }
+
+  if (found.length === 0) return null;
+
+  // Deduplicate
+  var unique = [];
+  for (var ui = 0; ui < found.length; ui++) {
+    if (unique.indexOf(found[ui]) === -1) unique.push(found[ui]);
+  }
+
+  return {
+    decision: "block",
+    reason: "Modified " + basename + " — related test file(s) found: " + unique.join(", ") + ". Run tests before committing."
+  };
+};


### PR DESCRIPTION
## Summary
- New `test-coverage-check` PostToolUse module
- Warns when source files with corresponding test files are modified
- Checks scripts/test/, test/, tests/, __tests__/, spec/, and sibling test files
- Reminds to run tests before committing

## Test plan
- [x] Detects setup.js → test-setup-wizard.sh relationship
- [x] Skips test files themselves (no self-referential warnings)
- [x] Skips non-code files (README.md, etc.)
- [x] Skips non-Edit/Write tools
- [x] 88 tests pass (42 module tests now include test-coverage-check)