### PR TITLE
T072: Add per-module timing to hook-log

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -115,7 +115,7 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 
 ## Performance & Features (v1.4.0)
 - [x] T071: Add `env-var-check` PreToolUse module (blocks if required project env vars missing)
-- [ ] T072: Add per-module timing to hook-log (measure latency each module adds)
+- [x] T072: Add per-module timing to hook-log (measure latency each module adds)
 - [ ] T073: Report v3 — timing data visualization, per-module latency chart
 - [ ] T074: Module dependency system — `requires:` field in module header, load-modules validates
 - [ ] T075: Module hot-reload — detect changed modules, clear require cache without restarting Claude Code

--- a/hook-log.js
+++ b/hook-log.js
@@ -14,7 +14,7 @@ var MAX_LOG_SIZE = 10 * 1024 * 1024; // 10MB — rotate when exceeded
  * @param {string} event - PreToolUse, PostToolUse, Stop, SessionStart
  * @param {string} moduleName - e.g. "enforcement-gate"
  * @param {string} result - "pass", "block", "error", "text"
- * @param {object} context - { tool, command, file, reason, project }
+ * @param {object} context - { tool, command, file, reason, project, ms }
  */
 function logHook(event, moduleName, result, context) {
   try {
@@ -30,6 +30,7 @@ function logHook(event, moduleName, result, context) {
       if (context.file) entry.file = path.basename(context.file);
       if (context.reason) entry.reason = context.reason.substring(0, 200);
       if (context.project) entry.project = context.project;
+      if (typeof context.ms === "number") entry.ms = context.ms;
     }
 
     var line = JSON.stringify(entry) + "\n";

--- a/run-async.js
+++ b/run-async.js
@@ -62,6 +62,7 @@ function runModules(modulePaths, input, handleResult, handleDone, timeout) {
     var modName = path.basename(modPath, ".js");
     i++;
 
+    var t0 = Date.now();
     try {
       var mod = require(modPath);
       var result = mod(input);
@@ -71,21 +72,25 @@ function runModules(modulePaths, input, handleResult, handleDone, timeout) {
         hasAsync = true;
         withTimeout(result, timeout, modName).then(
           function (val) {
-            if (handleResult(modName, val)) return; // stopped
+            var ms = Date.now() - t0;
+            if (handleResult(modName, val, null, ms)) return; // stopped
             next();
           },
           function (err) {
-            handleResult(modName, null, err);
+            var ms = Date.now() - t0;
+            handleResult(modName, null, err, ms);
             next();
           }
         );
       } else {
         // Sync module — process immediately
-        if (handleResult(modName, result)) return; // stopped
+        var ms = Date.now() - t0;
+        if (handleResult(modName, result, null, ms)) return; // stopped
         next();
       }
     } catch (e) {
-      handleResult(modName, null, e);
+      var ms = Date.now() - t0;
+      handleResult(modName, null, e, ms);
       next();
     }
   }

--- a/run-posttooluse.js
+++ b/run-posttooluse.js
@@ -19,18 +19,18 @@ var ctx = hookLog.extractContext("PostToolUse", input);
 var modules = loadModules(path.join(__dirname, "run-modules", "PostToolUse"));
 
 runAsync.runModules(modules, input,
-  function handleResult(modName, result, err) {
+  function handleResult(modName, result, err, ms) {
     if (err) {
-      hookLog.logHook("PostToolUse", modName, "error", Object.assign({}, ctx, { reason: err.message }));
+      hookLog.logHook("PostToolUse", modName, "error", Object.assign({}, ctx, { reason: err.message, ms: ms }));
       process.stderr.write("hook-runner PostToolUse " + modName + " error: " + err.message + "\n");
       return false;
     }
     if (result && result.decision) {
-      hookLog.logHook("PostToolUse", modName, result.decision, Object.assign({}, ctx, { reason: result.reason }));
+      hookLog.logHook("PostToolUse", modName, result.decision, Object.assign({}, ctx, { reason: result.reason, ms: ms }));
       process.stdout.write(JSON.stringify(result));
       process.exit(0);
     }
-    hookLog.logHook("PostToolUse", modName, "pass", ctx);
+    hookLog.logHook("PostToolUse", modName, "pass", Object.assign({}, ctx, { ms: ms }));
     return false;
   },
   function handleDone() {

--- a/run-pretooluse.js
+++ b/run-pretooluse.js
@@ -19,18 +19,18 @@ var ctx = hookLog.extractContext("PreToolUse", input);
 var modules = loadModules(path.join(__dirname, "run-modules", "PreToolUse"));
 
 runAsync.runModules(modules, input,
-  function handleResult(modName, result, err) {
+  function handleResult(modName, result, err, ms) {
     if (err) {
-      hookLog.logHook("PreToolUse", modName, "error", Object.assign({}, ctx, { reason: err.message }));
+      hookLog.logHook("PreToolUse", modName, "error", Object.assign({}, ctx, { reason: err.message, ms: ms }));
       process.stderr.write("hook-runner PreToolUse " + modName + " error: " + err.message + "\n");
       return false;
     }
     if (result && result.decision) {
-      hookLog.logHook("PreToolUse", modName, result.decision, Object.assign({}, ctx, { reason: result.reason }));
+      hookLog.logHook("PreToolUse", modName, result.decision, Object.assign({}, ctx, { reason: result.reason, ms: ms }));
       process.stdout.write(JSON.stringify(result));
       process.exit(0);
     }
-    hookLog.logHook("PreToolUse", modName, "pass", ctx);
+    hookLog.logHook("PreToolUse", modName, "pass", Object.assign({}, ctx, { ms: ms }));
     return false;
   },
   function handleDone() {

--- a/run-sessionstart.js
+++ b/run-sessionstart.js
@@ -21,17 +21,17 @@ var modules = loadModules(path.join(__dirname, "run-modules", "SessionStart"));
 var output = [];
 
 runAsync.runModules(modules, input,
-  function handleResult(modName, result, err) {
+  function handleResult(modName, result, err, ms) {
     if (err) {
-      hookLog.logHook("SessionStart", modName, "error", Object.assign({}, ctx, { reason: err.message }));
+      hookLog.logHook("SessionStart", modName, "error", Object.assign({}, ctx, { reason: err.message, ms: ms }));
       process.stderr.write("hook-runner SessionStart " + modName + " error: " + err.message + "\n");
       return false;
     }
     if (result && result.text) {
-      hookLog.logHook("SessionStart", modName, "text", ctx);
+      hookLog.logHook("SessionStart", modName, "text", Object.assign({}, ctx, { ms: ms }));
       output.push(result.text);
     } else {
-      hookLog.logHook("SessionStart", modName, "pass", ctx);
+      hookLog.logHook("SessionStart", modName, "pass", Object.assign({}, ctx, { ms: ms }));
     }
     return false; // never stop — collect all text
   },

--- a/run-stop.js
+++ b/run-stop.js
@@ -20,18 +20,18 @@ var ctx = hookLog.extractContext("Stop", input);
 var modules = loadModules(path.join(__dirname, "run-modules", "Stop"));
 
 runAsync.runModules(modules, input,
-  function handleResult(modName, result, err) {
+  function handleResult(modName, result, err, ms) {
     if (err) {
-      hookLog.logHook("Stop", modName, "error", Object.assign({}, ctx, { reason: err.message }));
+      hookLog.logHook("Stop", modName, "error", Object.assign({}, ctx, { reason: err.message, ms: ms }));
       process.stderr.write("hook-runner Stop " + modName + " error: " + err.message + "\n");
       return false;
     }
     if (result && result.decision === "block") {
-      hookLog.logHook("Stop", modName, "block", Object.assign({}, ctx, { reason: result.reason }));
+      hookLog.logHook("Stop", modName, "block", Object.assign({}, ctx, { reason: result.reason, ms: ms }));
       process.stdout.write(JSON.stringify(result));
       process.exit(0);
     }
-    hookLog.logHook("Stop", modName, "pass", ctx);
+    hookLog.logHook("Stop", modName, "pass", Object.assign({}, ctx, { ms: ms }));
     return false;
   },
   function handleDone() {

--- a/run-userpromptsubmit.js
+++ b/run-userpromptsubmit.js
@@ -21,18 +21,18 @@ var ctx = hookLog.extractContext("UserPromptSubmit", input);
 var modules = loadModules(path.join(__dirname, "run-modules", "UserPromptSubmit"));
 
 runAsync.runModules(modules, input,
-  function handleResult(modName, result, err) {
+  function handleResult(modName, result, err, ms) {
     if (err) {
-      hookLog.logHook("UserPromptSubmit", modName, "error", Object.assign({}, ctx, { reason: err.message }));
+      hookLog.logHook("UserPromptSubmit", modName, "error", Object.assign({}, ctx, { reason: err.message, ms: ms }));
       process.stderr.write("hook-runner UserPromptSubmit " + modName + " error: " + err.message + "\n");
       return false;
     }
     if (result && result.decision) {
-      hookLog.logHook("UserPromptSubmit", modName, result.decision, Object.assign({}, ctx, { reason: result.reason }));
+      hookLog.logHook("UserPromptSubmit", modName, result.decision, Object.assign({}, ctx, { reason: result.reason, ms: ms }));
       process.stdout.write(JSON.stringify(result));
       process.exit(0);
     }
-    hookLog.logHook("UserPromptSubmit", modName, "pass", ctx);
+    hookLog.logHook("UserPromptSubmit", modName, "pass", Object.assign({}, ctx, { ms: ms }));
     return false;
   },
   function handleDone() {

--- a/setup.js
+++ b/setup.js
@@ -63,7 +63,7 @@ function parseLogLines(lines, stats, maxSamples) {
 
     var key = entry.event + "/" + entry.module;
     if (!stats[key]) {
-      stats[key] = { total: 0, pass: 0, block: 0, error: 0, text: 0, deny: 0, samples: [] };
+      stats[key] = { total: 0, pass: 0, block: 0, error: 0, text: 0, deny: 0, msTotal: 0, msCount: 0, msMax: 0, samples: [] };
     }
     var s = stats[key];
     s.total++;
@@ -73,6 +73,12 @@ function parseLogLines(lines, stats, maxSamples) {
     else if (r === "deny") { s.block++; s.deny++; }
     else if (r === "error") s.error++;
     else if (r === "text") s.text++;
+
+    if (typeof entry.ms === "number") {
+      s.msTotal += entry.ms;
+      s.msCount++;
+      if (entry.ms > s.msMax) s.msMax = entry.ms;
+    }
 
     if (r !== "pass" && r !== "text" && s.samples.length < maxSamples) {
       s.samples.push({
@@ -880,17 +886,34 @@ function cmdStats() {
   console.log("");
   var hasActivity = false;
   for (var sj = 0; sj < hsKeys.length; sj++) {
-    var ms = hs[hsKeys[sj]];
-    if (ms.block > 0 || ms.error > 0) {
+    var st = hs[hsKeys[sj]];
+    if (st.block > 0 || st.error > 0) {
       if (!hasActivity) { console.log("  Active hooks:"); hasActivity = true; }
       var parts = "    " + hsKeys[sj];
-      if (ms.block > 0) parts += "  " + ms.block + " blocked";
-      if (ms.error > 0) parts += "  " + ms.error + " errors";
+      if (st.block > 0) parts += "  " + st.block + " blocked";
+      if (st.error > 0) parts += "  " + st.error + " errors";
       console.log(parts);
     }
   }
   if (!hasActivity) console.log("  No blocks or errors recorded.");
   console.log("");
+
+  // Timing summary — show modules with timing data, sorted by avg latency
+  var timed = [];
+  for (var sk = 0; sk < hsKeys.length; sk++) {
+    var tm = hs[hsKeys[sk]];
+    if (tm.msCount > 0) {
+      timed.push({ key: hsKeys[sk], avg: Math.round(tm.msTotal / tm.msCount), max: tm.msMax, count: tm.msCount });
+    }
+  }
+  if (timed.length > 0) {
+    timed.sort(function(a, b) { return b.avg - a.avg; });
+    console.log("  Module timing (avg / max ms):");
+    for (var sl = 0; sl < timed.length && sl < 15; sl++) {
+      console.log("    " + timed[sl].key + "  avg:" + timed[sl].avg + "ms  max:" + timed[sl].max + "ms  (" + timed[sl].count + " samples)");
+    }
+    console.log("");
+  }
 }
 
 function cmdList() {


### PR DESCRIPTION
## Summary
- Records execution time (ms) for every module invocation in hook-log.jsonl
- Timing measured in run-async.js, passed through all 5 runners to logHook
- `--stats` command now shows avg/max latency per module, sorted by impact
- Fixed `t0` variable scoping in run-async.js catch block

## Test plan
- [x] Full test suite: 90/90 pass
- [x] Verified `ms` field appears in JSONL log entries
- [x] Verified `--stats` shows timing summary section