### PR TITLE
T080: Add --export command for shareable module config

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -105,13 +105,12 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 - [x] T070: Sync live module fixes back to repo catalog (branch-pr-gate, no-adhoc-commands, load-instructions, auto-continue)
 
 ## Status
-- 76 tasks completed, 0 pending
+- 79 tasks completed, 8 pending (T080-T087)
 - Version: 1.4.0
-- 90 tests passing across 5 test files (16 runner + 7 wizard + 13 async + 44 module + 10 sync)
+- 92 tests passing across 5 test files
 - CI: GitHub Actions runs all tests on push/PR — badge in README
-- 4 sync targets all identical: repo, live hooks, skill, marketplace
-- 22 modules in catalog (13 PreToolUse, 3 PostToolUse, 1 UserPromptSubmit, 3 SessionStart, 2 Stop)
-- CLI commands: setup, report, dry-run, health, sync, stats, list, test, upgrade, uninstall, prune, version, help
+- Workflow engine: workflow.js + workflow-gate.js + 2 built-in templates
+- CLI commands: setup, report, dry-run, health, sync, stats, list, test, upgrade, uninstall, prune, version, help, workflow, perf
 
 ## Performance & Features (v1.4.0)
 - [x] T071: Add `env-var-check` PreToolUse module (blocks if required project env vars missing)
@@ -126,7 +125,20 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 
 ## Performance & Polish
 - [x] T078: Add --perf command (analyze timing data, identify slow modules, estimate total hook overhead)
-- [ ] T079: Add --export command (export module config as shareable YAML bundle)
+- [x] T079: Add workflow engine as first-class feature (workflow.js, workflow-gate.js, --workflow CLI, built-in templates)
+
+## Workflow System (T080+)
+
+WHY: Currently ~30 run-modules exist with no way to see the big picture — which relate to each other, which are obsolete, what rules they replaced. Workflows are groupings of modules that can be toggled on/off.
+
+- [x] T080: Add --export command (export module config as shareable YAML bundle)
+- [ ] T081: Hook runner checks workflow enabled state before running a module (module header: `// WORKFLOW: workflow-name`)
+- [ ] T082: Create `shtd.yml` workflow manifest — groups spec-gate, gsd-gate, branch-pr-gate, remote-tracking-gate
+- [ ] T083: Create `no-local-docker.yml` workflow + block-local-docker module
+- [ ] T084: Create `messaging-safety.yml` workflow + existing messaging guard modules
+- [ ] T085: Sync workflow.js, workflow-gate.js, workflows/ to live hooks
+- [ ] T086: Tests for workflow engine (YAML parsing, state management, gate checking)
+- [ ] T087: Update README, CLAUDE.md, SKILL.md with workflow docs + version bump
 
 ## Moved
 - T026: Moved to chat-export/TODO.md (out of scope for hook-runner)

