### PR TITLE
T101: Add workflow enable/disable CLI commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ archive/
 .DS_Store
 .test-results/
 SESSION_STATE.md
+.test-tmp-*

--- a/scripts/test/test-T098-workflow-config.sh
+++ b/scripts/test/test-T098-workflow-config.sh
@@ -3,9 +3,9 @@
 set -euo pipefail
 REPO_DIR="$(cd "$(dirname "$0")/../.." && (pwd -W 2>/dev/null || pwd))"
 PASS=0; FAIL=0
-TMPDIR="$REPO_DIR/.test-tmp-T098"
-rm -rf "$TMPDIR"; mkdir -p "$TMPDIR"
-trap "rm -rf $TMPDIR" EXIT
+TMPDIR="$REPO_DIR/.test-tmp-T098-$$"
+mkdir -p "$TMPDIR"
+trap 'mv "$TMPDIR" "${TMPDIR}-done" 2>/dev/null || true' EXIT
 
 check() {
   if eval "$2"; then PASS=$((PASS+1)); echo "  PASS: $1"

--- a/scripts/test/test-T099-filter-by-config.sh
+++ b/scripts/test/test-T099-filter-by-config.sh
@@ -3,10 +3,7 @@
 set -euo pipefail
 REPO_DIR="$(cd "$(dirname "$0")/../.." && (pwd -W 2>/dev/null || pwd))"
 PASS=0; FAIL=0
-TMPDIR="$REPO_DIR/.test-tmp-T099"
-# Clean previous run artifacts (archive-not-delete gate doesn't apply to test temp dirs)
-[ -d "$TMPDIR" ] && mv "$TMPDIR" "$REPO_DIR/.test-tmp-T099-old" 2>/dev/null || true
-[ -d "$REPO_DIR/.test-tmp-T099-done" ] && mv "$REPO_DIR/.test-tmp-T099-done" "$REPO_DIR/.test-tmp-T099-old2" 2>/dev/null || true
+TMPDIR="$REPO_DIR/.test-tmp-T099-$$"
 mkdir -p "$TMPDIR/run-modules/PreToolUse"
 
 check() {
@@ -14,7 +11,7 @@ check() {
   else FAIL=$((FAIL+1)); echo "  FAIL: $1"; fi
 }
 
-cleanup() { mv "$TMPDIR" "$REPO_DIR/.test-tmp-T099-done" 2>/dev/null || true; }
+cleanup() { mv "$TMPDIR" "${TMPDIR}-done" 2>/dev/null || true; }
 trap cleanup EXIT
 
 echo "=== hook-runner: filter by workflow config ==="

--- a/scripts/test/test-T101-workflow-cli.sh
+++ b/scripts/test/test-T101-workflow-cli.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Test T101: workflow CLI enable/disable/list commands
+set -euo pipefail
+REPO_DIR="$(cd "$(dirname "$0")/../.." && (pwd -W 2>/dev/null || pwd))"
+PASS=0; FAIL=0
+TMPDIR="$REPO_DIR/.test-tmp-T101-$$"
+mkdir -p "$TMPDIR"
+cleanup() { mv "$TMPDIR" "${TMPDIR}-done" 2>/dev/null || true; }
+trap cleanup EXIT
+
+check() {
+  if eval "$2"; then PASS=$((PASS+1)); echo "  PASS: $1"
+  else FAIL=$((FAIL+1)); echo "  FAIL: $1"; fi
+}
+
+echo "=== hook-runner: workflow CLI ==="
+
+# Test --workflow list shows workflows with module counts
+LIST=$(CLAUDE_PROJECT_DIR="$TMPDIR" node "$REPO_DIR/setup.js" --workflow list 2>&1)
+check "list shows shtd workflow" 'echo "$LIST" | grep -q "shtd"'
+check "list shows module counts" 'echo "$LIST" | grep -q "modules"'
+
+# Test --workflow enable
+ENABLE_OUT=$(CLAUDE_PROJECT_DIR="$TMPDIR" node "$REPO_DIR/setup.js" --workflow enable shtd 2>&1)
+check "enable shtd succeeds" 'echo "$ENABLE_OUT" | grep -qi "enabled"'
+check "config file created" '[ -f "$TMPDIR/workflow-config.json" ]'
+
+# Verify enabled state
+ENABLED=$(node -e "
+  var wf = require('$REPO_DIR/workflow.js');
+  console.log(wf.isWorkflowEnabled('shtd', '$TMPDIR') ? 'yes' : 'no');
+")
+check "shtd is enabled in config" '[ "$ENABLED" = "yes" ]'
+
+# Test --workflow disable
+DISABLE_OUT=$(CLAUDE_PROJECT_DIR="$TMPDIR" node "$REPO_DIR/setup.js" --workflow disable shtd 2>&1)
+check "disable shtd succeeds" 'echo "$DISABLE_OUT" | grep -qi "disabled"'
+
+DISABLED=$(node -e "
+  var wf = require('$REPO_DIR/workflow.js');
+  console.log(wf.isWorkflowEnabled('shtd', '$TMPDIR') ? 'yes' : 'no');
+")
+check "shtd is disabled in config" '[ "$DISABLED" = "no" ]'
+
+# Test --workflow enable another workflow (project-level only, never touch global)
+CLAUDE_PROJECT_DIR="$TMPDIR" node "$REPO_DIR/setup.js" --workflow enable code-quality 2>&1 > /dev/null
+CQ_ENABLED=$(node -e "
+  var wf = require('$REPO_DIR/workflow.js');
+  console.log(wf.isWorkflowEnabled('code-quality', '$TMPDIR') ? 'yes' : 'no');
+")
+check "code-quality enabled (project)" '[ "$CQ_ENABLED" = "yes" ]'
+
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/setup.js
+++ b/setup.js
@@ -1350,16 +1350,63 @@ function cmdWorkflow(args) {
   }
   var projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
 
+  var globalDir = path.join(HOME, ".claude", "hooks");
+
   if (!sub || sub === "list") {
     var workflows = wf.findWorkflows(projectDir);
     if (workflows.length === 0) { console.log("No workflows found."); return; }
+    var globalEnabled = wf.enabledWorkflows(globalDir);
+    var projectEnabled = wf.enabledWorkflows(projectDir);
+    var globalConfig = wf.readConfig(globalDir);
+    var projectConfig = wf.readConfig(projectDir);
     for (var wi = 0; wi < workflows.length; wi++) {
       var w = workflows[wi];
-      console.log(w.name + " (" + w.steps.length + " steps) — " + (w.description || ""));
-      for (var si = 0; si < w.steps.length; si++) {
-        console.log("  " + w.steps[si].id + ": " + w.steps[si].name);
+      var modCount = (w.modules || []).length;
+      // Determine effective enabled state (project overrides global)
+      var state = "off";
+      if (globalConfig[w.name] === true) state = "global";
+      if (projectConfig[w.name] === true) state = "project";
+      if (projectConfig[w.name] === false) state = "off (project override)";
+      if (globalConfig[w.name] === false && !projectConfig.hasOwnProperty(w.name)) state = "off";
+      var stateLabel = state === "off" || state.startsWith("off") ? "  " : "ON";
+      console.log("[" + stateLabel + "] " + w.name + " — " + modCount + " modules — " + (w.description || ""));
+      if (modCount > 0) {
+        console.log("     modules: " + (w.modules || []).join(", "));
+      }
+      if (w.steps.length > 1 || (w.steps.length === 1 && w.steps[0].id !== "active")) {
+        console.log("     steps: " + w.steps.map(function(s) { return s.id; }).join(" → "));
       }
     }
+    return;
+  }
+
+  if (sub === "enable") {
+    var enName = args[args.indexOf("enable") + 1];
+    if (!enName) { console.error("Usage: --workflow enable <name> [--global]"); process.exit(1); }
+    var isGlobal = args.indexOf("--global") !== -1;
+    var targetDir = isGlobal ? globalDir : projectDir;
+    var workflows = wf.findWorkflows(projectDir);
+    var found = false;
+    for (var ei = 0; ei < workflows.length; ei++) {
+      if (workflows[ei].name === enName) { found = true; break; }
+    }
+    if (!found) { console.error("Workflow not found: " + enName); process.exit(1); }
+    wf.enableWorkflow(enName, targetDir);
+    var scope = isGlobal ? "globally" : "for this project";
+    console.log('Enabled workflow "' + enName + '" ' + scope + ".");
+    var mods = workflows.filter(function(w) { return w.name === enName; })[0].modules || [];
+    if (mods.length > 0) console.log("  " + mods.length + " module(s) now active: " + mods.join(", "));
+    return;
+  }
+
+  if (sub === "disable") {
+    var disName = args[args.indexOf("disable") + 1];
+    if (!disName) { console.error("Usage: --workflow disable <name> [--global]"); process.exit(1); }
+    var isGlobalDis = args.indexOf("--global") !== -1;
+    var targetDirDis = isGlobalDis ? globalDir : projectDir;
+    wf.disableWorkflow(disName, targetDirDis);
+    var scopeDis = isGlobalDis ? "globally" : "for this project";
+    console.log('Disabled workflow "' + disName + '" ' + scopeDis + ".");
     return;
   }
 
@@ -1419,7 +1466,7 @@ function cmdWorkflow(args) {
   }
 
   console.error("Unknown workflow subcommand: " + sub);
-  console.error("Usage: --workflow [list|start <name>|status|complete <step>|reset]");
+  console.error("Usage: --workflow [list|enable <name>|disable <name>|start <name>|status|complete <step>|reset]");
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary
- `--workflow enable <name> [--global]` — enable a workflow (project or global)
- `--workflow disable <name> [--global]` — disable a workflow
- `--workflow list` now shows [ON]/[  ] status, module count, module names, step pipeline
- Test isolation: PID-unique temp dirs prevent cross-test contamination
- `.test-tmp-*` added to .gitignore

## Test plan
- [x] `test-T101-workflow-cli.sh` — 8/8 pass
- [x] `node setup.js --test` — 214/214 pass across 17 suites