### PR TITLE
T074: Add module dependency system

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -117,7 +117,7 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 - [x] T071: Add `env-var-check` PreToolUse module (blocks if required project env vars missing)
 - [x] T072: Add per-module timing to hook-log (measure latency each module adds)
 - [x] T073: Report v3 — timing data visualization, per-module latency chart
-- [ ] T074: Module dependency system — `requires:` field in module header, load-modules validates
+- [x] T074: Module dependency system — `requires:` field in module header, load-modules validates
 - [ ] T075: Module hot-reload — detect changed modules, clear require cache without restarting Claude Code
 
 ## Moved

--- a/load-modules.js
+++ b/load-modules.js
@@ -14,7 +14,57 @@ var fs = require("fs");
 var path = require("path");
 
 /**
+ * Parse "// requires: mod1, mod2" from the first 5 lines of a module file.
+ * Only matches module-name patterns (lowercase with hyphens, no spaces in names).
+ * Returns array of required module base names (without .js).
+ */
+function parseRequires(filePath) {
+  try {
+    var content = fs.readFileSync(filePath, "utf-8");
+    var lines = content.split("\n").slice(0, 5);
+    for (var i = 0; i < lines.length; i++) {
+      var match = lines[i].match(/^\/\/\s*requires:\s*(.+)/i);
+      if (match) {
+        var deps = match[1].split(",").map(function(s) { return s.trim(); }).filter(Boolean);
+        // Only accept valid module names (lowercase, hyphens, digits — no spaces/descriptions)
+        var valid = deps.filter(function(d) { return /^[a-z0-9][-a-z0-9]*$/.test(d); });
+        if (valid.length > 0) return valid;
+      }
+    }
+  } catch (e) { /* can't read, no deps */ }
+  return [];
+}
+
+/**
+ * Filter out modules whose dependencies are not present.
+ * Warns to stderr about missing deps. Returns filtered list.
+ */
+function validateDeps(modulePaths) {
+  var available = {};
+  for (var i = 0; i < modulePaths.length; i++) {
+    available[path.basename(modulePaths[i], ".js")] = true;
+  }
+
+  var result = [];
+  for (var j = 0; j < modulePaths.length; j++) {
+    var deps = parseRequires(modulePaths[j]);
+    var missing = [];
+    for (var k = 0; k < deps.length; k++) {
+      if (!available[deps[k]]) missing.push(deps[k]);
+    }
+    if (missing.length > 0) {
+      var modName = path.basename(modulePaths[j], ".js");
+      process.stderr.write("hook-runner: skipping " + modName + " — missing deps: " + missing.join(", ") + "\n");
+    } else {
+      result.push(modulePaths[j]);
+    }
+  }
+  return result;
+}
+
+/**
  * Return sorted list of module paths to load for the given event dir.
+ * Validates module dependencies — modules with missing deps are skipped.
  * @param {string} eventDir  e.g. ~/.claude/hooks/run-modules/PreToolUse
  * @returns {string[]} absolute paths to .js module files
  */
