### PR TITLE
T077: Sync continuous-claude-gate fix from live

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -121,6 +121,9 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 - [x] T075: N/A — hot-reload is unnecessary (each hook invocation is a new Node process, require cache is always fresh)
 - [x] T076: Update docs (README, CLAUDE.md, SKILL.md) + version bump to 1.4.0 + marketplace push
 
+## Sync & Code Review
+- [x] T077: Sync live module fixes back to repo (continuous-claude-gate SKIP_SPEC_GATE fix)
+
 ## Moved
 - T026: Moved to chat-export/TODO.md (out of scope for hook-runner)
 

--- a/modules/PreToolUse/continuous-claude-gate.js
+++ b/modules/PreToolUse/continuous-claude-gate.js
@@ -16,6 +16,9 @@ var fs = require("fs");
 var path = require("path");
 
 module.exports = function(input) {
+  // API-dispatched tasks skip this gate (workers implement directly)
+  if (process.env.SKIP_SPEC_GATE === "1" || process.env.CONTINUOUS_CLAUDE === "1") return null;
+
   var tool = input.tool_name;
   if (tool !== "Edit" && tool !== "Write") return null;
 


### PR DESCRIPTION
## Summary
- Synced SKIP_SPEC_GATE/CONTINUOUS_CLAUDE early return from live to repo catalog
- Live version had this fix since T070 but repo copy was stale

## Test plan
- [x] 90/90 tests pass