### PR TITLE
T094-T095: Complete module docs, fix minor code issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 - `modules/` — distributable module catalog organized by event type
 - `workflows/` — built-in workflow definitions (YAML)
 - `package.json` — npm package metadata (enables `npx grobomo/hook-runner`)
-- `scripts/test/` — test scripts (172 tests across 10 files)
+- `scripts/test/` — test scripts (180 tests across 12 files)
 
 ## Sync Targets (must stay identical)
 1. Repo: this directory
@@ -29,7 +29,7 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 
 ## Testing
 ```bash
-node setup.js --test    # runs all 10 suites (172 tests)
+node setup.js --test    # runs all 12 suites (180 tests)
 ```
 
 ## Module Contract

--- a/README.md
+++ b/README.md
@@ -236,44 +236,77 @@ Full catalog in `modules/` directory:
 ### PreToolUse (gates before tool execution)
 | Module | Description |
 |--------|-------------|
-| `enforcement-gate` | Requires git repo + TODO.md. Dirty-tree check on main only. |
-| `branch-pr-gate` | Model C workflow: feature branch → task branch → PR |
-| `remote-tracking-gate` | Blocks edits if branch not pushed to remote |
-| `spec-gate` | Blocks code without specs/tasks.md |
-| `gsd-gate` | Blocks code without e2e test in checkpoint |
-| `continuous-claude-gate` | Blocks code without tracked task workflow |
-| `root-cause-gate` | Blocks retry/cleanup without root cause diagnosis |
-| `archive-not-delete` | Blocks `rm -rf`, forces `mv` to `archive/` |
-| `no-adhoc-commands` | Blocks raw aws/ssh/docker/kubectl, forces scripts/ |
-| `secret-scan-gate` | Blocks git commit if staged diff contains API keys, tokens, or passwords |
-| `no-hardcoded-paths` | Blocks Write/Edit with hardcoded absolute user paths in content |
-| `env-var-check` | Blocks edits if `.env.required` vars are missing (cached per project) |
 | `aws-tagging-gate` | Enforces required tags on AWS resource creation (env-configurable) |
 | `block-local-docker` | Blocks docker/docker-compose (allows ps/logs/inspect). Tagged: `no-local-docker` workflow |
+| `branch-pr-gate` | Model C workflow: feature branch → task branch → PR |
+| `claude-p-pattern` | Enforces correct `claude -p` invocation (stdin redirect, not pipe/args) |
+| `continuous-claude-gate` | Blocks code without tracked task workflow |
+| `crlf-ssh-key-check` | Blocks scp/cp of SSH keys without `tr -d '\r'` (Windows CRLF corruption) |
+| `enforcement-gate` | Requires git repo + TODO.md. Dirty-tree check on main only. |
+| `env-var-check` | Blocks edits if `.env.required` vars are missing (cached per project) |
+| `git-rebase-safety` | Warns about reversed --ours/--theirs during rebase |
+| `gsd-gate` | Blocks code without e2e test in checkpoint |
+| `instruction-to-hook-gate` | Enforces converting user directives ("always X") into hook modules |
 | `messaging-safety-gate` | Blocks outbound messaging unless target authorized. Tagged: `messaging-safety` workflow |
+| `no-adhoc-commands` | Blocks raw aws/ssh/docker/kubectl, forces scripts/ |
+| `no-focus-steal` | Blocks background process launches that steal window focus |
+| `no-fragile-heuristics` | Blocks pixel-ratio/color-counting heuristics; use AI judgment instead |
+| `no-hardcoded-paths` | Blocks Write/Edit with hardcoded absolute user paths in content |
+| `no-passive-rules` | Blocks creating .md rules when a hook module would be more effective |
+| `pr-per-task-gate` | Blocks `gh pr create` if PR title doesn't include a task ID (T001, etc.) |
+| `preserve-iterated-content` | Warns on full-file rewrites of files with significant git history |
+| `remote-tracking-gate` | Blocks edits if branch not pushed to remote |
+| `root-cause-gate` | Blocks retry/cleanup without root cause diagnosis |
+| `secret-scan-gate` | Blocks git commit if staged diff contains API keys, tokens, or passwords |
+| `settings-change-gate` | Injects reminder to state rationale when modifying ~/.claude/ config |
+| `spec-gate` | Blocks code without specs/tasks.md |
 | `workflow-gate` | Enforces step order in active workflows |
