### PR TITLE
T083: Add no-local-docker workflow + module

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -134,7 +134,7 @@ WHY: Currently ~30 run-modules exist with no way to see the big picture — whic
 - [x] T080: Add --export command (export module config as shareable YAML bundle)
 - [x] T081: Hook runner checks workflow enabled state before running a module (module header: `// WORKFLOW: workflow-name`)
 - [x] T082: Create `shtd.yml` workflow manifest — groups spec-gate, gsd-gate, branch-pr-gate, remote-tracking-gate
-- [ ] T083: Create `no-local-docker.yml` workflow + block-local-docker module
+- [x] T083: Create `no-local-docker.yml` workflow + block-local-docker module
 - [ ] T084: Create `messaging-safety.yml` workflow + existing messaging guard modules
 - [ ] T085: Sync workflow.js, workflow-gate.js, workflows/ to live hooks
 - [ ] T086: Tests for workflow engine (YAML parsing, state management, gate checking)

--- a/modules/PreToolUse/block-local-docker.js
+++ b/modules/PreToolUse/block-local-docker.js
@@ -1,0 +1,25 @@
+// WHY: Local docker builds consumed disk/CPU and caused "no space left on device" failures.
+// All container workloads should run on remote infrastructure (EC2, ECS, cloud-claude).
+// WORKFLOW: no-local-docker
+"use strict";
+
+module.exports = function(input) {
+  if (input.tool_name !== "Bash") return null;
+
+  var cmd = (input.tool_input && input.tool_input.command) || "";
+  var trimmed = cmd.trim().replace(/^(sudo\s+)/, "");
+
+  // Block docker and docker-compose commands
+  if (/^docker(\s|$)/.test(trimmed) || /^docker-compose(\s|$)/.test(trimmed)) {
+    // Allow read-only inspection commands
+    if (/^docker\s+(ps|images|inspect|logs|version|info|stats)\b/.test(trimmed)) return null;
+    if (/^docker-compose\s+(ps|logs|config)\b/.test(trimmed)) return null;
+
+    return {
+      decision: "block",
+      reason: "[no-local-docker] Local Docker commands blocked. Use remote infrastructure (EC2, ECS, cloud-claude) for container workloads. Read-only commands (ps, logs, inspect) are allowed."
+    };
+  }
+
+  return null;
+};

--- a/workflows/no-local-docker.yml
+++ b/workflows/no-local-docker.yml
@@ -1,0 +1,10 @@
+name: no-local-docker
+description: Block local Docker commands — force containerized workloads to run on remote infrastructure
+version: 1
+steps:
+  - id: active
+    name: Workflow is active — all local docker/docker-compose commands are blocked
+    gate:
+      require_files: []
+    completion:
+      require_files: []


### PR DESCRIPTION
## Summary
- `no-local-docker.yml` workflow blocks local Docker commands
- `block-local-docker.js` PreToolUse module: blocks docker build/run/push/exec, allows ps/logs/inspect
- Tagged with `// WORKFLOW: no-local-docker` — only active when workflow is started

## Test plan
- [x] Module blocks docker build, allows docker ps
- [x] 110/110 tests pass