### PR TITLE
T091: Add package.json for npx install

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,12 @@ No installation required — just clone and run `node setup.js --report`.
 ## Quick Start (full system)
 
 ```bash
-# Install via grobomo marketplace (if not already added)
-# In Claude Code: /install hook-runner
+# One-liner install from GitHub
+npx grobomo/hook-runner
+
+# Or clone first
+git clone https://github.com/grobomo/hook-runner.git
+cd hook-runner && node setup.js
 
 # Commands
 /hook-runner setup        # scan → report → backup → install → verify

--- a/TODO.md
+++ b/TODO.md
@@ -105,11 +105,11 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 - [x] T070: Sync live module fixes back to repo catalog (branch-pr-gate, no-adhoc-commands, load-instructions, auto-continue)
 
 ## Status
-- 90 tasks completed, 0 pending
+- 91 tasks completed, 0 pending
 - Stale remote branches cleaned (9 deleted)
 - Next: consider installer improvements, npm packaging
 - Version: 1.5.0
-- 168 tests passing across 9 test files
+- 172 tests passing across 10 test files
 - CI: GitHub Actions runs all tests on push/PR — badge in README
 - Workflow engine: workflow.js + workflow-gate.js + 5 built-in templates
 - CLI commands: setup, report, dry-run, health, sync, stats, list, test, upgrade, uninstall, prune, version, help, workflow, perf, export
@@ -150,6 +150,9 @@ WHY: Currently ~30 run-modules exist with no way to see the big picture — whic
 
 ## Security Hardening
 - [x] T090: Sanitize inputs in fetchFromGitHub and openFile to prevent command injection
+
+## Packaging
+- [x] T091: Add package.json for npx install (`npx grobomo/hook-runner`)
 
 ## Moved
 - T026: Moved to chat-export/TODO.md (out of scope for hook-runner)

--- a/package.json
+++ b/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "hook-runner",
+  "version": "1.5.0",
+  "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
+  "bin": {
+    "hook-runner": "setup.js"
+  },
+  "files": [
+    "setup.js",
+    "report.js",
+    "workflow.js",
+    "load-modules.js",
+    "hook-log.js",
+    "run-async.js",
+    "run-pretooluse.js",
+    "run-posttooluse.js",
+    "run-sessionstart.js",
+    "run-stop.js",
+    "run-userpromptsubmit.js",
+    "modules/",
+    "workflows/"
+  ],
+  "keywords": [
+    "claude-code",
+    "hooks",
+    "modular",
+    "runner",
+    "gates",
+    "workflow"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/grobomo/hook-runner.git"
+  },
+  "engines": {
+    "node": ">=14"
+  },
+  "dependencies": {}
+}

--- a/scripts/test/test-T091-package.sh
+++ b/scripts/test/test-T091-package.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Test T091: package.json validity
+set -euo pipefail
+REPO_DIR="$(cd "$(dirname "$0")/../.." && (pwd -W 2>/dev/null || pwd))"
+PASS=0; FAIL=0
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+echo "=== hook-runner: package.json validation ==="
+
+# Test: package.json exists and is valid JSON
+if [ -f "$REPO_DIR/package.json" ]; then
+  if node -e "JSON.parse(require('fs').readFileSync('$REPO_DIR/package.json','utf8'))" 2>/dev/null; then
+    pass "package.json is valid JSON"
+  else
+    fail "package.json is invalid JSON"
+  fi
+else
+  fail "package.json missing"
+fi
+
+# Test: bin field points to setup.js
+result=$(node -e "
+var p = JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));
+console.log(p.bin && p.bin['hook-runner'] === 'setup.js' ? 'OK' : 'MISSING');
+" "$REPO_DIR/package.json" 2>&1)
+if [ "$result" = "OK" ]; then
+  pass "bin.hook-runner points to setup.js"
+else
+  fail "bin field incorrect: $result"
+fi
+
+# Test: no dependencies (zero-dep project)
+result=$(node -e "
+var p = JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));
+var deps = Object.keys(p.dependencies || {}).length;
+console.log(deps === 0 ? 'OK' : deps);
+" "$REPO_DIR/package.json" 2>&1)
+if [ "$result" = "OK" ]; then
+  pass "zero dependencies"
+else
+  fail "unexpected dependencies: $result"
+fi
+
+# Test: files field includes core files
+result=$(node -e "
+var p = JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));
+var f = p.files || [];
+var needed = ['setup.js','report.js','workflow.js','load-modules.js','hook-log.js','run-async.js','modules/','workflows/'];
+var missing = needed.filter(function(n){ return f.indexOf(n) === -1; });
+console.log(missing.length === 0 ? 'OK' : 'MISSING:' + missing.join(','));
+" "$REPO_DIR/package.json" 2>&1)
+if [ "$result" = "OK" ]; then
+  pass "files field includes all core files"
+else
+  fail "files field: $result"
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary
- Adds `package.json` enabling `npx grobomo/hook-runner` one-liner setup
- Zero dependencies, `bin.hook-runner` points to `setup.js`
- Updated README with npx install instructions
- 172 tests across 10 suites, all passing