--- a/setup.js
+++ b/setup.js
@@ -693,6 +693,7 @@ function cmdHelp() {
   console.log("  --list          Show catalog vs installed modules with status");
   console.log("  --stats         Quick text summary of hook log activity");
   console.log("  --workflow      Manage enforceable step pipelines (list|start|status|complete|reset)");
+  console.log("  --export [file] Export installed modules as shareable YAML (default: modules-export.yaml)");
   console.log("  --perf          Analyze module timing data and identify bottlenecks");
   console.log("  --test          Run all test suites");
   console.log("  --upgrade       Fetch latest runners from GitHub and update local copies");
@@ -1249,6 +1250,86 @@ function cmdPerf() {
   console.log("");
 }
 
+function cmdExport(args) {
+  var outFile = null;
+  for (var i = 0; i < args.length; i++) {
+    if (args[i] === "--export" && args[i + 1] && !args[i + 1].startsWith("--")) {
+      outFile = args[i + 1]; break;
+    }
+  }
+  if (!outFile) outFile = "modules-export.yaml";
+
+  var EVENTS = ["PreToolUse", "PostToolUse", "UserPromptSubmit", "Stop", "SessionStart"];
+  var modulesDir = path.join(HOOKS_DIR, "run-modules");
+  var lines = [];
+  lines.push("# hook-runner module configuration (exported " + new Date().toISOString().slice(0, 10) + ")");
+  lines.push("# Import: copy to ~/.claude/hooks/modules.yaml then run: node setup.js --sync");
+  lines.push("");
+  lines.push("source: grobomo/hook-runner");
+  lines.push("branch: main");
+  lines.push("");
+  lines.push("modules:");
+
+  var projectModules = {};
+
+  for (var e = 0; e < EVENTS.length; e++) {
+    var evt = EVENTS[e];
+    var evtDir = path.join(modulesDir, evt);
+    if (!fs.existsSync(evtDir)) continue;
+
+    var globalMods = [];
+    var entries = fs.readdirSync(evtDir);
+    entries.sort();
+    for (var f = 0; f < entries.length; f++) {
+      var entry = entries[f];
+      var full = path.join(evtDir, entry);
+      if (entry.endsWith(".js") && fs.statSync(full).isFile()) {
+        globalMods.push(entry.replace(/\.js$/, ""));
+      } else if (fs.statSync(full).isDirectory() && entry !== "archive") {
+        // Project-scoped modules
+        var projName = entry;
+        if (!projectModules[projName]) projectModules[projName] = {};
+        if (!projectModules[projName][evt]) projectModules[projName][evt] = [];
+        var projFiles = fs.readdirSync(full).filter(function(pf) { return pf.endsWith(".js"); }).sort();
+        for (var pf = 0; pf < projFiles.length; pf++) {
+          projectModules[projName][evt].push(projFiles[pf].replace(/\.js$/, ""));
+        }
+      }
+    }
+
+    if (globalMods.length > 0) {
+      lines.push("  " + evt + ":");
+      for (var g = 0; g < globalMods.length; g++) {
+        lines.push("    - " + globalMods[g]);
+      }
+    }
+  }
+
+  // Project-scoped modules
+  var projNames = Object.keys(projectModules).sort();
+  if (projNames.length > 0) {
+    lines.push("");
+    lines.push("project_modules:");
+    for (var p = 0; p < projNames.length; p++) {
+      lines.push("  " + projNames[p] + ":");
+      var projEvts = Object.keys(projectModules[projNames[p]]).sort();
+      for (var pe = 0; pe < projEvts.length; pe++) {
+        lines.push("    " + projEvts[pe] + ":");
+        var mods = projectModules[projNames[p]][projEvts[pe]];
+        for (var m = 0; m < mods.length; m++) {
+          lines.push("      - " + mods[m]);
+        }
+      }
+    }
+  }
+
+  lines.push("");
+  var content = lines.join("\n");
+  fs.writeFileSync(outFile, content);
+  console.log("[hook-runner] Exported module config to " + outFile);
+  console.log("  Share this file — others can import with: cp " + outFile + " ~/.claude/hooks/modules.yaml && node setup.js --sync");
+}
+
 function cmdWorkflow(args) {
   var wf;
   try { wf = require(path.join(__dirname, "workflow.js")); } catch(e) {
@@ -1346,6 +1427,7 @@ function main() {
   if (args.indexOf("--uninstall") !== -1) return cmdUninstall(args, dryRun);
   if (args.indexOf("--prune") !== -1) return cmdPrune(args, dryRun);
   if (args.indexOf("--stats") !== -1) return cmdStats();
+  if (args.indexOf("--export") !== -1) return cmdExport(args);
   if (args.indexOf("--perf") !== -1) return cmdPerf();
   if (args.indexOf("--list") !== -1) return cmdList();
   if (args.indexOf("--test") !== -1) return cmdTest();


### PR DESCRIPTION
## Summary
- New `--export [file]` CLI command scans installed modules and generates portable YAML
- Output compatible with `--sync` import workflow
- Includes global and project-scoped modules

## Test plan
- [x] `node setup.js --export` generates valid YAML with all installed modules
- [x] 92/92 tests pass