### PR TITLE
T001-T006: Fix VBS escaping, remove exemption

### DIFF
--- a/run-modules/PreToolUse/branch-pr-gate.js
+++ b/run-modules/PreToolUse/branch-pr-gate.js
@@ -120,17 +120,29 @@ module.exports = function(input) {
     if (!targetFile) return null;
     var norm = targetFile.replace(/\\/g, "/");
 
-    // Allow bootstrap/config/spec/planning/test files on any branch
-    var allowPatterns = [
-      /TODO\.md$/, /SESSION_STATE\.md$/, /CLAUDE\.md$/, /README\.md$/,
-      /\.claude\//, /\/specs\//, /\.planning\//, /\.specify\//,
-      /\.github\//, /\/hooks\//, /\/rules\//,
-      /\.gitignore$/, /scripts\/test\//, /\.json$/,
-    ];
+    // Allow bootstrap/config/spec/planning/test files on any branch.
+    // EXCEPTION: when ~/.claude IS the project, JS/SH code files are NOT exempt —
+    // they must go through branches+PRs like any other project's code.
     var home = (process.env.HOME || process.env.USERPROFILE || "").replace(/\\/g, "/");
-    if (home && norm.startsWith(home + "/.claude/")) return null;
-    for (var i = 0; i < allowPatterns.length; i++) {
-      if (allowPatterns[i].test(norm)) return null;
+    var projectDir = (process.env.CLAUDE_PROJECT_DIR || "").replace(/\\/g, "/");
+    var isClaudeProject = projectDir && (
+      projectDir === home + "/.claude" ||
+      projectDir.replace(/\/+$/, "") === home + "/.claude"
+    );
+
+    // When ~/.claude is the project, JS/SH files are code, not config
+    if (isClaudeProject && /\.(js|sh|ts|py)$/.test(norm)) {
+      // Fall through to branch check — these are code files
+    } else {
+      var allowPatterns = [
+        /TODO\.md$/, /SESSION_STATE\.md$/, /CLAUDE\.md$/, /README\.md$/,
+        /\.claude\//, /\/specs\//, /\.planning\//, /\.specify\//,
+        /\.github\//, /\/hooks\//, /\/rules\//,
+        /\.gitignore$/, /scripts\/test\//, /\.json$/,
+      ];
+      for (var i = 0; i < allowPatterns.length; i++) {
+        if (allowPatterns[i].test(norm)) return null;
+      }
     }
 
     var branch = getBranch();

--- a/run-modules/PreToolUse/no-focus-steal.js
+++ b/run-modules/PreToolUse/no-focus-steal.js
@@ -9,8 +9,10 @@ module.exports = function(input) {
 
   // Detect background process spawning patterns that will steal focus on Windows
   // Only check commands that spawn detached/background processes
+  // Note: & (background) vs && (chaining) — only match trailing & not &&
+  var hasBackground = /[^&]&\s*$/.test(cmd) || /^&\s*$/.test(cmd);
   if (cmd.indexOf("run_in_background") === -1 &&
-      cmd.indexOf("&") === -1 &&
+      !hasBackground &&
       cmd.indexOf("nohup") === -1 &&
       cmd.indexOf("start ") === -1) return null;
 

--- a/run-modules/SessionStart/load-lessons.js
+++ b/run-modules/SessionStart/load-lessons.js
@@ -7,33 +7,67 @@ var fs = require("fs");
 var path = require("path");
 var os = require("os");
 
-var LESSONS_FILE = path.join(os.homedir(), ".claude", "hooks", "self-analysis-lessons.jsonl");
+var CLAUDE_DIR = path.join(os.homedir(), ".claude");
+var LESSONS_FILE = path.join(CLAUDE_DIR, "hooks", "self-analysis-lessons.jsonl");
+var ERROR_LOG = path.join(CLAUDE_DIR, "self-analysis-errors.log");
+var ANALYSIS_LOG = path.join(CLAUDE_DIR, "self-analysis.log");
 var MAX_LESSONS = 10; // inject the 10 most recent
 
-module.exports = function(input) {
-  try {
-    if (!fs.existsSync(LESSONS_FILE)) return null;
-    var content = fs.readFileSync(LESSONS_FILE, "utf-8").trim();
-    if (!content) return null;
-
-    var lines = content.split("\n").filter(function(l) { return l.trim(); });
-    var recent = lines.slice(-MAX_LESSONS);
-
-    var lessons = recent.map(function(line) {
-      try {
-        var obj = JSON.parse(line);
-        return obj.lesson || "";
-      } catch(e) {
-        return "";
+function checkBgErrors() {
+  // Surface background script errors that the user can't see
+  var msgs = [];
+  [ERROR_LOG, ANALYSIS_LOG].forEach(function(logFile) {
+    try {
+      if (!fs.existsSync(logFile)) return;
+      var stat = fs.statSync(logFile);
+      // Only report if modified in last 24 hours
+      if (Date.now() - stat.mtimeMs > 86400000) return;
+      var lines = fs.readFileSync(logFile, "utf-8").trim().split("\n");
+      var errors = lines.filter(function(l) {
+        return /error|fail|stderr/i.test(l);
+      }).slice(-3);
+      if (errors.length > 0) {
+        msgs.push("Background script issues in " + path.basename(logFile) + ":\n" +
+          errors.join("\n"));
       }
-    }).filter(function(l) { return l; });
+    } catch(e) {}
+  });
+  return msgs.length > 0 ? msgs.join("\n\n") : "";
+}
 
-    if (lessons.length === 0) return null;
+module.exports = function(input) {
+  var parts = [];
+  try {
+    // Check for background script errors
+    var errors = checkBgErrors();
+    if (errors) {
+      parts.push("BACKGROUND SCRIPT ERRORS (auto-detected):\n" + errors +
+        "\nInvestigate and fix these before they recur.");
+    }
 
-    return "SELF-ANALYSIS LESSONS (from past interrupt reflections):\n" +
-      lessons.join("\n") +
-      "\nApply these lessons. If you catch yourself repeating a pattern, stop and correct.";
-  } catch(e) {
-    return null;
-  }
+    // Load lessons
+    if (fs.existsSync(LESSONS_FILE)) {
+      var content = fs.readFileSync(LESSONS_FILE, "utf-8").trim();
+      if (content) {
+        var lines = content.split("\n").filter(function(l) { return l.trim(); });
+        var recent = lines.slice(-MAX_LESSONS);
+        var lessons = recent.map(function(line) {
+          try {
+            var obj = JSON.parse(line);
+            return obj.lesson || "";
+          } catch(e) {
+            return "";
+          }
+        }).filter(function(l) { return l; });
+
+        if (lessons.length > 0) {
+          parts.push("SELF-ANALYSIS LESSONS (from past interrupt reflections):\n" +
+            lessons.join("\n") +
+            "\nApply these lessons. If you catch yourself repeating a pattern, stop and correct.");
+        }
+      }
+    }
+  } catch(e) {}
+
+  return parts.length > 0 ? parts.join("\n\n") : null;
 };

--- a/run-modules/UserPromptSubmit/interrupt-detector.js
+++ b/run-modules/UserPromptSubmit/interrupt-detector.js
@@ -79,20 +79,29 @@ function spawnAnalysis(userPrompt) {
   }
 
   try {
+    // Write args to a temp JSON file — avoids quote escaping nightmares in VBS/cmd.
+    // The self-analyze-loop.js reads this file instead of process.argv.
+    var argsFile = path.join(os.tmpdir(), "claude-analyze-args-" + Date.now() + ".json");
+    fs.writeFileSync(argsFile, JSON.stringify({
+      projectDir: projectDir,
+      userCorrection: userPrompt.substring(0, 500)
+    }));
+
     if (process.platform === "win32") {
       // Use wscript.exe with a VBS wrapper to hide the window completely.
       // node.exe + detached + windowsHide still flashes a console.
       var vbs = path.join(os.tmpdir(), "claude-analyze.vbs");
-      var cmd = 'node "' + scriptPath.replace(/\//g, "\\") + '" "' +
-        projectDir.replace(/\//g, "\\") + '" "' +
-        userPrompt.substring(0, 300).replace(/"/g, '""') + '"';
+      var nodePath = scriptPath.replace(/\//g, "\\");
+      var argsPath = argsFile.replace(/\//g, "\\");
+      // Redirect stderr to log so VBS errors don't pop up silently
+      var errLog = path.join(home, ".claude/self-analysis-errors.log").replace(/\//g, "\\");
       fs.writeFileSync(vbs,
         'Set ws = CreateObject("WScript.Shell")\n' +
-        'ws.Run "cmd /c ' + cmd.replace(/"/g, '""') + '", 0, False\n');
+        'ws.Run "cmd /c node ""' + nodePath + '"" ""' + argsPath + '"" 2>>""' + errLog + '""", 0, False\n');
       cp.spawn("wscript.exe", [vbs], { detached: true, stdio: "ignore" }).unref();
     } else {
       cp.spawn("node", [
-        scriptPath, projectDir, userPrompt.substring(0, 500)
+        scriptPath, argsFile
       ], { detached: true, stdio: "ignore" }).unref();
     }
   } catch (e) {


### PR DESCRIPTION
## Summary
- Fix VBS quote escaping: pass args via temp JSON file instead of command line
- Add stderr redirect to error log for background scripts
- Surface background script errors in SessionStart load-lessons module
- Remove blanket `~/.claude/` exemption from branch-pr-gate: JS/SH/TS/PY files in the claude-config project now require task branches like any other project
- Fix no-focus-steal gate false positive: distinguish `&` (background) from `&&` (chaining)

## Test plan
- [x] `bash scripts/test/test-bg-error-detection.sh` — passes
- [x] `bash scripts/test/test-branch-gate-claude-project.sh` — all 5 scenarios pass
- [x] VBS output string verified via node eval — correct escaping