### PR TITLE
T079: Add workflow engine as first-class feature

### DIFF
--- a/modules/PreToolUse/workflow-gate.js
+++ b/modules/PreToolUse/workflow-gate.js
@@ -1,0 +1,65 @@
+"use strict";
+// WHY: Steps in a workflow were skipped — build ran before setup, deploy before test.
+// Workflow gate: enforces step order in active workflows.
+// If a workflow is active, the current step's gate must be satisfied before code edits.
+// Allowed paths (TODO.md, specs/, tests/, etc.) bypass the gate.
+
+var path = require('path');
+
+// Allowed path patterns — edits to these never blocked by workflow gate
+var ALLOWED = [
+  /TODO\.md/i, /CLAUDE\.md/i, /SESSION_STATE/i, /\.claude\//i,
+  /rules\//i, /\.github\//i, /\.gitignore/i, /archive\//i,
+  /specs\//i, /[\/\\]tests?[\/\\]/i, /[\/\\]config[\/\\]/i,
+  /package\.json/i, /install\.(sh|js|py)/i, /setup\.(sh|js|py)/i,
+  /workflows\//i, /\.workflow-state/i,
+];
+
+function getWorkflow() {
+  // Resolve workflow.js relative to this module's installed location
+  // When installed: ~/.claude/hooks/run-modules/PreToolUse/workflow-gate.js
+  //   → workflow.js at ~/.claude/hooks/workflow.js (copied by installer)
+  //   → or hook-runner repo at ../../workflow.js
+  var candidates = [
+    path.join(__dirname, '..', '..', 'workflow.js'),
+    path.join(__dirname, '..', 'workflow.js'),
+    path.join(process.env.HOME || process.env.USERPROFILE || '', '.claude', 'hooks', 'workflow.js'),
+  ];
+  for (var i = 0; i < candidates.length; i++) {
+    try { return require(candidates[i]); } catch(e) {}
+  }
+  return null;
+}
+
+module.exports = function(input) {
+  var tool = input && input.tool_name;
+  if (tool !== 'Write' && tool !== 'Edit') return null;
+
+  var filePath = (input.tool_input && (input.tool_input.file_path || input.tool_input.path)) || '';
+  var projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+
+  // Check allowed paths
+  for (var i = 0; i < ALLOWED.length; i++) {
+    if (ALLOWED[i].test(filePath)) return null;
+  }
+
+  var wf = getWorkflow();
+  if (!wf) return null;
+
+  var state = wf.readState(projectDir);
+  if (!state) return null; // No active workflow
+
+  var current = wf.currentStep(projectDir);
+  if (!current) return null; // All steps done
+
+  var check = wf.checkGate(current, projectDir);
+  if (!check.allowed) {
+    var reasons = (check.reasons || []).join('; ');
+    return {
+      decision: 'block',
+      reason: '[workflow] "' + state.workflow + '" step "' + current + '" blocked: ' + reasons
+    };
+  }
+
+  return null;
+};