+
+#### Project-Scoped PreToolUse
+| Module | Project | Description |
+|--------|---------|-------------|
+| `share-is-generic` | ddei-email-security | Domain-specific gate for email security project |
+| `use-workers` | hackathon26 | Forces delegation to fleet workers instead of local execution |
 
 ### UserPromptSubmit (processes user prompts)
 | Module | Description |
 |--------|-------------|
+| `instruction-detector` | Detects "always/never/from now on" directives, flags for downstream enforcement |
+| `interrupt-detector` | Detects user interrupts (missing turn marker) and triggers self-analysis |
 | `prompt-logger` | Logs prompts to `~/.claude/hooks/prompt-log.jsonl` for audit (never blocks) |
 
 ### PostToolUse (checks after tool execution)
 | Module | Description |
 |--------|-------------|
-| `rule-hygiene` | Validates rule files are single-topic, under 20 lines |
 | `commit-msg-check` | Blocks WIP/fixup commits and over-long first lines (>72 chars) |
+| `hook-autocommit` | Auto-commits hook module edits to the run-modules git repo |
+| `rule-hygiene` | Validates rule files are single-topic, under 20 lines |
+| `settings-audit-log` | Records all ~/.claude/ config modifications to audit log (JSONL) |
 | `test-coverage-check` | Warns when source files with corresponding test files are modified |
+| `troubleshoot-detector` | Detects fail-fail-succeed patterns and prompts creating a hook to prevent recurrence |
+| `update-stale-docs` | Detects stale docs/comments after code edits and prompts updates |
 
 ### Stop (controls session ending)
 | Module | Description |
 |--------|-------------|
 | `auto-continue` | Blocks stopping — always find the next task |
+| `drift-review` | Checks if recent work matches the active spec task before continuing |
+| `log-gotchas` | Ensures debugging lessons are captured as rule files before stopping |
+| `mark-turn-complete` | Writes turn marker so interrupt-detector can detect incomplete turns |
+| `never-give-up` | Blocks "impossible" declarations — forces research before giving up |
 | `push-unpushed` | Blocks stop if unpushed commits on feature branch |
+| `test-before-done` | Reminds to run e2e tests before declaring features complete |
+
+#### Project-Scoped Stop
+| Module | Project | Description |
+|--------|---------|-------------|
+| `delegate-and-monitor` | hackathon26 | Delegates tasks to fleet workers and monitors completion |
 
 ### SessionStart (injects context)
 | Module | Description |
 |--------|-------------|
-| `load-instructions` | Injects working instructions at session start |
 | `backup-check` | Async — warns if claude-backup is stale (>72h) or missing |
+| `config-sync` | Auto-syncs ~/.claude config to git remote for backup/bootstrap |
+| `load-instructions` | Injects working instructions at session start |
+| `load-lessons` | Reads self-analysis lessons (JSONL) and injects recent ones as context |
 | `project-health` | Runs health check on session start, warns about issues |

--- a/TODO.md
+++ b/TODO.md
@@ -104,12 +104,16 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 ## Sync & Maintenance
 - [x] T070: Sync live module fixes back to repo catalog (branch-pr-gate, no-adhoc-commands, load-instructions, auto-continue)
 
+## Documentation & Polish
+- [x] T094: Complete Available Modules table in README (25+ modules undocumented)
+- [x] T095: Fix minor code issues — duplicate comment numbering in healthCheck, var redeclaration in cmdWorkflow
+
 ## Status
-- 93 tasks completed, 0 pending
-- Stale remote branches cleaned (9 deleted)
-- Next: consider installer improvements, npm packaging
+- 95 tasks completed, 0 pending
+- All sync targets up to date (live, skill, marketplace)
+- Next: consider usage examples, blog post, or new module ideas
 - Version: 1.5.1
-- 172 tests passing across 10 test files
+- 180 tests passing across 12 test files
 - CI: GitHub Actions runs all tests on push/PR — badge in README
 - Workflow engine: workflow.js + workflow-gate.js + 5 built-in templates
 - CLI commands: setup, report, dry-run, health, sync, stats, list, test, upgrade, uninstall, prune, version, help, workflow, perf, export

