### PR TITLE
T076: Update docs, bump version to 1.4.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,11 +12,11 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 - `setup.js` — CLI entry point with extracted command handlers (cmdHelp, cmdUpgrade, cmdUninstall, etc.)
 - `report.js` — HTML report generator (extracted from setup.js for maintainability)
 - `run-*.js` — event runners (one per event: pretooluse, posttooluse, stop, sessionstart, userpromptsubmit)
-- `load-modules.js` — shared module loader (global + project-scoped discovery)
-- `hook-log.js` — centralized logger (appends JSONL per invocation)
-- `run-async.js` — async module executor (Promise detection, 4s timeout)
+- `load-modules.js` — shared module loader (global + project-scoped discovery + dependency validation)
+- `hook-log.js` — centralized logger (appends JSONL per invocation, includes per-module timing)
+- `run-async.js` — async module executor (Promise detection, 4s timeout, timing measurement)
 - `modules/` — distributable module catalog organized by event type
-- `scripts/test/` — test scripts (88 tests across 5 files)
+- `scripts/test/` — test scripts (90 tests across 5 files)
 
 ## Sync Targets (must stay identical)
 1. Repo: this directory
@@ -39,6 +39,7 @@ bash scripts/test/test-module-sync.sh  # 10 sync tests
 - Sync: `module.exports = function(input) { return null; }` — preferred for gates
 - Async: `module.exports = async function(input) { ... }` — 4s timeout per module
 - Return `null` to pass, `{decision: "block", reason: "..."}` to block
+- Dependencies: `// requires: mod1, mod2` in first 5 lines — missing deps = skipped with warning
 - First block wins, remaining modules skipped
 
 ## CLI Commands

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The report shows:
 - **File status** — whether referenced scripts exist (missing files highlighted in red)
 - **Source code** — expandable view of each hook script with line numbers
 - **Block/error stats** — which hooks are actually blocking tool calls (from `hook-log.jsonl`)
+- **Latency chart** — horizontal bar chart of avg/max module execution time
 - **Flow diagram** — visual timeline of hook events from session start to stop
 - **Search + filter** — find hooks by name instantly
 
@@ -100,6 +101,7 @@ Rules:
 - Use `require()` not `import`
 - **Return null to pass**, `{decision: "block", reason: "..."}` to block
 - **Alphabetical order** — prefix with `01-` to control execution order
+- **Dependencies** — add `// requires: mod1, mod2` in first 5 lines; missing deps = module skipped with warning
 - **Never edit settings.json** — runners are already registered, just add module files
 
 ## Event Types
@@ -114,7 +116,7 @@ Rules:
 
 ## Logging
 
-Runners log every module invocation to `~/.claude/hooks/hook-log.jsonl`. Each line records the timestamp, event, module name, result (pass/block/error), and context (tool name, command snippet, project). The log auto-rotates at 10MB. Stats include both current and rotated log files.
+Runners log every module invocation to `~/.claude/hooks/hook-log.jsonl`. Each line records the timestamp, event, module name, result (pass/block/error), execution time (ms), and context (tool name, command snippet, project). The log auto-rotates at 10MB. Stats include both current and rotated log files.
 
 ```bash
 /hook-runner stats             # quick text summary to stdout
@@ -123,7 +125,7 @@ node setup.js --prune 3        # keep only last 3 days
 node setup.js --prune 7 --dry-run  # preview without deleting
 ```
 
-The `--stats` command shows total invocations, block rate, and per-module hit counts — useful for CI or quick terminal checks without opening the HTML report.
+The `--stats` command shows total invocations, block rate, per-module hit counts, and average/max latency per module — useful for CI or quick terminal checks without opening the HTML report.
 
 The setup report (`/hook-runner report`) reads the log and shows hit counts and sample triggers per module.
 
@@ -189,6 +191,7 @@ Full catalog in `modules/` directory:
 | `no-adhoc-commands` | Blocks raw aws/ssh/docker/kubectl, forces scripts/ |
 | `secret-scan-gate` | Blocks git commit if staged diff contains API keys, tokens, or passwords |
 | `no-hardcoded-paths` | Blocks Write/Edit with hardcoded absolute user paths in content |
+| `env-var-check` | Blocks edits if `.env.required` vars are missing (cached per project) |
 | `aws-tagging-gate` | Enforces required tags on AWS resource creation (env-configurable) |
 
 ### UserPromptSubmit (processes user prompts)

--- a/TODO.md
+++ b/TODO.md
@@ -105,12 +105,12 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 - [x] T070: Sync live module fixes back to repo catalog (branch-pr-gate, no-adhoc-commands, load-instructions, auto-continue)
 
 ## Status
-- 70 tasks completed, 0 pending
-- Version: 1.3.0
-- 88 tests passing across 5 test files (16 runner + 7 wizard + 13 async + 42 module + 10 sync)
+- 76 tasks completed, 0 pending
+- Version: 1.4.0
+- 90 tests passing across 5 test files (16 runner + 7 wizard + 13 async + 44 module + 10 sync)
 - CI: GitHub Actions runs all tests on push/PR — badge in README
 - 4 sync targets all identical: repo, live hooks, skill, marketplace
-- 21 modules in catalog (12 PreToolUse, 3 PostToolUse, 1 UserPromptSubmit, 3 SessionStart, 2 Stop)
+- 22 modules in catalog (13 PreToolUse, 3 PostToolUse, 1 UserPromptSubmit, 3 SessionStart, 2 Stop)
 - CLI commands: setup, report, dry-run, health, sync, stats, list, test, upgrade, uninstall, prune, version, help
 
 ## Performance & Features (v1.4.0)
@@ -118,7 +118,8 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 - [x] T072: Add per-module timing to hook-log (measure latency each module adds)
 - [x] T073: Report v3 — timing data visualization, per-module latency chart
 - [x] T074: Module dependency system — `requires:` field in module header, load-modules validates
-- [ ] T075: Module hot-reload — detect changed modules, clear require cache without restarting Claude Code
+- [x] T075: N/A — hot-reload is unnecessary (each hook invocation is a new Node process, require cache is always fresh)
+- [x] T076: Update docs (README, CLAUDE.md, SKILL.md) + version bump to 1.4.0 + marketplace push
 
 ## Moved
 - T026: Moved to chat-export/TODO.md (out of scope for hook-runner)

--- a/setup.js
+++ b/setup.js
@@ -46,7 +46,7 @@ var SCRIPT_DIR = __dirname;
 var REPO_DIR = SCRIPT_DIR;
 
 var HOOK_LOG_PATH = path.join(HOOKS_DIR, "hook-log.jsonl");
-var VERSION = "1.3.0";
+var VERSION = "1.4.0";
 
 // ============================================================
 // 0. Hook Log Stats


### PR DESCRIPTION
## Summary
- Version bump to 1.4.0
- README: added env-var-check module, latency chart, timing in logging, dependencies in module contract
- CLAUDE.md: updated test counts, file descriptions for timing + deps
- TODO.md: updated status (76 tasks, 22 modules, 90 tests)

## Test plan
- [x] Full test suite: 90/90 pass