### PR TITLE
T097: Add modules field to workflows, create 4 new workflow groups

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -111,8 +111,24 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 ## Health Check Fix
 - [x] T096: Fix healthCheck() scanning archive/ dirs (same bug as T089 but in setup.js code path)
 
+## Workflows as Primary Abstraction (T097+)
+
+WHY: Modules are implementation details — workflows are the human-readable interface.
+"Enable SHTD" is how a human thinks. The 9 modules behind it are how it's enforced.
+On context reset, Claude reads workflow state and immediately knows all active constraints.
+
+- [ ] T097: Add `modules:` field to workflow YAML definitions listing which modules belong
+- [ ] T098: Add workflow-config.json (enabled/disabled state per workflow, global + per-project)
+- [ ] T099: Update load-modules.js filterByWorkflow to use enable/disable config (not just step-state)
+- [ ] T100: Tag every module with `// WORKFLOW: <name>` — no orphans
+- [ ] T101: Add `--workflow enable/disable <name>` CLI commands
+- [ ] T102: Add `--workflow audit` — list orphan modules, workflow coverage report
+- [ ] T103: Add `--workflow query <tool>` — show which workflows affect Bash/Edit/Write
+- [ ] T104: Update SessionStart module to inject active workflow summary on context reset
+- [ ] T105: Update docs (README, CLAUDE.md, SKILL.md) + marketplace sync
+
 ## Status
-- 96 tasks completed, 0 pending
+- 96 tasks completed, 9 pending
 - All sync targets up to date (live, skill, marketplace)
 - Next: consider usage examples, blog post, or new module ideas
 - Version: 1.5.1

