### PR TITLE
T071: Add env-var-check PreToolUse module

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -113,25 +113,12 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 - 21 modules in catalog (12 PreToolUse, 3 PostToolUse, 1 UserPromptSubmit, 3 SessionStart, 2 Stop)
 - CLI commands: setup, report, dry-run, health, sync, stats, list, test, upgrade, uninstall, prune, version, help
 
-## Session Handoff (2026-03-30 session 3)
-Completed T066-T070 this session. Project is v1.3.0 (70 tasks, 88 tests, 21 modules).
-
-### What was done
-- T066: `project-health` SessionStart module (health check on session start)
-- T067: `test-coverage-check` PostToolUse module (warns when source files with tests are modified)
-- T068: Extracted main() from 553→15 lines into 10 named cmd* functions
-- T069: Docs + version bump to 1.3.0 + marketplace push
-- T070: Synced 4 live module fixes back to repo catalog (branch-pr-gate, no-adhoc-commands, load-instructions, auto-continue)
-
-### Nothing broken
-All 88 tests pass. All sync targets identical. Marketplace pushed.
-
-### Next session ideas (prioritized by impact)
-1. **Module dependency system** — some modules logically depend on others (spec-gate needs enforcement-gate). Could add `requires:` field.
-2. **Integration with hook-flow-bundle** — export/import module configs as portable bundles for team sharing
-3. **PreToolUse module: `env-var-check`** — blocks if required env vars for the project are missing
-4. **Report v3** — add per-module timing data (how much latency each module adds), configurable via hook-log
-5. **Module hot-reload** — detect changed modules without restarting Claude Code (clear require cache)
+## Performance & Features (v1.4.0)
+- [x] T071: Add `env-var-check` PreToolUse module (blocks if required project env vars missing)
+- [ ] T072: Add per-module timing to hook-log (measure latency each module adds)
+- [ ] T073: Report v3 — timing data visualization, per-module latency chart
+- [ ] T074: Module dependency system — `requires:` field in module header, load-modules validates
+- [ ] T075: Module hot-reload — detect changed modules, clear require cache without restarting Claude Code
 
 ## Moved
 - T026: Moved to chat-export/TODO.md (out of scope for hook-runner)

--- a/modules.example.yaml
+++ b/modules.example.yaml
@@ -28,6 +28,9 @@ modules:
     - secret-scan-gate       # blocks git commit if staged diff contains secrets
     - no-hardcoded-paths     # blocks Write/Edit with absolute user paths in content
 
+    # Environment
+    - env-var-check          # blocks edits if .env.required vars are missing
+
     # Optional / niche
     # - aws-tagging-gate     # enforce AWS resource tags (needs AWS_TAG_REQUIRED_VALUE env)
 

--- a/modules/PreToolUse/env-var-check.js
+++ b/modules/PreToolUse/env-var-check.js
@@ -1,0 +1,65 @@
+"use strict";
+// PreToolUse: block code edits if required environment variables are missing.
+// Looks for .env.required in CLAUDE_PROJECT_DIR — one variable name per line.
+// Lines starting with # are comments. Blank lines are ignored.
+// Only blocks Write, Edit, and Bash (state-changing tools).
+var fs = require("fs");
+var path = require("path");
+
+// Cache per project dir to avoid re-reading file on every tool call
+var _cache = { dir: null, missing: null, checked: false };
+
+function getMissingVars(projectDir) {
+  if (_cache.checked && _cache.dir === projectDir) return _cache.missing;
+
+  _cache.dir = projectDir;
+  _cache.checked = true;
+  _cache.missing = [];
+
+  if (!projectDir) return _cache.missing;
+
+  var reqFile = path.join(projectDir, ".env.required");
+  if (!fs.existsSync(reqFile)) return _cache.missing;
+
+  var lines;
+  try {
+    lines = fs.readFileSync(reqFile, "utf-8").split("\n");
+  } catch (e) {
+    return _cache.missing;
+  }
+
+  var missing = [];
+  for (var i = 0; i < lines.length; i++) {
+    var line = lines[i].trim();
+    if (!line || line.charAt(0) === "#") continue;
+
+    // Support "VAR_NAME # description" format
+    var varName = line.split(/\s+#/)[0].trim();
+    if (!varName) continue;
+
+    if (!process.env[varName]) {
+      missing.push(varName);
+    }
+  }
+
+  _cache.missing = missing;
+  return missing;
+}
+
+module.exports = function(input) {
+  var tool = input.tool_name;
+  if (tool !== "Write" && tool !== "Edit" && tool !== "Bash") return null;
+
+  var projectDir = process.env.CLAUDE_PROJECT_DIR || "";
+  var missing = getMissingVars(projectDir);
+
+  if (missing.length === 0) return null;
+
+  return {
+    decision: "block",
+    reason: "ENV VAR CHECK: Required environment variables are not set.\n" +
+      "Missing: " + missing.join(", ") + "\n" +
+      "Defined in: " + path.join(projectDir, ".env.required") + "\n" +
+      "Set them in your shell or add to Claude Code settings.json env section."
+  };
+};


### PR DESCRIPTION
## Summary
- New PreToolUse module: `env-var-check` — blocks Write/Edit/Bash if required env vars are missing
- Reads `.env.required` from project root (one var per line, `#` comments supported)
- Caches result per project directory to avoid repeated file reads
- Added to modules.example.yaml under Environment section

## Test plan
- [x] Module passes when no `.env.required` file exists
- [x] Module blocks when required vars are missing
- [x] Module allows Read tool even with missing vars
- [x] Module passes when all vars are set
- [x] Full test suite: 90/90 pass