### PR TITLE
T068: Extract main() into command handler functions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -96,7 +96,7 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 ## New Modules & Refactor
 - [x] T066: Add SessionStart module: `project-health` (runs --health on session start, warns about issues)
 - [x] T067: Add PostToolUse module: `test-coverage-check` (warns if test files modified without running tests)
-- [ ] T068: Extract main() dispatch into command handler functions (main() is 491 lines)
+- [x] T068: Extract main() dispatch into command handler functions (main() 553→15 lines)
 
 ## Status
 - 65 tasks completed, 3 pending

--- a/setup.js
+++ b/setup.js
@@ -672,476 +672,405 @@ function openFile(filePath) {
   } catch (e) { /* ignore */ }
 }
 
-function main() {
-  var args = process.argv.slice(2);
-  var reportOnly = args.indexOf("--report") !== -1;
-  var dryRun = args.indexOf("--dry-run") !== -1;
-  var installOnly = args.indexOf("--install") !== -1;
-  var syncMode = args.indexOf("--sync") !== -1;
-  var healthMode = args.indexOf("--health") !== -1;
-  var versionMode = args.indexOf("--version") !== -1 || args.indexOf("-v") !== -1;
-  var pruneMode = args.indexOf("--prune") !== -1;
-  var statsMode = args.indexOf("--stats") !== -1;
-  var listMode = args.indexOf("--list") !== -1;
-  var testMode = args.indexOf("--test") !== -1;
-  var uninstallMode = args.indexOf("--uninstall") !== -1;
-  var upgradeMode = args.indexOf("--upgrade") !== -1;
-  var openMode = args.indexOf("--open") !== -1;
-  var helpMode = args.indexOf("--help") !== -1 || args.indexOf("-h") !== -1;
+// --- Command Handlers ---
 
-  // --- Help ---
-  if (helpMode) {
-    console.log("hook-runner v" + VERSION + " — modular hook runner for Claude Code");
-    console.log("");
-    console.log("Usage: node setup.js [command] [options]");
-    console.log("");
-    console.log("Commands:");
-    console.log("  (none)          Full setup wizard (scan → report → backup → install)");
-    console.log("  --report        Generate HTML hooks report (works without installing)");
-    console.log("  --health        Verify runners, modules, and settings are correct");
-    console.log("  --sync          Sync modules from GitHub per ~/.claude/hooks/modules.yaml");
-    console.log("  --list          Show catalog vs installed modules with status");
-    console.log("  --stats         Quick text summary of hook log activity");
-    console.log("  --test          Run all test suites");
-    console.log("  --upgrade       Fetch latest runners from GitHub and update local copies");
-    console.log("  --uninstall     Remove hook-runner from settings.json and hooks dir");
-    console.log("  --prune [N]     Prune log entries older than N days (default 7)");
-    console.log("  --version, -v   Show version");
-    console.log("  --help, -h      Show this help");
-    console.log("");
-    console.log("Options:");
-    console.log("  --dry-run       Preview changes without modifying anything");
-    console.log("  --install       Skip report, just install runners");
-    console.log("  --open          Open report in browser (default: don't open)");
-    console.log("  --force         With --uninstall: also remove non-empty module dirs");
-    console.log("");
-    console.log("Examples:");
-    console.log("  node setup.js                    # first-time setup");
-    console.log("  node setup.js --report           # see your hooks without installing");
-    console.log("  node setup.js --sync --dry-run   # preview module sync");
-    console.log("  node setup.js --uninstall --dry-run  # preview removal");
+function cmdHelp() {
+  console.log("hook-runner v" + VERSION + " — modular hook runner for Claude Code");
+  console.log("");
+  console.log("Usage: node setup.js [command] [options]");
+  console.log("");
+  console.log("Commands:");
+  console.log("  (none)          Full setup wizard (scan → report → backup → install)");
+  console.log("  --report        Generate HTML hooks report (works without installing)");
+  console.log("  --health        Verify runners, modules, and settings are correct");
+  console.log("  --sync          Sync modules from GitHub per ~/.claude/hooks/modules.yaml");
+  console.log("  --list          Show catalog vs installed modules with status");
+  console.log("  --stats         Quick text summary of hook log activity");
+  console.log("  --test          Run all test suites");
+  console.log("  --upgrade       Fetch latest runners from GitHub and update local copies");
+  console.log("  --uninstall     Remove hook-runner from settings.json and hooks dir");
+  console.log("  --prune [N]     Prune log entries older than N days (default 7)");
+  console.log("  --version, -v   Show version");
+  console.log("  --help, -h      Show this help");
+  console.log("");
+  console.log("Options:");
+  console.log("  --dry-run       Preview changes without modifying anything");
+  console.log("  --install       Skip report, just install runners");
+  console.log("  --open          Open report in browser (default: don't open)");
+  console.log("  --force         With --uninstall: also remove non-empty module dirs");
+  console.log("");
+  console.log("Examples:");
+  console.log("  node setup.js                    # first-time setup");
+  console.log("  node setup.js --report           # see your hooks without installing");
+  console.log("  node setup.js --sync --dry-run   # preview module sync");
+  console.log("  node setup.js --uninstall --dry-run  # preview removal");
+}
+
+function cmdUpgrade(args, dryRun) {
+  console.log("[hook-runner] Upgrade");
+  console.log("========================");
+  var source = "grobomo/hook-runner";
+  var branch = "main";
+  var coreFiles = [
+    "setup.js", "report.js",
+    "run-pretooluse.js", "run-posttooluse.js", "run-stop.js",
+    "run-sessionstart.js", "run-userpromptsubmit.js",
+    "load-modules.js", "hook-log.js", "run-async.js"
+  ];
+  var remoteSetup = fetchFromGitHub(source, branch, "setup.js");
+  if (!remoteSetup) {
+    console.log("  ERROR: Could not fetch from GitHub. Check network connection.");
     return;
   }
-
-  // --- Version ---
-  if (versionMode) {
-    console.log("hook-runner v" + VERSION);
+  var remoteVersionMatch = remoteSetup.match(/var VERSION\s*=\s*"([^"]+)"/);
+  var remoteVersion = remoteVersionMatch ? remoteVersionMatch[1] : "unknown";
+  console.log("  Local version:  " + VERSION);
+  console.log("  Remote version: " + remoteVersion);
+  console.log("");
+  if (remoteVersion === VERSION && !args.includes("--force")) {
+    console.log("  Already up to date. Use --force to re-download anyway.");
     return;
   }
-
-  // --- Upgrade mode: fetch latest from GitHub and update local copies ---
-  if (upgradeMode) {
-    console.log("[hook-runner] Upgrade");
-    console.log("========================");
-    var source = "grobomo/hook-runner";
-    var branch = "main";
-
-    // Core files to upgrade
-    var coreFiles = [
-      "setup.js", "report.js",
-      "run-pretooluse.js", "run-posttooluse.js", "run-stop.js",
-      "run-sessionstart.js", "run-userpromptsubmit.js",
-      "load-modules.js", "hook-log.js", "run-async.js"
-    ];
-
-    // Check remote version first
-    var remoteSetup = fetchFromGitHub(source, branch, "setup.js");
-    if (!remoteSetup) {
-      console.log("  ERROR: Could not fetch from GitHub. Check network connection.");
-      return;
+  var updated = 0, skipped = 0;
+  for (var ui = 0; ui < coreFiles.length; ui++) {
+    var fileName = coreFiles[ui];
+    var content = fileName === "setup.js" ? remoteSetup : fetchFromGitHub(source, branch, fileName);
+    if (!content) {
+      console.log("  SKIP: " + fileName + " (not found on remote)");
+      skipped++;
+      continue;
     }
-    var remoteVersionMatch = remoteSetup.match(/var VERSION\s*=\s*"([^"]+)"/);
-    var remoteVersion = remoteVersionMatch ? remoteVersionMatch[1] : "unknown";
-    console.log("  Local version:  " + VERSION);
-    console.log("  Remote version: " + remoteVersion);
-    console.log("");
-
-    if (remoteVersion === VERSION && !args.includes("--force")) {
-      console.log("  Already up to date. Use --force to re-download anyway.");
-      return;
-    }
-
-    var updated = 0, skipped = 0;
-    for (var ui = 0; ui < coreFiles.length; ui++) {
-      var fileName = coreFiles[ui];
-      var content = fileName === "setup.js" ? remoteSetup : fetchFromGitHub(source, branch, fileName);
-      if (!content) {
-        console.log("  SKIP: " + fileName + " (not found on remote)");
-        skipped++;
-        continue;
-      }
-      var dest = path.join(HOOKS_DIR, fileName);
-      if (dryRun) {
-        var exists = fs.existsSync(dest);
-        console.log("  " + (exists ? "UPDATE" : "CREATE") + ": " + fileName);
-      } else {
-        fs.writeFileSync(dest, content, "utf-8");
-        console.log("  Updated: " + fileName);
-      }
-      updated++;
-    }
-
-    console.log("");
+    var dest = path.join(HOOKS_DIR, fileName);
     if (dryRun) {
-      console.log("  Dry-run complete. " + updated + " file(s) would be updated.");
+      var exists = fs.existsSync(dest);
+      console.log("  " + (exists ? "UPDATE" : "CREATE") + ": " + fileName);
     } else {
-      console.log("  Upgrade complete: " + updated + " file(s) updated" + (skipped ? ", " + skipped + " skipped" : "") + ".");
-      console.log("  Run 'node setup.js --health' to verify.");
+      fs.writeFileSync(dest, content, "utf-8");
+      console.log("  Updated: " + fileName);
     }
-    return;
+    updated++;
   }
-
-  // --- Uninstall mode: remove hook-runner from settings.json and hooks dir ---
-  if (uninstallMode) {
-    console.log("[hook-runner] Uninstall");
-    console.log("========================");
-    if (dryRun) console.log("  (dry-run mode — no changes will be made)");
-    console.log("");
-    var uninstallChanges = [];
-
-    // 1. Remove hook-runner entries from settings.json
-    if (fs.existsSync(SETTINGS_PATH)) {
-      var settings = JSON.parse(fs.readFileSync(SETTINGS_PATH, "utf-8"));
-      if (settings.hooks) {
-        var hookEvents = Object.keys(settings.hooks);
-        var runnerPattern = /run-(pretooluse|posttooluse|stop|sessionstart|userpromptsubmit)\.js/;
-        var keptEvents = {};
-        for (var ui = 0; ui < hookEvents.length; ui++) {
-          var evt = hookEvents[ui];
-          var entries = settings.hooks[evt];
-          if (!Array.isArray(entries)) { keptEvents[evt] = entries; continue; }
-          // Filter out hook-runner entries, keep non-runner entries
-          var kept = entries.filter(function(entry) {
-            var hooks = entry.hooks || [];
-            return !hooks.some(function(h) { return h.command && runnerPattern.test(h.command); });
-          });
-          if (kept.length > 0) {
-            keptEvents[evt] = kept;
-            uninstallChanges.push({ what: "settings.json " + evt, status: "kept " + kept.length + " non-runner entry(s)" });
-          } else {
-            uninstallChanges.push({ what: "settings.json " + evt, status: "removed" });
-          }
-        }
-        settings.hooks = keptEvents;
-        if (Object.keys(keptEvents).length === 0) delete settings.hooks;
-        if (!dryRun) {
-          fs.writeFileSync(SETTINGS_PATH, JSON.stringify(settings, null, 2), "utf-8");
-        }
-      } else {
-        uninstallChanges.push({ what: "settings.json", status: "no hooks section found" });
-      }
-    } else {
-      uninstallChanges.push({ what: "settings.json", status: "not found" });
-    }
-
-    // 2. Remove runner files
-    var runnerFiles = ["run-pretooluse.js", "run-posttooluse.js", "run-stop.js", "run-sessionstart.js", "run-userpromptsubmit.js", "load-modules.js", "hook-log.js", "run-async.js", "setup.js"];
-    for (var uf = 0; uf < runnerFiles.length; uf++) {
-      var fp = path.join(HOOKS_DIR, runnerFiles[uf]);
-      if (fs.existsSync(fp)) {
-        if (!dryRun) fs.unlinkSync(fp);
-        uninstallChanges.push({ what: runnerFiles[uf], status: dryRun ? "would remove" : "removed" });
-      }
-    }
-
-    // 3. Remove run-modules directories (only if empty or --force)
-    var forceMode = args.indexOf("--force") !== -1;
-    var runModulesDir = path.join(HOOKS_DIR, "run-modules");
-    if (fs.existsSync(runModulesDir)) {
-      var eventDirs = ["PreToolUse", "PostToolUse", "Stop", "SessionStart", "UserPromptSubmit"];
-      for (var ud = 0; ud < eventDirs.length; ud++) {
-        var evDir = path.join(runModulesDir, eventDirs[ud]);
-        if (!fs.existsSync(evDir)) continue;
-        var contents = fs.readdirSync(evDir);
-        if (contents.length === 0 || forceMode) {
-          if (!dryRun) fs.rmSync(evDir, { recursive: true });
-          uninstallChanges.push({ what: "run-modules/" + eventDirs[ud], status: (dryRun ? "would remove" : "removed") + (contents.length > 0 ? " (" + contents.length + " files)" : "") });
-        } else {
-          uninstallChanges.push({ what: "run-modules/" + eventDirs[ud], status: "kept (has " + contents.length + " module(s) — use --force to remove)" });
-        }
-      }
-      // Remove run-modules dir itself if empty
-      try {
-        var remaining = fs.readdirSync(runModulesDir);
-        if (remaining.length === 0) {
-          if (!dryRun) fs.rmdirSync(runModulesDir);
-          uninstallChanges.push({ what: "run-modules/", status: dryRun ? "would remove" : "removed" });
-        }
-      } catch(e) {}
-    }
-
-    // 4. Remove log files
-    var logFile = path.join(HOOKS_DIR, "hook-log.jsonl");
-    var logFile1 = logFile + ".1";
-    for (var lf = 0; lf < 2; lf++) {
-      var lfp = lf === 0 ? logFile : logFile1;
-      if (fs.existsSync(lfp)) {
-        if (!dryRun) fs.unlinkSync(lfp);
-        uninstallChanges.push({ what: path.basename(lfp), status: dryRun ? "would remove" : "removed" });
-      }
-    }
-
-    // Display results
-    for (var uc = 0; uc < uninstallChanges.length; uc++) {
-      console.log("  " + uninstallChanges[uc].what + ": " + uninstallChanges[uc].status);
-    }
-    console.log("");
-    console.log("[hook-runner] " + (dryRun ? "Dry-run complete. No changes made." : "Uninstall complete."));
-    return;
+  console.log("");
+  if (dryRun) {
+    console.log("  Dry-run complete. " + updated + " file(s) would be updated.");
+  } else {
+    console.log("  Upgrade complete: " + updated + " file(s) updated" + (skipped ? ", " + skipped + " skipped" : "") + ".");
+    console.log("  Run 'node setup.js --health' to verify.");
   }
+}
 
-  // --- Prune mode: trim old log entries ---
-  if (pruneMode) {
-    var pruneIdx = args.indexOf("--prune");
-    var pruneDays = parseInt(args[pruneIdx + 1], 10) || 7;
-    console.log("[hook-runner] Log Prune");
-    console.log("========================");
-    console.log("  Keeping entries from last " + pruneDays + " day(s)");
-    if (dryRun) console.log("  (dry-run mode)");
-    var pruneResult = pruneLog(pruneDays, dryRun);
-    console.log("  Kept: " + pruneResult.kept + " entries");
-    console.log("  Pruned: " + pruneResult.pruned + " entries");
-    if (pruneResult.rotatedRemoved) console.log("  Rotated log (.1): " + (dryRun ? "would remove" : "removed"));
-    console.log("");
-    console.log("[hook-runner] " + (dryRun ? "Dry-run complete." : "Prune complete."));
-    return;
-  }
-
-  // --- Stats mode: quick text summary of hook log ---
-  if (statsMode) {
-    console.log("[hook-runner] Log Stats");
-    console.log("========================");
-    var hs = readHookStats(3);
-    var hsKeys = Object.keys(hs).sort();
-    if (hsKeys.length === 0) {
-      console.log("  No hook log data found.");
-      return;
-    }
-    var totalInv = 0, totalBlk = 0, totalErr = 0;
-    for (var si = 0; si < hsKeys.length; si++) {
-      totalInv += hs[hsKeys[si]].total;
-      totalBlk += hs[hsKeys[si]].block;
-      totalErr += hs[hsKeys[si]].error;
-    }
-    console.log("  Total invocations: " + totalInv);
-    console.log("  Total blocks: " + totalBlk + " (" + (totalInv > 0 ? ((totalBlk / totalInv) * 100).toFixed(1) : "0") + "%)");
-    if (totalErr > 0) console.log("  Total errors: " + totalErr);
-    console.log("");
-    // Show modules with blocks or errors
-    var hasActivity = false;
-    for (var sj = 0; sj < hsKeys.length; sj++) {
-      var ms = hs[hsKeys[sj]];
-      if (ms.block > 0 || ms.error > 0) {
-        if (!hasActivity) { console.log("  Active hooks:"); hasActivity = true; }
-        var parts = "    " + hsKeys[sj];
-        if (ms.block > 0) parts += "  " + ms.block + " blocked";
-        if (ms.error > 0) parts += "  " + ms.error + " errors";
-        console.log(parts);
-      }
-    }
-    if (!hasActivity) console.log("  No blocks or errors recorded.");
-    console.log("");
-    return;
-  }
-
-  // --- List mode: show catalog vs installed modules ---
-  if (listMode) {
-    console.log("[hook-runner] Module List");
-    console.log("========================");
-
-    // Catalog modules (from repo modules/ directory)
-    var catalogDir = path.join(REPO_DIR, "modules");
-    var events = ["PreToolUse", "PostToolUse", "UserPromptSubmit", "Stop", "SessionStart"];
-    var catalog = {};
-    var catalogCount = 0;
-    for (var li = 0; li < events.length; li++) {
-      var evDir = path.join(catalogDir, events[li]);
-      catalog[events[li]] = [];
-      try {
-        var files = fs.readdirSync(evDir).filter(function(f) { return f.endsWith(".js"); }).sort();
-        catalog[events[li]] = files;
-        catalogCount += files.length;
-      } catch(e) {}
-    }
-
-    // Installed modules (from live run-modules/)
-    var liveDir = path.join(HOOKS_DIR, "run-modules");
-    var installed = {};
-    var installedCount = 0;
-    for (var lj = 0; lj < events.length; lj++) {
-      var livEvDir = path.join(liveDir, events[lj]);
-      installed[events[lj]] = [];
-      try {
-        var livFiles = fs.readdirSync(livEvDir).filter(function(f) { return f.endsWith(".js"); }).sort();
-        installed[events[lj]] = livFiles;
-        installedCount += livFiles.length;
-      } catch(e) {}
-    }
-
-    // Display
-    for (var lk = 0; lk < events.length; lk++) {
-      var ev = events[lk];
-      var catMods = catalog[ev];
-      var instMods = installed[ev];
-      if (catMods.length === 0 && instMods.length === 0) continue;
-
-      console.log("");
-      console.log("  " + ev + ":");
-      var allMods = {};
-      for (var cm = 0; cm < catMods.length; cm++) allMods[catMods[cm]] = { catalog: true, installed: false };
-      for (var im = 0; im < instMods.length; im++) {
-        if (!allMods[instMods[im]]) allMods[instMods[im]] = { catalog: false, installed: false };
-        allMods[instMods[im]].installed = true;
-      }
-      var modNames = Object.keys(allMods).sort();
-      for (var mn = 0; mn < modNames.length; mn++) {
-        var m = allMods[modNames[mn]];
-        var status = m.installed && m.catalog ? " [installed]" :
-                     m.installed && !m.catalog ? " [installed, custom]" :
-                     " [available]";
-        console.log("    " + modNames[mn].replace(".js", "") + status);
-      }
-    }
-
-    // Also check for project-scoped modules in all event directories
-    var projScoped = [];
-    for (var pe = 0; pe < events.length; pe++) {
-      try {
-        var liveEvtDir = path.join(liveDir, events[pe]);
-        var liveEntries = fs.readdirSync(liveEvtDir, { withFileTypes: true });
-        var projDirs = liveEntries.filter(function(e) { return e.isDirectory(); });
-        for (var pd = 0; pd < projDirs.length; pd++) {
-          var projPath = path.join(liveEvtDir, projDirs[pd].name);
-          var projMods = fs.readdirSync(projPath).filter(function(f) { return f.endsWith(".js"); });
-          for (var pm = 0; pm < projMods.length; pm++) {
-            projScoped.push(events[pe] + "/" + projDirs[pd].name + "/" + projMods[pm].replace(".js", ""));
-          }
-        }
-      } catch(e) {}
-    }
-    if (projScoped.length > 0) {
-      console.log("");
-      console.log("  Project-scoped:");
-      for (var ps = 0; ps < projScoped.length; ps++) {
-        console.log("    " + projScoped[ps] + " [installed]");
-      }
-    }
-
-    console.log("");
-    console.log("[hook-runner] " + installedCount + " installed, " + catalogCount + " in catalog");
-    return;
-  }
-
-  // --- Test mode: run all test suites ---
-  if (testMode) {
-    console.log("[hook-runner] Test Suite");
-    console.log("========================");
-    var testDir = path.join(REPO_DIR, "scripts", "test");
-    var testFiles;
-    try {
-      testFiles = fs.readdirSync(testDir).filter(function(f) { return f.startsWith("test-") && f.endsWith(".sh"); }).sort();
-    } catch(e) {
-      console.log("  ERROR: test directory not found: " + testDir);
-      process.exit(1);
-    }
-    if (testFiles.length === 0) {
-      console.log("  No test scripts found in " + testDir);
-      process.exit(1);
-    }
-    var totalPass = 0, totalFail = 0, suiteFail = 0;
-    for (var ti = 0; ti < testFiles.length; ti++) {
-      var testPath = path.join(testDir, testFiles[ti]);
-      var suiteName = testFiles[ti].replace("test-", "").replace(".sh", "");
-      console.log("");
-      console.log("  [" + suiteName + "] " + testFiles[ti]);
-      try {
-        var result = cp.execSync("bash " + JSON.stringify(testPath), {
-          cwd: REPO_DIR,
-          encoding: "utf-8",
-          stdio: ["pipe", "pipe", "pipe"],
-          timeout: 60000
+function cmdUninstall(args, dryRun) {
+  console.log("[hook-runner] Uninstall");
+  console.log("========================");
+  if (dryRun) console.log("  (dry-run mode — no changes will be made)");
+  console.log("");
+  var uninstallChanges = [];
+  if (fs.existsSync(SETTINGS_PATH)) {
+    var settings = JSON.parse(fs.readFileSync(SETTINGS_PATH, "utf-8"));
+    if (settings.hooks) {
+      var hookEvents = Object.keys(settings.hooks);
+      var runnerPattern = /run-(pretooluse|posttooluse|stop|sessionstart|userpromptsubmit)\.js/;
+      var keptEvents = {};
+      for (var ui = 0; ui < hookEvents.length; ui++) {
+        var evt = hookEvents[ui];
+        var entries = settings.hooks[evt];
+        if (!Array.isArray(entries)) { keptEvents[evt] = entries; continue; }
+        var kept = entries.filter(function(entry) {
+          var hooks = entry.hooks || [];
+          return !hooks.some(function(h) { return h.command && runnerPattern.test(h.command); });
         });
-        // Parse results line: "=== Results: N passed, N failed ==="
-        var match = result.match(/(\d+) passed, (\d+) failed/);
-        if (match) {
-          totalPass += parseInt(match[1], 10);
-          totalFail += parseInt(match[2], 10);
-          if (parseInt(match[2], 10) > 0) suiteFail++;
-        }
-        // Show last few lines (results summary)
-        var lines = result.trim().split("\n");
-        var summaryLines = lines.slice(-3);
-        for (var sl = 0; sl < summaryLines.length; sl++) {
-          console.log("    " + summaryLines[sl]);
-        }
-      } catch(e) {
-        suiteFail++;
-        var errOut = (e.stdout || "") + (e.stderr || "");
-        var errLines = errOut.trim().split("\n").slice(-5);
-        for (var el = 0; el < errLines.length; el++) {
-          console.log("    " + errLines[el]);
-        }
-        // Try to parse partial results
-        var partMatch = errOut.match(/(\d+) passed, (\d+) failed/);
-        if (partMatch) {
-          totalPass += parseInt(partMatch[1], 10);
-          totalFail += parseInt(partMatch[2], 10);
+        if (kept.length > 0) {
+          keptEvents[evt] = kept;
+          uninstallChanges.push({ what: "settings.json " + evt, status: "kept " + kept.length + " non-runner entry(s)" });
+        } else {
+          uninstallChanges.push({ what: "settings.json " + evt, status: "removed" });
         }
       }
-    }
-    console.log("");
-    console.log("========================");
-    console.log("[hook-runner] " + testFiles.length + " suites, " + totalPass + " passed, " + totalFail + " failed");
-    if (suiteFail > 0) {
-      console.log("[hook-runner] " + suiteFail + " suite(s) had failures");
-      process.exit(1);
-    }
-    return;
-  }
-
-  // --- Health check mode ---
-  if (healthMode) {
-    console.log("[hook-runner] Health Check");
-    console.log("========================");
-    var results = healthCheck();
-    var ok = 0, warn = 0, fail = 0;
-    for (var hi = 0; hi < results.length; hi++) {
-      var r = results[hi];
-      var icon = r.status === "ok" ? "  OK" : r.status === "warning" ? "WARN" : "FAIL";
-      if (r.status === "ok") ok++;
-      else if (r.status === "warning") warn++;
-      else fail++;
-      var line = "  [" + icon + "] " + r.check + ": " + r.file;
-      if (r.detail) line += " — " + r.detail;
-      console.log(line);
-    }
-    console.log("");
-    console.log("[hook-runner] " + ok + " ok, " + warn + " warnings, " + fail + " failures");
-    if (fail > 0) process.exit(1);
-    return;
-  }
-
-  // --- Sync mode: fetch modules from GitHub per modules.yaml ---
-  if (syncMode) {
-    console.log("[hook-runner] Module Sync");
-    console.log("========================");
-    console.log("  Config: " + MODULES_YAML_PATH);
-    if (dryRun) console.log("  (dry-run mode)");
-    console.log("");
-    var syncChanges = syncModules(dryRun);
-    var installed = syncChanges.filter(function(c) { return c.action === "installed" || c.action === "updated"; }).length;
-    var upToDate = syncChanges.filter(function(c) { return c.action === "up-to-date"; }).length;
-    var wouldChange = syncChanges.filter(function(c) { return /^would-/.test(c.action); }).length;
-    var errors = syncChanges.filter(function(c) { return c.action === "error"; }).length;
-    console.log("");
-    if (dryRun) {
-      console.log("[hook-runner] Dry-run: " + wouldChange + " would change, " + upToDate + " up to date" + (errors ? ", " + errors + " errors" : ""));
+      settings.hooks = keptEvents;
+      if (Object.keys(keptEvents).length === 0) delete settings.hooks;
+      if (!dryRun) {
+        fs.writeFileSync(SETTINGS_PATH, JSON.stringify(settings, null, 2), "utf-8");
+      }
     } else {
-      console.log("[hook-runner] Sync complete: " + installed + " installed/updated, " + upToDate + " up to date" + (errors ? ", " + errors + " errors" : ""));
+      uninstallChanges.push({ what: "settings.json", status: "no hooks section found" });
     }
+  } else {
+    uninstallChanges.push({ what: "settings.json", status: "not found" });
+  }
+  var runnerFiles = ["run-pretooluse.js", "run-posttooluse.js", "run-stop.js", "run-sessionstart.js", "run-userpromptsubmit.js", "load-modules.js", "hook-log.js", "run-async.js", "setup.js"];
+  for (var uf = 0; uf < runnerFiles.length; uf++) {
+    var fp = path.join(HOOKS_DIR, runnerFiles[uf]);
+    if (fs.existsSync(fp)) {
+      if (!dryRun) fs.unlinkSync(fp);
+      uninstallChanges.push({ what: runnerFiles[uf], status: dryRun ? "would remove" : "removed" });
+    }
+  }
+  var forceMode = args.indexOf("--force") !== -1;
+  var runModulesDir = path.join(HOOKS_DIR, "run-modules");
+  if (fs.existsSync(runModulesDir)) {
+    var eventDirs = ["PreToolUse", "PostToolUse", "Stop", "SessionStart", "UserPromptSubmit"];
+    for (var ud = 0; ud < eventDirs.length; ud++) {
+      var evDir = path.join(runModulesDir, eventDirs[ud]);
+      if (!fs.existsSync(evDir)) continue;
+      var contents = fs.readdirSync(evDir);
+      if (contents.length === 0 || forceMode) {
+        if (!dryRun) fs.rmSync(evDir, { recursive: true });
+        uninstallChanges.push({ what: "run-modules/" + eventDirs[ud], status: (dryRun ? "would remove" : "removed") + (contents.length > 0 ? " (" + contents.length + " files)" : "") });
+      } else {
+        uninstallChanges.push({ what: "run-modules/" + eventDirs[ud], status: "kept (has " + contents.length + " module(s) — use --force to remove)" });
+      }
+    }
+    try {
+      var remaining = fs.readdirSync(runModulesDir);
+      if (remaining.length === 0) {
+        if (!dryRun) fs.rmdirSync(runModulesDir);
+        uninstallChanges.push({ what: "run-modules/", status: dryRun ? "would remove" : "removed" });
+      }
+    } catch(e) {}
+  }
+  var logFile = path.join(HOOKS_DIR, "hook-log.jsonl");
+  var logFile1 = logFile + ".1";
+  for (var lf = 0; lf < 2; lf++) {
+    var lfp = lf === 0 ? logFile : logFile1;
+    if (fs.existsSync(lfp)) {
+      if (!dryRun) fs.unlinkSync(lfp);
+      uninstallChanges.push({ what: path.basename(lfp), status: dryRun ? "would remove" : "removed" });
+    }
+  }
+  for (var uc = 0; uc < uninstallChanges.length; uc++) {
+    console.log("  " + uninstallChanges[uc].what + ": " + uninstallChanges[uc].status);
+  }
+  console.log("");
+  console.log("[hook-runner] " + (dryRun ? "Dry-run complete. No changes made." : "Uninstall complete."));
+}
+
+function cmdPrune(args, dryRun) {
+  var pruneIdx = args.indexOf("--prune");
+  var pruneDays = parseInt(args[pruneIdx + 1], 10) || 7;
+  console.log("[hook-runner] Log Prune");
+  console.log("========================");
+  console.log("  Keeping entries from last " + pruneDays + " day(s)");
+  if (dryRun) console.log("  (dry-run mode)");
+  var pruneResult = pruneLog(pruneDays, dryRun);
+  console.log("  Kept: " + pruneResult.kept + " entries");
+  console.log("  Pruned: " + pruneResult.pruned + " entries");
+  if (pruneResult.rotatedRemoved) console.log("  Rotated log (.1): " + (dryRun ? "would remove" : "removed"));
+  console.log("");
+  console.log("[hook-runner] " + (dryRun ? "Dry-run complete." : "Prune complete."));
+}
+
+function cmdStats() {
+  console.log("[hook-runner] Log Stats");
+  console.log("========================");
+  var hs = readHookStats(3);
+  var hsKeys = Object.keys(hs).sort();
+  if (hsKeys.length === 0) {
+    console.log("  No hook log data found.");
     return;
   }
+  var totalInv = 0, totalBlk = 0, totalErr = 0;
+  for (var si = 0; si < hsKeys.length; si++) {
+    totalInv += hs[hsKeys[si]].total;
+    totalBlk += hs[hsKeys[si]].block;
+    totalErr += hs[hsKeys[si]].error;
+  }
+  console.log("  Total invocations: " + totalInv);
+  console.log("  Total blocks: " + totalBlk + " (" + (totalInv > 0 ? ((totalBlk / totalInv) * 100).toFixed(1) : "0") + "%)");
+  if (totalErr > 0) console.log("  Total errors: " + totalErr);
+  console.log("");
+  var hasActivity = false;
+  for (var sj = 0; sj < hsKeys.length; sj++) {
+    var ms = hs[hsKeys[sj]];
+    if (ms.block > 0 || ms.error > 0) {
+      if (!hasActivity) { console.log("  Active hooks:"); hasActivity = true; }
+      var parts = "    " + hsKeys[sj];
+      if (ms.block > 0) parts += "  " + ms.block + " blocked";
+      if (ms.error > 0) parts += "  " + ms.error + " errors";
+      console.log(parts);
+    }
+  }
+  if (!hasActivity) console.log("  No blocks or errors recorded.");
+  console.log("");
+}
 
+function cmdList() {
+  console.log("[hook-runner] Module List");
+  console.log("========================");
+  var catalogDir = path.join(REPO_DIR, "modules");
+  var events = ["PreToolUse", "PostToolUse", "UserPromptSubmit", "Stop", "SessionStart"];
+  var catalog = {};
+  var catalogCount = 0;
+  for (var li = 0; li < events.length; li++) {
+    var evDir = path.join(catalogDir, events[li]);
+    catalog[events[li]] = [];
+    try {
+      var files = fs.readdirSync(evDir).filter(function(f) { return f.endsWith(".js"); }).sort();
+      catalog[events[li]] = files;
+      catalogCount += files.length;
+    } catch(e) {}
+  }
+  var liveDir = path.join(HOOKS_DIR, "run-modules");
+  var installed = {};
+  var installedCount = 0;
+  for (var lj = 0; lj < events.length; lj++) {
+    var livEvDir = path.join(liveDir, events[lj]);
+    installed[events[lj]] = [];
+    try {
+      var livFiles = fs.readdirSync(livEvDir).filter(function(f) { return f.endsWith(".js"); }).sort();
+      installed[events[lj]] = livFiles;
+      installedCount += livFiles.length;
+    } catch(e) {}
+  }
+  for (var lk = 0; lk < events.length; lk++) {
+    var ev = events[lk];
+    var catMods = catalog[ev];
+    var instMods = installed[ev];
+    if (catMods.length === 0 && instMods.length === 0) continue;
+    console.log("");
+    console.log("  " + ev + ":");
+    var allMods = {};
+    for (var cm = 0; cm < catMods.length; cm++) allMods[catMods[cm]] = { catalog: true, installed: false };
+    for (var im = 0; im < instMods.length; im++) {
+      if (!allMods[instMods[im]]) allMods[instMods[im]] = { catalog: false, installed: false };
+      allMods[instMods[im]].installed = true;
+    }
+    var modNames = Object.keys(allMods).sort();
+    for (var mn = 0; mn < modNames.length; mn++) {
+      var m = allMods[modNames[mn]];
+      var status = m.installed && m.catalog ? " [installed]" :
+                   m.installed && !m.catalog ? " [installed, custom]" :
+                   " [available]";
+      console.log("    " + modNames[mn].replace(".js", "") + status);
+    }
+  }
+  var projScoped = [];
+  for (var pe = 0; pe < events.length; pe++) {
+    try {
+      var liveEvtDir = path.join(liveDir, events[pe]);
+      var liveEntries = fs.readdirSync(liveEvtDir, { withFileTypes: true });
+      var projDirs = liveEntries.filter(function(e) { return e.isDirectory(); });
+      for (var pd = 0; pd < projDirs.length; pd++) {
+        var projPath = path.join(liveEvtDir, projDirs[pd].name);
+        var projMods = fs.readdirSync(projPath).filter(function(f) { return f.endsWith(".js"); });
+        for (var pm = 0; pm < projMods.length; pm++) {
+          projScoped.push(events[pe] + "/" + projDirs[pd].name + "/" + projMods[pm].replace(".js", ""));
+        }
+      }
+    } catch(e) {}
+  }
+  if (projScoped.length > 0) {
+    console.log("");
+    console.log("  Project-scoped:");
+    for (var ps = 0; ps < projScoped.length; ps++) {
+      console.log("    " + projScoped[ps] + " [installed]");
+    }
+  }
+  console.log("");
+  console.log("[hook-runner] " + installedCount + " installed, " + catalogCount + " in catalog");
+}
+
+function cmdTest() {
+  console.log("[hook-runner] Test Suite");
+  console.log("========================");
+  var testDir = path.join(REPO_DIR, "scripts", "test");
+  var testFiles;
+  try {
+    testFiles = fs.readdirSync(testDir).filter(function(f) { return f.startsWith("test-") && f.endsWith(".sh"); }).sort();
+  } catch(e) {
+    console.log("  ERROR: test directory not found: " + testDir);
+    process.exit(1);
+  }
+  if (testFiles.length === 0) {
+    console.log("  No test scripts found in " + testDir);
+    process.exit(1);
+  }
+  var totalPass = 0, totalFail = 0, suiteFail = 0;
+  for (var ti = 0; ti < testFiles.length; ti++) {
+    var testPath = path.join(testDir, testFiles[ti]);
+    var suiteName = testFiles[ti].replace("test-", "").replace(".sh", "");
+    console.log("");
+    console.log("  [" + suiteName + "] " + testFiles[ti]);
+    try {
+      var result = cp.execSync("bash " + JSON.stringify(testPath), {
+        cwd: REPO_DIR,
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+        timeout: 60000
+      });
+      var match = result.match(/(\d+) passed, (\d+) failed/);
+      if (match) {
+        totalPass += parseInt(match[1], 10);
+        totalFail += parseInt(match[2], 10);
+        if (parseInt(match[2], 10) > 0) suiteFail++;
+      }
+      var lines = result.trim().split("\n");
+      var summaryLines = lines.slice(-3);
+      for (var sl = 0; sl < summaryLines.length; sl++) {
+        console.log("    " + summaryLines[sl]);
+      }
+    } catch(e) {
+      suiteFail++;
+      var errOut = (e.stdout || "") + (e.stderr || "");
+      var errLines = errOut.trim().split("\n").slice(-5);
+      for (var el = 0; el < errLines.length; el++) {
+        console.log("    " + errLines[el]);
+      }
+      var partMatch = errOut.match(/(\d+) passed, (\d+) failed/);
+      if (partMatch) {
+        totalPass += parseInt(partMatch[1], 10);
+        totalFail += parseInt(partMatch[2], 10);
+      }
+    }
+  }
+  console.log("");
+  console.log("========================");
+  console.log("[hook-runner] " + testFiles.length + " suites, " + totalPass + " passed, " + totalFail + " failed");
+  if (suiteFail > 0) {
+    console.log("[hook-runner] " + suiteFail + " suite(s) had failures");
+    process.exit(1);
+  }
+}
+
+function cmdHealth() {
+  console.log("[hook-runner] Health Check");
+  console.log("========================");
+  var results = healthCheck();
+  var ok = 0, warn = 0, fail = 0;
+  for (var hi = 0; hi < results.length; hi++) {
+    var r = results[hi];
+    var icon = r.status === "ok" ? "  OK" : r.status === "warning" ? "WARN" : "FAIL";
+    if (r.status === "ok") ok++;
+    else if (r.status === "warning") warn++;
+    else fail++;
+    var line = "  [" + icon + "] " + r.check + ": " + r.file;
+    if (r.detail) line += " — " + r.detail;
+    console.log(line);
+  }
+  console.log("");
+  console.log("[hook-runner] " + ok + " ok, " + warn + " warnings, " + fail + " failures");
+  if (fail > 0) process.exit(1);
+}
+
+function cmdSync(dryRun) {
+  console.log("[hook-runner] Module Sync");
+  console.log("========================");
+  console.log("  Config: " + MODULES_YAML_PATH);
+  if (dryRun) console.log("  (dry-run mode)");
+  console.log("");
+  var syncChanges = syncModules(dryRun);
+  var installed = syncChanges.filter(function(c) { return c.action === "installed" || c.action === "updated"; }).length;
+  var upToDate = syncChanges.filter(function(c) { return c.action === "up-to-date"; }).length;
+  var wouldChange = syncChanges.filter(function(c) { return /^would-/.test(c.action); }).length;
+  var errors = syncChanges.filter(function(c) { return c.action === "error"; }).length;
+  console.log("");
+  if (dryRun) {
+    console.log("[hook-runner] Dry-run: " + wouldChange + " would change, " + upToDate + " up to date" + (errors ? ", " + errors + " errors" : ""));
+  } else {
+    console.log("[hook-runner] Sync complete: " + installed + " installed/updated, " + upToDate + " up to date" + (errors ? ", " + errors + " errors" : ""));
+  }
+}
+
+function cmdWizard(reportOnly, dryRun, openMode) {
   console.log("[hook-runner] Setup Wizard");
   console.log("========================");
 
@@ -1224,6 +1153,27 @@ function main() {
   console.log("  To restore original hooks:");
   console.log("    cp " + backup.backupDir + "/settings.json ~/.claude/settings.json");
   console.log("============================================");
+}
+
+function main() {
+  var args = process.argv.slice(2);
+  var dryRun = args.indexOf("--dry-run") !== -1;
+  var openMode = args.indexOf("--open") !== -1;
+
+  if (args.indexOf("--help") !== -1 || args.indexOf("-h") !== -1) return cmdHelp();
+  if (args.indexOf("--version") !== -1 || args.indexOf("-v") !== -1) { console.log("hook-runner v" + VERSION); return; }
+  if (args.indexOf("--upgrade") !== -1) return cmdUpgrade(args, dryRun);
+  if (args.indexOf("--uninstall") !== -1) return cmdUninstall(args, dryRun);
+  if (args.indexOf("--prune") !== -1) return cmdPrune(args, dryRun);
+  if (args.indexOf("--stats") !== -1) return cmdStats();
+  if (args.indexOf("--list") !== -1) return cmdList();
+  if (args.indexOf("--test") !== -1) return cmdTest();
+  if (args.indexOf("--health") !== -1) return cmdHealth();
+  if (args.indexOf("--sync") !== -1) return cmdSync(dryRun);
+
+  // Default: setup wizard (with --report and --install as sub-modes)
+  var reportOnly = args.indexOf("--report") !== -1;
+  cmdWizard(reportOnly, dryRun, openMode);
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary
- Refactored main() from 553 lines to 15-line dispatcher
- Each CLI command is now a standalone function: cmdHelp, cmdUpgrade, cmdUninstall, cmdPrune, cmdStats, cmdList, cmdTest, cmdHealth, cmdSync, cmdWizard
- setup.js dropped from 1327 to 1277 lines
- No behavior changes — pure refactor

## Test plan
- [x] 88 tests pass (all 5 suites)
- [x] Smoke-tested: --version, --health, --stats, --list all produce correct output