### PR TITLE
T069: Update docs, bump version to 1.3.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,14 +9,14 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 - **Live hooks**: ~/.claude/hooks/ (run-*.js, load-modules.js, run-modules/)
 
 ## File Layout
-- `setup.js` — CLI entry point (setup wizard, report, health, sync, stats, test, uninstall, prune, version)
+- `setup.js` — CLI entry point with extracted command handlers (cmdHelp, cmdUpgrade, cmdUninstall, etc.)
 - `report.js` — HTML report generator (extracted from setup.js for maintainability)
 - `run-*.js` — event runners (one per event: pretooluse, posttooluse, stop, sessionstart, userpromptsubmit)
 - `load-modules.js` — shared module loader (global + project-scoped discovery)
 - `hook-log.js` — centralized logger (appends JSONL per invocation)
 - `run-async.js` — async module executor (Promise detection, 4s timeout)
 - `modules/` — distributable module catalog organized by event type
-- `scripts/test/` — test scripts (84 tests across 5 files)
+- `scripts/test/` — test scripts (88 tests across 5 files)
 
 ## Sync Targets (must stay identical)
 1. Repo: this directory

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Full catalog in `modules/` directory:
 |--------|-------------|
 | `rule-hygiene` | Validates rule files are single-topic, under 20 lines |
 | `commit-msg-check` | Blocks WIP/fixup commits and over-long first lines (>72 chars) |
+| `test-coverage-check` | Warns when source files with corresponding test files are modified |
 
 ### Stop (controls session ending)
 | Module | Description |
@@ -213,3 +214,4 @@ Full catalog in `modules/` directory:
 |--------|-------------|
 | `load-instructions` | Injects working instructions at session start |
 | `backup-check` | Async — warns if claude-backup is stale (>72h) or missing |
+| `project-health` | Runs health check on session start, warns about issues |

--- a/TODO.md
+++ b/TODO.md
@@ -98,13 +98,16 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 - [x] T067: Add PostToolUse module: `test-coverage-check` (warns if test files modified without running tests)
 - [x] T068: Extract main() dispatch into command handler functions (main() 553→15 lines)
 
+## Docs & Release
+- [x] T069: Update README, CLAUDE.md, SKILL.md + version bump to 1.3.0 + marketplace push
+
 ## Status
-- 65 tasks completed, 3 pending
-- Version: 1.2.0
-- 84 tests passing across 5 test files (16 runner + 7 wizard + 13 async + 38 module + 10 sync)
+- 69 tasks completed, 0 pending
+- Version: 1.3.0
+- 88 tests passing across 5 test files (16 runner + 7 wizard + 13 async + 42 module + 10 sync)
 - CI: GitHub Actions runs all tests on push/PR — badge in README
 - 4 sync targets all identical: repo, live hooks, skill, marketplace
-- 19 modules in catalog (12 PreToolUse, 2 PostToolUse, 1 UserPromptSubmit, 2 SessionStart, 2 Stop)
+- 21 modules in catalog (12 PreToolUse, 3 PostToolUse, 1 UserPromptSubmit, 3 SessionStart, 2 Stop)
 - CLI commands: setup, report, dry-run, health, sync, stats, list, test, upgrade, uninstall, prune, version, help
 
 ## Moved

--- a/setup.js
+++ b/setup.js
@@ -46,7 +46,7 @@ var SCRIPT_DIR = __dirname;
 var REPO_DIR = SCRIPT_DIR;
 
 var HOOK_LOG_PATH = path.join(HOOKS_DIR, "hook-log.jsonl");
-var VERSION = "1.2.0";
+var VERSION = "1.3.0";
 
 // ============================================================
 // 0. Hook Log Stats


### PR DESCRIPTION
## Summary
- Added project-health and test-coverage-check to README module tables
- Updated CLAUDE.md test counts (88) and file layout description
- Version bump 1.2.0 → 1.3.0

## Test plan
- [x] 88 tests pass