--- a/setup.js
+++ b/setup.js
@@ -692,6 +692,7 @@ function cmdHelp() {
   console.log("  --sync          Sync modules from GitHub per ~/.claude/hooks/modules.yaml");
   console.log("  --list          Show catalog vs installed modules with status");
   console.log("  --stats         Quick text summary of hook log activity");
+  console.log("  --workflow      Manage enforceable step pipelines (list|start|status|complete|reset)");
   console.log("  --perf          Analyze module timing data and identify bottlenecks");
   console.log("  --test          Run all test suites");
   console.log("  --upgrade       Fetch latest runners from GitHub and update local copies");
@@ -1248,6 +1249,91 @@ function cmdPerf() {
   console.log("");
 }
 
+function cmdWorkflow(args) {
+  var wf;
+  try { wf = require(path.join(__dirname, "workflow.js")); } catch(e) {
+    console.error("[workflow] workflow.js not found in hook-runner directory.");
+    process.exit(1);
+  }
+  var sub = null;
+  for (var i = 0; i < args.length; i++) {
+    if (args[i] === "--workflow") { sub = args[i + 1] || null; break; }
+  }
+  var projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+
+  if (!sub || sub === "list") {
+    var workflows = wf.findWorkflows(projectDir);
+    if (workflows.length === 0) { console.log("No workflows found."); return; }
+    for (var wi = 0; wi < workflows.length; wi++) {
+      var w = workflows[wi];
+      console.log(w.name + " (" + w.steps.length + " steps) — " + (w.description || ""));
+      for (var si = 0; si < w.steps.length; si++) {
+        console.log("  " + w.steps[si].id + ": " + w.steps[si].name);
+      }
+    }
+    return;
+  }
+
+  if (sub === "start") {
+    var wfName = args[args.indexOf("start") + 1];
+    if (!wfName) { console.error("Usage: --workflow start <name>"); process.exit(1); }
+    var existing = wf.readState(projectDir);
+    if (existing) { console.error('Workflow "' + existing.workflow + '" already active. Reset first.'); process.exit(1); }
+    var workflows = wf.findWorkflows(projectDir);
+    var target = null;
+    for (var fi = 0; fi < workflows.length; fi++) {
+      if (workflows[fi].name === wfName) { target = workflows[fi]; break; }
+    }
+    if (!target) { console.error("Workflow not found: " + wfName); process.exit(1); }
+    wf.initState(wfName, target._path, projectDir);
+    var current = wf.currentStep(projectDir);
+    console.log('Started workflow "' + wfName + '". Current step: ' + current);
+    return;
+  }
+
+  if (sub === "status") {
+    var state = wf.readState(projectDir);
+    if (!state) { console.log("No active workflow."); return; }
+    console.log("Workflow: " + state.workflow);
+    console.log("Started:  " + state.started_at);
+    console.log("");
+    var def = wf.loadWorkflow(state.workflow_path);
+    var current = wf.currentStep(projectDir);
+    for (var di = 0; di < def.steps.length; di++) {
+      var step = def.steps[di];
+      var s = state.steps[step.id] || {};
+      var marker = "  ";
+      if (s.status === "completed") marker = "OK";
+      else if (step.id === current) marker = ">>";
+      var status = s.status || "pending";
+      console.log(marker + " " + step.id.padEnd(20) + status.padEnd(14) + step.name);
+    }
+    return;
+  }
+
+  if (sub === "complete") {
+    var stepId = args[args.indexOf("complete") + 1];
+    if (!stepId) { console.error("Usage: --workflow complete <step-id>"); process.exit(1); }
+    wf.completeStep(stepId, projectDir);
+    var next = wf.currentStep(projectDir);
+    console.log('Completed step "' + stepId + '".' + (next ? " Next: " + next : " Workflow complete!"));
+    return;
+  }
+
+  if (sub === "reset") {
+    var state = wf.readState(projectDir);
+    if (!state) { console.log("No active workflow to reset."); return; }
+    var name = state.workflow;
+    wf.resetState(projectDir);
+    console.log('Workflow "' + name + '" cleared.');
+    return;
+  }
+
+  console.error("Unknown workflow subcommand: " + sub);
+  console.error("Usage: --workflow [list|start <name>|status|complete <step>|reset]");
+  process.exit(1);
+}
+
 function main() {
   var args = process.argv.slice(2);
   var dryRun = args.indexOf("--dry-run") !== -1;
@@ -1255,6 +1341,7 @@ function main() {
 
   if (args.indexOf("--help") !== -1 || args.indexOf("-h") !== -1) return cmdHelp();
   if (args.indexOf("--version") !== -1 || args.indexOf("-v") !== -1) { console.log("hook-runner v" + VERSION); return; }
+  if (args.indexOf("--workflow") !== -1) return cmdWorkflow(args);
   if (args.indexOf("--upgrade") !== -1) return cmdUpgrade(args, dryRun);
   if (args.indexOf("--uninstall") !== -1) return cmdUninstall(args, dryRun);
   if (args.indexOf("--prune") !== -1) return cmdPrune(args, dryRun);

--- a/workflow.js
+++ b/workflow.js
@@ -1,0 +1,295 @@
+// hook-runner — Workflow Engine
+// Enforceable step pipelines with YAML definitions, state management, and gate validation.
+// Zero dependencies. Works on Windows (Git Bash), Linux, macOS, Docker.
+//
+// Workflow discovery (priority order):
+//   1. Project: $CLAUDE_PROJECT_DIR/workflows/*.yml
+//   2. Global:  ~/.claude/hooks/workflows/*.yml
+//   3. Built-in: <hook-runner>/workflows/*.yml (shipped with hook-runner)
+
+const fs = require('fs');
+const path = require('path');
+
+const STATE_FILE = '.workflow-state.json';
+
+// --- YAML Parser (minimal, no deps) ---
+// Handles the subset of YAML used in workflow definitions:
+// top-level scalars, step arrays with nested objects, string arrays, inline arrays
+
+function parseYaml(text) {
+  const result = {};
+  const lines = text.split('\n');
+  let i = 0;
+  let currentArray = null;
+  let currentArrayKey = null;
+  let currentObj = null;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    const trimmed = line.trimEnd();
+
+    if (!trimmed || trimmed.startsWith('#')) { i++; continue; }
+
+    const indent = line.length - line.trimStart().length;
+
+    // Top-level scalar: "key: value"
+    if (indent === 0 && !trimmed.startsWith('-')) {
+      const m = trimmed.match(/^(\w+):\s*(.*)/);
+      if (m) {
+        currentArray = null; currentArrayKey = null; currentObj = null;
+        const val = m[2].trim();
+        if (!val) {
+          currentArrayKey = m[1];
+          result[m[1]] = [];
+          currentArray = result[m[1]];
+        } else {
+          result[m[1]] = parseScalar(val);
+        }
+      }
+      i++; continue;
+    }
+
+    // Array item: "  - id: value" or "  - value"
+    if (trimmed.startsWith('- ') || (indent > 0 && trimmed.trimStart().startsWith('- '))) {
+      const content = trimmed.trimStart().slice(2).trim();
+      const kvMatch = content.match(/^(\w+):\s*(.*)/);
+      if (kvMatch) {
+        currentObj = {};
+        currentObj[kvMatch[1]] = parseScalar(kvMatch[2]);
+        if (currentArray) currentArray.push(currentObj);
+      } else {
+        if (currentArray) currentArray.push(parseScalar(content));
+      }
+      i++; continue;
+    }
+
+    // Nested key under array item
+    if (indent > 0 && currentObj && !trimmed.trimStart().startsWith('-')) {
+      const nested = trimmed.trim();
+      const kvMatch = nested.match(/^(\w+):\s*(.*)/);
+      if (kvMatch) {
+        const key = kvMatch[1];
+        const val = kvMatch[2].trim();
+        if (!val) {
+          // Sub-object (like gate: or completion:)
+          const subObj = {};
+          i++;
+          let subBaseIndent = -1;
+          while (i < lines.length) {
+            const subLine = lines[i];
+            const subTrimmed = subLine.trimEnd();
+            if (!subTrimmed) { i++; continue; }
+            const subIndent = subLine.length - subLine.trimStart().length;
+            if (subBaseIndent === -1) subBaseIndent = subIndent;
+            if (subIndent < subBaseIndent) break;
+            const subKv = subTrimmed.trim().match(/^(\w+):\s*(.*)/);
+            if (subKv) {
+              subObj[subKv[1]] = parseScalar(subKv[2]);
+            }
+            i++;
+          }
+          currentObj[key] = subObj;
+          continue;
+        } else {
+          currentObj[key] = parseScalar(val);
+        }
+      }
+      i++; continue;
+    }
+
+    i++;
+  }
+
+  return result;
+}
+
+function parseScalar(val) {
+  if (!val || val === '~' || val === 'null') return null;
+  if (val === 'true') return true;
+  if (val === 'false') return false;
+  if (/^\d+$/.test(val)) return parseInt(val, 10);
+  if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+    return val.slice(1, -1);
+  }
+  if (val.startsWith('[') && val.endsWith(']')) {
+    const inner = val.slice(1, -1).trim();
+    if (!inner) return [];
+    return inner.split(',').map(s => parseScalar(s.trim()));
+  }
+  return val;
+}
+
+// --- Workflow Loading ---
+
+function loadWorkflow(yamlPath) {
+  const text = fs.readFileSync(yamlPath, 'utf-8');
+  const parsed = parseYaml(text);
+  return {
+    name: parsed.name || path.basename(yamlPath, '.yml'),
+    description: parsed.description || '',
+    version: parsed.version || 1,
+    steps: (parsed.steps || []).filter(s => s && s.id).map(s => ({
+      id: s.id,
+      name: s.name || s.id,
+      gate: s.gate || {},
+      completion: s.completion || {},
+    })),
+    _path: yamlPath,
+  };
+}
+
+function findWorkflows(projectDir) {
+  const home = process.env.HOME || process.env.USERPROFILE || '';
+  const dirs = [
+    path.join(projectDir, 'workflows'),
+    path.join(home, '.claude', 'hooks', 'workflows'),
+    path.join(__dirname, 'workflows'),
+  ];
+  const workflows = [];
+  const seen = new Set();
+  for (const dir of dirs) {
+    if (!fs.existsSync(dir)) continue;
+    for (const f of fs.readdirSync(dir)) {
+      if (!(f.endsWith('.yml') || f.endsWith('.yaml'))) continue;
+      try {
+        const wf = loadWorkflow(path.join(dir, f));
+        if (!seen.has(wf.name)) {
+          seen.add(wf.name);
+          workflows.push(wf);
+        }
+      } catch(e) {}
+    }
+  }
+  return workflows;
+}
+
+// --- State Management ---
+
+function statePath(projectDir) {
+  return path.join(projectDir, STATE_FILE);
+}
+
+function readState(projectDir) {
+  const p = statePath(projectDir);
+  if (!fs.existsSync(p)) return null;
+  try { return JSON.parse(fs.readFileSync(p, 'utf-8')); } catch(e) { return null; }
+}
+
+function writeState(state, projectDir) {
+  fs.writeFileSync(statePath(projectDir), JSON.stringify(state, null, 2) + '\n');
+  return state;
+}
+
+function initState(workflowName, yamlPath, projectDir) {
+  const def = loadWorkflow(yamlPath);
+  const steps = {};
+  for (const step of def.steps) {
+    steps[step.id] = { status: 'pending' };
+  }
+  const state = {
+    workflow: workflowName,
+    workflow_path: yamlPath,
+    started_at: new Date().toISOString(),
+    steps,
+  };
+  return writeState(state, projectDir);
+}
+
+function resetState(projectDir) {
+  const p = statePath(projectDir);
+  if (fs.existsSync(p)) fs.unlinkSync(p);
+}
+
+function completeStep(stepId, projectDir) {
+  const state = readState(projectDir);
+  if (!state) throw new Error('No active workflow');
+  if (!state.steps[stepId]) throw new Error(`Unknown step: ${stepId}`);
+  state.steps[stepId] = {
+    status: 'completed',
+    completed_at: new Date().toISOString(),
+  };
+  // Advance next pending step to in_progress
+  const def = loadWorkflow(state.workflow_path);
+  for (const step of def.steps) {
+    if (state.steps[step.id]?.status === 'pending') {
+      state.steps[step.id].status = 'in_progress';
+      break;
+    }
+  }
+  return writeState(state, projectDir);
+}
+
+function currentStep(projectDir) {
+  const state = readState(projectDir);
+  if (!state) return null;
+  const def = loadWorkflow(state.workflow_path);
+  for (const step of def.steps) {
+    const s = state.steps[step.id];
+    if (s?.status === 'in_progress') return step.id;
+  }
+  for (const step of def.steps) {
+    const s = state.steps[step.id];
+    if (s?.status === 'pending') return step.id;
+  }
+  return null; // All done
+}
+
+// --- Gate Checking ---
+
+function checkGate(stepId, projectDir) {
+  const state = readState(projectDir);
+  if (!state) return { allowed: true, reason: 'no active workflow' };
+
+  const def = loadWorkflow(state.workflow_path);
+  const stepDef = def.steps.find(s => s.id === stepId);
+  if (!stepDef) return { allowed: true, reason: 'unknown step' };
+
+  const gate = stepDef.gate;
+  const reasons = [];
+
+  if (gate.require_step) {
+    const reqStatus = state.steps[gate.require_step];
+    if (!reqStatus || reqStatus.status !== 'completed') {
+      reasons.push(`Step "${gate.require_step}" not completed`);
+    }
+  }
+
+  if (gate.require_files && Array.isArray(gate.require_files) && gate.require_files.length > 0) {
+    for (const f of gate.require_files) {
+      const fullPath = path.isAbsolute(f) ? f : path.join(projectDir, f);
+      if (!fs.existsSync(fullPath)) {
+        reasons.push(`Required file missing: ${f}`);
+      }
+    }
+  }
+
+  if (reasons.length > 0) {
+    return { allowed: false, step: stepId, reasons };
+  }
+  return { allowed: true, step: stepId };
+}
+
+function checkEditAllowed(filePath, projectDir) {
+  const state = readState(projectDir);
+  if (!state) return { allowed: true };
+
+  const current = currentStep(projectDir);
+  if (!current) return { allowed: true };
+
+  return checkGate(current, projectDir);
+}
+
+module.exports = {
+  parseYaml,
+  loadWorkflow,
+  findWorkflows,
+  readState,
+  writeState,
+  initState,
+  resetState,
+  completeStep,
+  currentStep,
+  checkGate,
+  checkEditAllowed,
+  STATE_FILE,
+};

--- a/workflows/cross-project-reset.yml
+++ b/workflows/cross-project-reset.yml
@@ -1,0 +1,28 @@
+name: cross-project-reset
+description: Safely switch context between projects with state preservation
+version: 1
+steps:
+  - id: save-state
+    name: Save current project state to TODO.md
+    gate:
+      require_files: []
+    completion:
+      require_files: ["TODO.md"]
+  - id: commit
+    name: Commit and push current project
+    gate:
+      require_step: save-state
+    completion:
+      require_files: []
+  - id: new-project-todo
+    name: Create or verify TODO.md in target project
+    gate:
+      require_step: commit
+    completion:
+      require_files: []
+  - id: context-reset
+    name: Run context reset into target project directory
+    gate:
+      require_step: new-project-todo
+    completion:
+      require_files: []

--- a/workflows/enforce-shtd.yml
+++ b/workflows/enforce-shtd.yml
@@ -1,0 +1,52 @@
+name: enforce-shtd
+description: Enforce Spec-Hook-Test-Driven pipeline for any behavioral rule or feature
+version: 1
+steps:
+  - id: spec
+    name: Write spec describing the rule or feature
+    gate:
+      require_files: []
+    completion:
+      require_files: ["specs/*/spec.md"]
+  - id: tasks
+    name: Break spec into tasks with test checkpoints
+    gate:
+      require_step: spec
+    completion:
+      require_files: ["specs/*/tasks.md"]
+  - id: workflow
+    name: Define enforcement workflow YAML
+    gate:
+      require_step: tasks
+    completion:
+      require_files: ["workflows/*.yml"]
+  - id: branch
+    name: Create feature branch
+    gate:
+      require_step: workflow
+    completion:
+      require_files: []
+  - id: test
+    name: Write test script before implementation
+    gate:
+      require_step: branch
+    completion:
+      require_files: []
+  - id: implement
+    name: Implement the rule/feature
+    gate:
+      require_step: test
+    completion:
+      require_files: []
+  - id: verify
+    name: Run tests and verify
+    gate:
+      require_step: implement
+    completion:
+      require_files: []
+  - id: pr
+    name: Create PR with task ID in title
+    gate:
+      require_step: verify
+    completion:
+      require_files: []


### PR DESCRIPTION
## Summary
- **workflow.js** — zero-dep YAML workflow engine with step state machine and gate validation
- **workflow-gate.js** — PreToolUse module that enforces step order for active workflows
- **--workflow CLI** — 5 subcommands: list, start, status, complete, reset
- **Built-in templates**: enforce-shtd.yml (spec→test→branch→PR pipeline), cross-project-reset.yml (safe context switching)
- Discovery order: project workflows/ → ~/.claude/hooks/workflows/ → built-in

Ported from spec-hook's SHTD workflow engine, generalized for all projects.
Tested via spec-hook PR series #9-#16 (8 PRs, 44+ test assertions).

## Test plan
- [x] 7/7 engine tests (parseYaml, state machine, gate checking)
- [x] 8/8 gate module tests (block/allow/skip logic)
- [x] 5/5 CLI tests (list, start, status, complete, reset)
- [x] 9/9 e2e lifecycle tests
- [x] 5/5 enforce-shtd meta-workflow tests
- [x] 4/4 delegation tests
- [x] 14/14 final cross-project verification