--- a/scripts/test/test-T097-workflow-modules.sh
+++ b/scripts/test/test-T097-workflow-modules.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Test T097: Workflow YAML files have modules: field listing member modules
+set -euo pipefail
+REPO_DIR="$(cd "$(dirname "$0")/../.." && (pwd -W 2>/dev/null || pwd))"
+PASS=0; FAIL=0
+
+check() {
+  if eval "$2"; then PASS=$((PASS+1)); echo "  PASS: $1"
+  else FAIL=$((FAIL+1)); echo "  FAIL: $1"; fi
+}
+
+echo "=== hook-runner: workflow modules field ==="
+
+# Every workflow YAML should have a modules: section
+for yml in "$REPO_DIR"/workflows/*.yml; do
+  name=$(basename "$yml" .yml)
+  check "$name.yml has modules: field" "grep -q '^modules:' '$yml'"
+done
+
+# workflow.js loadWorkflow should parse modules field
+MOD_COUNT=$(node -e "
+  var wf = require('$REPO_DIR/workflow.js');
+  var w = wf.loadWorkflow('$REPO_DIR/workflows/shtd.yml');
+  console.log((w.modules || []).length);
+")
+check "shtd workflow has modules listed" '[ "$MOD_COUNT" -gt 0 ]'
+
+# Modules listed in workflows should exist in modules/ catalog
+MISSING=""
+for yml in "$REPO_DIR"/workflows/*.yml; do
+  name=$(basename "$yml" .yml)
+  # Extract module names from modules: section
+  node -e "
+    var wf = require('$REPO_DIR/workflow.js');
+    var w = wf.loadWorkflow('$yml');
+    var mods = w.modules || [];
+    mods.forEach(function(m) { console.log(m); });
+  " | while read mod; do
+    # Check if module exists somewhere in modules/
+    found=$(find "$REPO_DIR/modules" -name "${mod}.js" 2>/dev/null | head -1)
+    if [ -z "$found" ]; then
+      MISSING="$MISSING $name:$mod"
+    fi
+  done
+done
+check "all workflow modules exist in catalog" '[ -z "$MISSING" ]'
+
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/workflow.js
+++ b/workflow.js
@@ -124,6 +124,12 @@ function parseScalar(val) {
 function loadWorkflow(yamlPath) {
   const text = fs.readFileSync(yamlPath, 'utf-8');
   const parsed = parseYaml(text);
+  // Parse modules list (array of module base names)
+  var modules = [];
+  if (Array.isArray(parsed.modules)) {
+    modules = parsed.modules.filter(m => typeof m === 'string');
+  }
+
   return {
     name: parsed.name || path.basename(yamlPath, '.yml'),
     description: parsed.description || '',
@@ -134,6 +140,7 @@ function loadWorkflow(yamlPath) {
       gate: s.gate || {},
       completion: s.completion || {},
     })),
+    modules: modules,
     _path: yamlPath,
   };
 }

--- a/workflows/code-quality.yml
+++ b/workflows/code-quality.yml
@@ -1,0 +1,19 @@
+name: code-quality
+description: Code hygiene — prevents hardcoded paths, fragile heuristics, missed test coverage, and stale docs
+version: 1
+steps:
+  - id: active
+    name: Workflow is active — code quality checks enforced
+    gate:
+      require_files: []
+    completion:
+      require_files: []
+
+modules:
+  - no-hardcoded-paths
+  - no-fragile-heuristics
+  - preserve-iterated-content
+  - root-cause-gate
+  - test-coverage-check
+  - update-stale-docs
+  - rule-hygiene

--- a/workflows/cross-project-reset.yml
+++ b/workflows/cross-project-reset.yml
@@ -26,3 +26,5 @@ steps:
       require_step: new-project-todo
     completion:
       require_files: []
+
+modules: []

--- a/workflows/enforce-shtd.yml
+++ b/workflows/enforce-shtd.yml
@@ -50,3 +50,5 @@ steps:
       require_step: verify
     completion:
       require_files: []
+
+modules: []

--- a/workflows/infra-safety.yml
+++ b/workflows/infra-safety.yml
@@ -1,0 +1,19 @@
+name: infra-safety
+description: Cloud and infrastructure safety — no ad-hoc commands, required tags, env var checks, config audit
+version: 1
+steps:
+  - id: active
+    name: Workflow is active — infrastructure safety modules enforced
+    gate:
+      require_files: []
+    completion:
+      require_files: []
+
+modules:
+  - no-adhoc-commands
+  - aws-tagging-gate
+  - crlf-ssh-key-check
+  - env-var-check
+  - no-focus-steal
+  - settings-change-gate
+  - settings-audit-log

--- a/workflows/messaging-safety.yml
+++ b/workflows/messaging-safety.yml
@@ -9,5 +9,5 @@ steps:
     completion:
       require_files: []
 
-# Modules tagged with // WORKFLOW: messaging-safety:
-# PreToolUse: messaging-safety-gate (blocks email, Teams send, calendar invites)
+modules:
+  - messaging-safety-gate

--- a/workflows/no-local-docker.yml
+++ b/workflows/no-local-docker.yml
@@ -8,3 +8,6 @@ steps:
       require_files: []
     completion:
       require_files: []
+
+modules:
+  - block-local-docker

--- a/workflows/self-improvement.yml
+++ b/workflows/self-improvement.yml
@@ -1,0 +1,18 @@
+name: self-improvement
+description: Learning loop — detect instructions, interrupts, and troubleshooting patterns; enforce durable rules
+version: 1
+steps:
+  - id: active
+    name: Workflow is active — self-improvement modules enforced
+    gate:
+      require_files: []
+    completion:
+      require_files: []
+
+modules:
+  - instruction-to-hook-gate
+  - instruction-detector
+  - interrupt-detector
+  - troubleshoot-detector
+  - no-passive-rules
+  - prompt-logger

--- a/workflows/session-management.yml
+++ b/workflows/session-management.yml
@@ -1,0 +1,21 @@
+name: session-management
+description: Session lifecycle — auto-continue, context injection, health checks, backups
+version: 1
+steps:
+  - id: active
+    name: Workflow is active — session management modules enforced
+    gate:
+      require_files: []
+    completion:
+      require_files: []
+
+modules:
+  - auto-continue
+  - never-give-up
+  - log-gotchas
+  - mark-turn-complete
+  - load-instructions
+  - load-lessons
+  - project-health
+  - backup-check
+  - config-sync

--- a/workflows/shtd.yml
+++ b/workflows/shtd.yml
@@ -45,6 +45,16 @@ steps:
     completion:
       require_files: []
 
-# Modules that belong to this workflow (tag with: // WORKFLOW: shtd)
-# PreToolUse: spec-gate, gsd-gate, branch-pr-gate, remote-tracking-gate
-# These modules enforce the step order when this workflow is active.
+modules:
+  - spec-gate
+  - gsd-gate
+  - branch-pr-gate
+  - remote-tracking-gate
+  - pr-per-task-gate
+  - continuous-claude-gate
+  - enforcement-gate
+  - secret-scan-gate
+  - commit-msg-check
+  - push-unpushed
+  - test-before-done
+  - drift-review


### PR DESCRIPTION
## Summary
- Every workflow YAML now has a `modules:` field listing which modules belong to it
- 4 new workflows: code-quality (7), session-management (9), self-improvement (6), infra-safety (7)
- Existing updated: shtd (12), messaging-safety (1), no-local-docker (1)
- Process-only workflows (cross-project-reset, enforce-shtd) have `modules: []`
- `workflow.js` `loadWorkflow()` parses the modules array

This is step 1 of making workflows the primary human-friendly abstraction for hook-runner.

## Test plan
- [x] `bash scripts/test/test-T097-workflow-modules.sh` — 11/11 pass
- [x] `bash scripts/test/test-T081-T082-T083-T084-T085-T086-workflow.sh` — 16/16 pass