### PR TITLE
T086-T087: Workflow docs, version bump to 1.5.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,48 +1,64 @@
-# Hook Runner
+# hook-runner
 
-Modular hook system for Claude Code. One runner per event, modules auto-loaded.
+Modular hook runner system for Claude Code. One runner per event, modules in folders.
 
-## Architecture
+## Repo
+- **Account**: grobomo (public)
+- **Marketplace**: grobomo/claude-code-skills → plugins/hook-runner
+- **Local skill**: ~/.claude/skills/hook-runner/
+- **Live hooks**: ~/.claude/hooks/ (run-*.js, load-modules.js, run-modules/)
 
+## File Layout
+- `setup.js` — CLI entry point with extracted command handlers
+- `report.js` — HTML report generator
+- `workflow.js` — zero-dep YAML workflow engine (state machine, gate validation)
+- `load-modules.js` — shared module loader (global + project-scoped + workflow filtering + dependency validation)
+- `hook-log.js` — centralized logger (JSONL per invocation, per-module timing)
+- `run-async.js` — async module executor (Promise detection, 4s timeout)
+- `run-*.js` — event runners (pretooluse, posttooluse, stop, sessionstart, userpromptsubmit)
+- `modules/` — distributable module catalog organized by event type
+- `workflows/` — built-in workflow definitions (YAML)
+- `scripts/test/` — test scripts (112 tests across 6 files)
+
+## Sync Targets (must stay identical)
+1. Repo: this directory
+2. Live: ~/.claude/hooks/
+3. Skill: ~/.claude/skills/hook-runner/
+4. Marketplace: ../claude-code-skills/plugins/hook-runner/
+
+## Testing
+```bash
+node setup.js --test    # runs all 6 suites (112 tests)
 ```
