### PR TITLE
T103: Add --workflow query command

### DIFF
--- a/scripts/test/test-T103-workflow-query.sh
+++ b/scripts/test/test-T103-workflow-query.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Test T103: --workflow query <tool> command
+set -euo pipefail
+REPO_DIR="$(cd "$(dirname "$0")/../.." && (pwd -W 2>/dev/null || pwd))"
+PASS=0; FAIL=0
+check() {
+  if eval "$2"; then PASS=$((PASS+1)); echo "  PASS: $1"
+  else FAIL=$((FAIL+1)); echo "  FAIL: $1"; fi
+}
+echo "=== hook-runner: workflow query ==="
+
+# 1. Query for Edit shows results
+EDIT_OUT=$(cd "$REPO_DIR" && node setup.js --workflow query Edit 2>&1) || true
+check "query Edit shows results" 'echo "$EDIT_OUT" | grep -q "Edit"'
+
+# 2. Query for Edit shows spec-gate (known to check Edit)
+check "query Edit includes spec-gate" 'echo "$EDIT_OUT" | grep -q "spec-gate"'
+
+# 3. Query for Bash shows results
+BASH_OUT=$(cd "$REPO_DIR" && node setup.js --workflow query Bash 2>&1) || true
+check "query Bash shows results" 'echo "$BASH_OUT" | grep -q "Bash"'
+
+# 4. Query for unknown tool shows no matches
+UNKNOWN_OUT=$(cd "$REPO_DIR" && node setup.js --workflow query FooBarTool 2>&1) || true
+check "query unknown tool shows no matches" 'echo "$UNKNOWN_OUT" | grep -qi "no modules"'
+
+# 5. Query with no tool shows usage
+NOARG_OUT=$(cd "$REPO_DIR" && node setup.js --workflow query 2>&1) || true
+check "query no arg shows usage" 'echo "$NOARG_OUT" | grep -qi "usage"'
+
+# 6. Shows workflow names in output
+check "query shows workflow names" 'echo "$EDIT_OUT" | grep -q "shtd\|code-quality"'
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/setup.js
+++ b/setup.js
@@ -1601,8 +1601,43 @@ function cmdWorkflow(args) {
     return;
   }
 
+  if (sub === "query") {
+    var queryTool = args[args.indexOf("query") + 1];
+    if (!queryTool) { console.error("Usage: --workflow query <tool-name> (e.g. Edit, Write, Bash)"); process.exit(1); }
+    var lmq;
+    try { lmq = require(path.join(__dirname, "load-modules.js")); } catch(e) {
+      console.error("[query] load-modules.js not found."); process.exit(1);
+    }
+    // Scan all PreToolUse modules for references to the queried tool
+    var modulesDir = path.join(__dirname, "modules", "PreToolUse");
+    var matches = [];
+    if (fs.existsSync(modulesDir)) {
+      var files = fs.readdirSync(modulesDir).filter(function(f) { return f.endsWith(".js"); }).sort();
+      for (var qi = 0; qi < files.length; qi++) {
+        try {
+          var src = fs.readFileSync(path.join(modulesDir, files[qi]), "utf-8");
+          // Check if module source references the tool name (case-sensitive match for tool names)
+          var toolPattern = new RegExp('["\'\\s]' + queryTool + '["\'\\s,;)\\]]', 'g');
+          if (toolPattern.test(src)) {
+            var tag = lmq.parseWorkflowTag(path.join(modulesDir, files[qi]));
+            matches.push({ name: files[qi].replace(/\.js$/, ""), workflow: tag || "(untagged)" });
+          }
+        } catch(e) {}
+      }
+    }
+    console.log("Modules affecting " + queryTool + ":");
+    if (matches.length === 0) {
+      console.log("  No modules found matching tool: " + queryTool);
+    } else {
+      for (var mi3 = 0; mi3 < matches.length; mi3++) {
+        console.log("  " + matches[mi3].name + " — workflow: " + matches[mi3].workflow);
+      }
+    }
+    return;
+  }
+
   console.error("Unknown workflow subcommand: " + sub);
-  console.error("Usage: --workflow [list|audit|enable <name>|disable <name>|start <name>|status|complete <step>|reset]");
+  console.error("Usage: --workflow [list|audit|query <tool>|enable <name>|disable <name>|start <name>|status|complete <step>|reset]");
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary
- Adds `--workflow query <tool>` CLI command
- Scans PreToolUse modules for tool name references, shows matching modules with workflow tags
- Example: `--workflow query Edit` shows spec-gate, no-hardcoded-paths, etc.
- 6 new tests, 227 total passing

## Test plan
- [x] `bash scripts/test/test-T103-workflow-query.sh` — 6 pass
- [x] `node setup.js --test` — 227/227 pass