@@ -31,25 +81,28 @@ module.exports = function loadModules(eventDir) {
 
   // 2. Project-scoped modules: subfolder matching project name
   var projectDir = process.env.CLAUDE_PROJECT_DIR || "";
-  if (!projectDir) return globalFiles;
+  var allFiles = globalFiles;
 
-  var projectName = path.basename(projectDir);
-  if (projectName === "archive") return globalFiles;
-  var projectModDir = path.join(eventDir, projectName);
-  if (!fs.existsSync(projectModDir) || !fs.statSync(projectModDir).isDirectory()) {
-    return globalFiles;
+  if (projectDir) {
+    var projectName = path.basename(projectDir);
+    if (projectName !== "archive") {
+      var projectModDir = path.join(eventDir, projectName);
+      if (fs.existsSync(projectModDir) && fs.statSync(projectModDir).isDirectory()) {
+        try {
+          var projectFiles = fs.readdirSync(projectModDir)
+            .filter(function(f) { return f.endsWith(".js"); })
+            .sort()
+            .map(function(f) { return path.join(projectModDir, f); });
+          allFiles = globalFiles.concat(projectFiles);
+        } catch (e) { /* skip */ }
+      }
+    }
   }
 
-  var projectFiles;
-  try {
-    projectFiles = fs.readdirSync(projectModDir)
-      .filter(function(f) { return f.endsWith(".js"); })
-      .sort()
-      .map(function(f) { return path.join(projectModDir, f); });
-  } catch (e) {
-    projectFiles = [];
-  }
-
-  // Global first, then project-scoped (so project modules can override/extend)
-  return globalFiles.concat(projectFiles);
+  // 3. Validate dependencies — skip modules with missing deps
+  return validateDeps(allFiles);
 };
+
+// Exported for testing
+module.exports.parseRequires = parseRequires;
+module.exports.validateDeps = validateDeps;

--- a/modules/PreToolUse/gsd-gate.js
+++ b/modules/PreToolUse/gsd-gate.js
@@ -1,4 +1,5 @@
 "use strict";
+// requires: enforcement-gate, spec-gate
 // GSD gate: blocks implementation unless the current spec task has a real e2e test
 // as completion criteria. Every task phase must reference a scripts/test/ script.
 // The test is the GSD completion criteria — no manual verification allowed.

--- a/modules/PreToolUse/spec-gate.js
+++ b/modules/PreToolUse/spec-gate.js
@@ -1,4 +1,5 @@
 "use strict";
+// requires: enforcement-gate
 // Spec gate: blocks code edits unless work maps to an unchecked task in tasks.md.
 // If you're doing undocumented work, add it to the spec first.
 // Allows: config, specs, planning, rules, hooks, TODO.md, SESSION_STATE.md

--- a/setup.js
+++ b/setup.js
@@ -1266,7 +1266,28 @@ function healthCheck() {
     }
   }
 
-  // 3. Check settings.json has hook entries
+  // 3. Check module dependencies
+  var loadModules = require("./load-modules");
+  for (var di = 0; di < events.length; di++) {
+    var depEvt = events[di];
+    var depDir = path.join(HOOKS_DIR, "run-modules", depEvt);
+    if (!fs.existsSync(depDir)) continue;
+    var depFiles;
+    try { depFiles = fs.readdirSync(depDir).filter(function(f) { return f.endsWith(".js"); }); } catch(e) { continue; }
+    var depAvailable = {};
+    for (var dj = 0; dj < depFiles.length; dj++) depAvailable[depFiles[dj].replace(/\.js$/, "")] = true;
+    for (var dk = 0; dk < depFiles.length; dk++) {
+      var depPath = path.join(depDir, depFiles[dk]);
+      var deps = loadModules.parseRequires(depPath);
+      for (var dl = 0; dl < deps.length; dl++) {
+        if (!depAvailable[deps[dl]]) {
+          results.push({ check: "dependency", file: depEvt + "/" + depFiles[dk], status: "warning", detail: "requires " + deps[dl] + " (not installed)" });
+        }
+      }
+    }
+  }
+
+  // 4. Check settings.json has hook entries
   if (fs.existsSync(SETTINGS_PATH)) {
     try {
       var settings = JSON.parse(fs.readFileSync(SETTINGS_PATH, "utf-8"));


### PR DESCRIPTION
## Summary
- Modules declare deps via `// requires: mod1, mod2` in first 5 lines
- `load-modules.js` validates deps at load time, skips modules with missing deps (stderr warning)
- `--health` check reports missing dependencies as warnings
- Only valid module-name patterns accepted (prevents false positives on prose `// Requires:` comments)
- Added `requires:` to spec-gate (needs enforcement-gate) and gsd-gate (needs enforcement-gate, spec-gate)

## Test plan
- [x] parseRequires correctly extracts deps from module headers
- [x] validateDeps filters out modules with missing deps
- [x] Prose "Requires:" comments are NOT parsed as deps
- [x] Health check reports dep warnings
- [x] Full test suite: 90/90 pass