--- a/scripts/test/test-T094-module-docs.sh
+++ b/scripts/test/test-T094-module-docs.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Test T094: Verify README documents all distributable modules
+set -euo pipefail
+REPO_DIR="$(cd "$(dirname "$0")/../.." && (pwd -W 2>/dev/null || pwd))"
+PASS=0; FAIL=0
+
+check() {
+  if eval "$2"; then PASS=$((PASS+1)); echo "  PASS: $1"
+  else FAIL=$((FAIL+1)); echo "  FAIL: $1"; fi
+}
+
+echo "=== hook-runner: module documentation ==="
+
+README="$REPO_DIR/README.md"
+
+# Get all distributable .js modules (exclude _example-project, archive)
+MODULES=$(find "$REPO_DIR/modules" -name "*.js" -not -path "*archive*" -not -path "*_example*" | while read f; do basename "$f" .js; done | sort -u)
+
+# Check each module appears in README
+MISSING=""
+for mod in $MODULES; do
+  if ! grep -q "$mod" "$README" 2>/dev/null; then
+    MISSING="$MISSING $mod"
+  fi
+done
+
+check "all modules documented in README" '[ -z "$MISSING" ]'
+if [ -n "$MISSING" ]; then
+  echo "    Missing:$MISSING"
+fi
+
+# Check README has all 5 event sections
+for evt in PreToolUse PostToolUse UserPromptSubmit Stop SessionStart; do
+  check "$evt section exists" "grep -q '### $evt' '$README'"
+done
+
+# Check module count in README roughly matches catalog
+README_MODS=$(grep -c '| `[a-z]' "$README" || true)
+CATALOG_COUNT=$(echo "$MODULES" | wc -w | tr -d ' ')
+check "README module count ($README_MODS) close to catalog ($CATALOG_COUNT)" '[ "$README_MODS" -ge "$((CATALOG_COUNT - 5))" ]'
+
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/scripts/test/test-T095-code-quality.sh
+++ b/scripts/test/test-T095-code-quality.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Test T095: Code quality checks
+set -euo pipefail
+REPO_DIR="$(cd "$(dirname "$0")/../.." && (pwd -W 2>/dev/null || pwd))"
+PASS=0; FAIL=0
+
+check() {
+  if eval "$2"; then PASS=$((PASS+1)); echo "  PASS: $1"
+  else FAIL=$((FAIL+1)); echo "  FAIL: $1"; fi
+}
+
+echo "=== hook-runner: code quality ==="
+
+# Check no duplicate section number comments in healthCheck
+DUPES=$(grep -n '// [0-9]\.' "$REPO_DIR/setup.js" | awk -F'// ' '{print $2}' | sort | uniq -d)
+check "no duplicate section numbers in setup.js" '[ -z "$DUPES" ]'
+
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/setup.js
+++ b/setup.js
@@ -1410,9 +1410,9 @@ function cmdWorkflow(args) {
   }
 
   if (sub === "reset") {
-    var state = wf.readState(projectDir);
-    if (!state) { console.log("No active workflow to reset."); return; }
-    var name = state.workflow;
+    var resetState = wf.readState(projectDir);
+    if (!resetState) { console.log("No active workflow to reset."); return; }
+    var name = resetState.workflow;
     wf.resetState(projectDir);
     console.log('Workflow "' + name + '" cleared.');
     return;
@@ -1553,7 +1553,7 @@ function healthCheck() {
     results.push({ check: "settings", file: "settings.json", status: "missing" });
   }
 
-  // 4. Check hook log writability
+  // 5. Check hook log writability
   try {
     fs.accessSync(path.dirname(HOOK_LOG_PATH), fs.constants.W_OK);
     results.push({ check: "log", file: "hook-log.jsonl", status: "ok", detail: fs.existsSync(HOOK_LOG_PATH) ? "exists" : "will be created on first trigger" });


### PR DESCRIPTION
## Summary
- Document all 50 modules in README Available Modules table (was 30, missing 25+)
- Add project-scoped module sections for hackathon26 and ddei-email-security
- Fix duplicate comment numbering in healthCheck (`// 4.` appeared twice)
- Fix `var state` redeclaration in `cmdWorkflow` (renamed to `resetState`)
- Add 2 test scripts (8 tests): module-docs coverage, code quality checks
- 180 tests passing across 12 suites

## Test plan
- [x] `bash scripts/test/test-T094-module-docs.sh` — all 50 modules documented
- [x] `bash scripts/test/test-T095-code-quality.sh` — no duplicate section numbers
- [x] `node setup.js --test` — 180/180 pass