### PR TITLE
T096: Fix healthCheck scanning archive/ dirs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -108,12 +108,15 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 - [x] T094: Complete Available Modules table in README (25+ modules undocumented)
 - [x] T095: Fix minor code issues — duplicate comment numbering in healthCheck, var redeclaration in cmdWorkflow
 
+## Health Check Fix
+- [x] T096: Fix healthCheck() scanning archive/ dirs (same bug as T089 but in setup.js code path)
+
 ## Status
-- 95 tasks completed, 0 pending
+- 96 tasks completed, 0 pending
 - All sync targets up to date (live, skill, marketplace)
 - Next: consider usage examples, blog post, or new module ideas
 - Version: 1.5.1
-- 180 tests passing across 12 test files
+- 183 tests passing across 13 test files
 - CI: GitHub Actions runs all tests on push/PR — badge in README
 - Workflow engine: workflow.js + workflow-gate.js + 5 built-in templates
 - CLI commands: setup, report, dry-run, health, sync, stats, list, test, upgrade, uninstall, prune, version, help, workflow, perf, export

--- a/scripts/test/test-T096-health-archive.sh
+++ b/scripts/test/test-T096-health-archive.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Test T096: Health check should skip archive/ directories
+set -euo pipefail
+REPO_DIR="$(cd "$(dirname "$0")/../.." && (pwd -W 2>/dev/null || pwd))"
+PASS=0; FAIL=0
+
+check() {
+  if eval "$2"; then PASS=$((PASS+1)); echo "  PASS: $1"
+  else FAIL=$((FAIL+1)); echo "  FAIL: $1"; fi
+}
+
+echo "=== hook-runner: health check archive skip ==="
+
+# Run health check and capture output
+HEALTH_OUT=$(node "$REPO_DIR/setup.js" --health 2>&1 || true)
+
+# Check no archive/ modules appear in failures
+ARCHIVE_FAILS=$(echo "$HEALTH_OUT" | grep -c 'FAIL.*archive/' || true)
+check "no archive/ modules in health failures" '[ "$ARCHIVE_FAILS" -eq 0 ]'
+
+# Check health check still reports OK for non-archive modules
+OK_COUNT=$(echo "$HEALTH_OUT" | grep -c '\[  OK\]' || true)
+check "health check reports OK modules ($OK_COUNT)" '[ "$OK_COUNT" -gt 0 ]'
+
+# Check zero failures total
+FAIL_COUNT=$(echo "$HEALTH_OUT" | grep -oP '\d+ failures' | grep -oP '\d+' || echo "0")
+check "zero total failures" '[ "$FAIL_COUNT" -eq 0 ]'
+
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/setup.js
+++ b/setup.js
@@ -1482,6 +1482,8 @@ function healthCheck() {
       var stat;
       try { stat = fs.statSync(fPath); } catch(e) { continue; }
       if (stat.isDirectory()) {
+        // skip archive directories — contain superseded modules with stale deps
+        if (f === "archive") continue;
         // project-scoped: check each file inside
         var subFiles;
         try { subFiles = fs.readdirSync(fPath); } catch(e) { continue; }


### PR DESCRIPTION
## Summary
- Skip `archive/` directories in `healthCheck()` — they contain superseded modules with stale deps
- Same bug as T089 (project-health.js) but in the setup.js `--health` code path
- Fixes 7 false failures from archived SHTD modules referencing deleted `lib/` files

## Test plan
- [x] `bash scripts/test/test-T096-health-archive.sh` — zero archive failures
- [x] `node setup.js --test` — 183/183 pass across 13 suites