-~/.claude/hooks/
-  load-modules.js          # shared loader (global + project-scoped)
-  run-pretooluse.js        # PreToolUse runner
-  run-posttooluse.js       # PostToolUse runner
-  run-stop.js              # Stop runner
-  run-sessionstart.js      # SessionStart runner
-  run-modules/
-    PreToolUse/
-      *.js                 # global modules (all projects)
-      hackathon26/*.js     # only for hackathon26 project
-    PostToolUse/
-      *.js
-    Stop/
-      *.js
-    SessionStart/
-      *.js
+
+## Module Contract
+- Sync: `module.exports = function(input) { return null; }` — preferred for gates
+- Async: `module.exports = async function(input) { ... }` — 4s timeout per module
+- Return `null` to pass, `{decision: "block", reason: "..."}` to block
+- Dependencies: `// requires: mod1, mod2` in first 5 lines — missing deps = skipped
+- Workflow tag: `// WORKFLOW: name` in first 5 lines — only runs when that workflow is active
+
+## CLI Commands
+```
+node setup.js               # full setup wizard
+node setup.js --report      # HTML report
+node setup.js --health      # verify runners + modules
+node setup.js --sync        # sync modules from GitHub
+node setup.js --list        # catalog vs installed
+node setup.js --stats       # text summary of hook log
+node setup.js --perf        # module timing analysis
+node setup.js --export      # export module config as YAML
+node setup.js --workflow     # list|start|status|complete|reset
+node setup.js --test        # run all test suites
+node setup.js --upgrade     # fetch latest from GitHub
+node setup.js --uninstall   # remove hook-runner
+node setup.js --prune [N]   # prune log entries older than N days
+node setup.js --version     # show version
 ```
 
-## Design Decisions
-
-### Shared `load-modules.js`
-All four runners delegate module discovery to `load-modules.js`. This avoids duplicating the global+project logic in each runner. Runners only differ in how they interpret module results (block/allow vs text output).
-
-### Project Scoping by Basename
-Project-scoped modules live in subfolders named after `path.basename(CLAUDE_PROJECT_DIR)`. Basename was chosen over full path because:
-- Folder names are short and readable (`hackathon26`, not `C-Users-joelg-Documents-...`)
-- Projects don't move between machines with different base paths
-- Collisions are unlikely — project names are already unique within ProjectsCL1
-
-### Load Order: Global First, Then Project
-Global modules run first (sorted alphabetically), then project-scoped modules (also sorted). This means project modules can add extra gates but can't override a global block — once any module returns a decision, the runner stops. If a project needs to *skip* a global gate, move that gate out of global into the projects that need it.
-
-### Modules Are Synchronous
-All modules export a synchronous function. They read stdin via `fs.readFileSync(0)` in the runner, which passes the parsed input object. Async hooks race with the timeout and silently fail.
-
-## Adding a Module
-
-1. **Global** (all projects): create `run-modules/{Event}/my-gate.js`
-2. **Project-scoped**: create `run-modules/{Event}/<project-name>/my-gate.js`
-3. Module signature: `module.exports = function(input) { return null; }` (null = allow, `{decision: "block", reason: "..."}` = block)
-4. Never add entries to `settings.json` — runners are already registered there.
+## Push Workflow
+This is a grobomo repo. Before pushing:
+1. `gh auth switch --user grobomo`
+2. Push
+3. Sync to marketplace: `cp setup.js report.js load-modules.js workflow.js ../claude-code-skills/plugins/hook-runner/`
+4. `gh auth switch --user joel-ginsberg_tmemu`

--- a/README.md
+++ b/README.md
@@ -173,6 +173,58 @@ curl -fsSL https://raw.githubusercontent.com/grobomo/hook-runner/main/modules.ex
 /hook-runner sync-dry-run    # preview first
 ```
 
+## Workflows
+
+Workflows group related modules into enforceable pipelines with step ordering. Modules tagged with `// WORKFLOW: name` only run when that workflow is active.
+
+```bash
+/hook-runner workflow list                    # show all available workflows
+/hook-runner workflow start shtd              # activate the SHTD pipeline
+/hook-runner workflow status                  # show current step + progress
+/hook-runner workflow complete spec           # mark a step as done
+/hook-runner workflow reset                   # clear active workflow
+```
+
+### Built-in Workflows
+
+| Workflow | Description |
+|----------|-------------|
+| `shtd` | Spec → tasks → branch → test → implement → verify → PR |
+| `enforce-shtd` | Extended SHTD with workflow YAML definition step |
+| `cross-project-reset` | Safe project switching with state preservation |
+| `no-local-docker` | Block local Docker, force remote infrastructure |
+| `messaging-safety` | Block outbound messaging unless target authorized |
+
+### Custom Workflows
+
+Create `workflows/*.yml` in your project or `~/.claude/hooks/workflows/`:
+
+```yaml
+name: my-workflow
+description: What this workflow enforces
+version: 1
+steps:
+  - id: setup
+    name: Set up environment
+    gate:
+      require_files: []
+  - id: build
+    name: Build the thing
+    gate:
+      require_step: setup
+```
+
+Tag modules with `// WORKFLOW: my-workflow` in the first 5 lines to restrict them to this workflow.
+
+### Export Config
+
+```bash
+/hook-runner export                 # export installed modules as modules-export.yaml
+/hook-runner export my-config.yaml  # custom output path
+```
+
+Share the exported YAML — others import with `cp my-config.yaml ~/.claude/hooks/modules.yaml && /hook-runner sync`.
+
 ## Available Modules
 
 Full catalog in `modules/` directory:
@@ -193,6 +245,9 @@ Full catalog in `modules/` directory:
 | `no-hardcoded-paths` | Blocks Write/Edit with hardcoded absolute user paths in content |
 | `env-var-check` | Blocks edits if `.env.required` vars are missing (cached per project) |
 | `aws-tagging-gate` | Enforces required tags on AWS resource creation (env-configurable) |
+| `block-local-docker` | Blocks docker/docker-compose (allows ps/logs/inspect). Tagged: `no-local-docker` workflow |
+| `messaging-safety-gate` | Blocks outbound messaging unless target authorized. Tagged: `messaging-safety` workflow |
+| `workflow-gate` | Enforces step order in active workflows |
 
 ### UserPromptSubmit (processes user prompts)
 | Module | Description |

--- a/TODO.md
+++ b/TODO.md
@@ -105,12 +105,12 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 - [x] T070: Sync live module fixes back to repo catalog (branch-pr-gate, no-adhoc-commands, load-instructions, auto-continue)
 
 ## Status
-- 79 tasks completed, 8 pending (T080-T087)
-- Version: 1.4.0
-- 92 tests passing across 5 test files
+- 87 tasks completed, 0 pending
+- Version: 1.5.0
+- 112 tests passing across 6 test files
 - CI: GitHub Actions runs all tests on push/PR — badge in README
-- Workflow engine: workflow.js + workflow-gate.js + 2 built-in templates
-- CLI commands: setup, report, dry-run, health, sync, stats, list, test, upgrade, uninstall, prune, version, help, workflow, perf
+- Workflow engine: workflow.js + workflow-gate.js + 5 built-in templates
+- CLI commands: setup, report, dry-run, health, sync, stats, list, test, upgrade, uninstall, prune, version, help, workflow, perf, export
 
 ## Performance & Features (v1.4.0)
 - [x] T071: Add `env-var-check` PreToolUse module (blocks if required project env vars missing)
@@ -137,8 +137,8 @@ WHY: Currently ~30 run-modules exist with no way to see the big picture — whic
 - [x] T083: Create `no-local-docker.yml` workflow + block-local-docker module
 - [x] T084: Create `messaging-safety.yml` workflow + existing messaging guard modules
 - [x] T085: Sync workflow.js, workflow-gate.js, workflows/ to live hooks + skill + marketplace
-- [ ] T086: Tests for workflow engine (YAML parsing, state management, gate checking)
-- [ ] T087: Update README, CLAUDE.md, SKILL.md with workflow docs + version bump
+- [x] T086: Tests for workflow engine (YAML parsing, state management, gate checking) — done in T081
+- [x] T087: Update README, CLAUDE.md, SKILL.md with workflow docs + version bump
 
 ## Moved
 - T026: Moved to chat-export/TODO.md (out of scope for hook-runner)

--- a/setup.js
+++ b/setup.js
@@ -46,7 +46,7 @@ var SCRIPT_DIR = __dirname;
 var REPO_DIR = SCRIPT_DIR;
 
 var HOOK_LOG_PATH = path.join(HOOKS_DIR, "hook-log.jsonl");
-var VERSION = "1.4.0";
+var VERSION = "1.5.0";
 
 // ============================================================
 // 0. Hook Log Stats


### PR DESCRIPTION
## Summary
- T086: Workflow tests already complete (16 tests in T081)
- T087: README adds workflow section with built-in templates, export docs, new modules
- CLAUDE.md rewritten with workflow engine, all CLI commands, accurate file layout
- Version bumped to 1.5.0

## Test plan
- [x] 112/112 tests pass
- [x] `--workflow list` shows 5 workflows
- [x] `node setup.js --version` shows 1.5.0