### PR TITLE
T113-T115: Workflow CRUD + sync-live commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ Full catalog in `modules/` directory:
 | `secret-scan-gate` | Blocks git commit if staged diff contains API keys, tokens, or passwords |
 | `settings-change-gate` | Injects reminder to state rationale when modifying ~/.claude/ config |
 | `spec-gate` | Blocks code without specs/tasks.md |
+| `why-reminder` | Non-blocking WHY-first reminder before every Write/Edit to code/docs |
 | `workflow-gate` | Enforces step order in active workflows |
 
 #### Project-Scoped PreToolUse

--- a/TODO.md
+++ b/TODO.md
@@ -125,7 +125,18 @@ On context reset, Claude reads workflow state and immediately knows all active c
 - [x] T102: Add `--workflow audit` — list orphan modules, workflow coverage report
 - [x] T103: Add `--workflow query <tool>` — show which workflows affect Bash/Edit/Write
 - [x] T104: Update SessionStart module to inject active workflow summary on context reset
-- [ ] T105: Update docs (README, CLAUDE.md, SKILL.md) + version bump + marketplace sync
+- [x] T105: Update docs (README, CLAUDE.md, SKILL.md) + version bump to 1.6.0
+- [x] T112: Add why-reminder PreToolUse gate + WHY in all SHTD block messages
+
+## Workflow CRUD Automation (T113)
+
+WHY: Creating/editing workflows requires touching 3+ files (YAML, module, live copy).
+Manual file management is error-prone and breaks the principle that workflows are the
+primary abstraction. Automate CRUD so workflows are first-class CLI citizens.
+
+- [ ] T113: Add `--workflow create <name>` — generates YAML + optional module stubs + copies to live
+- [ ] T114: Add `--workflow add-module <workflow> <module>` — creates module file with WORKFLOW tag + WHY stub, adds to YAML, copies to live
+- [ ] T115: Add `--workflow sync` — copies all workflow YAMLs + tagged modules to live hooks dir
 
 ## Reduced-Friction SHTD + Dispatcher/Worker Model (T106+)
 
@@ -144,10 +155,10 @@ so the workflow scales naturally from one Claude to a CCC fleet.
 - [ ] T111: Document dispatcher/worker model in README + CLAUDE.md
 
 ## Status
-- 104 tasks completed, 7 pending
-- Next: T105 (docs + release), then T106-T111 (dispatcher/worker model)
-- Version: 1.5.1
-- 233 tests passing across 20 test suites
+- 106 tasks completed, 9 pending
+- Next: T113-T115 (workflow CRUD), then T106-T111 (dispatcher/worker model)
+- Version: 1.6.0
+- 240+ tests passing across 21 test suites
 - CI: GitHub Actions runs all tests on push/PR — badge in README
 - Workflow engine: workflow.js + workflow-gate.js + 9 built-in workflow templates
 - CLI commands: setup, report, dry-run, health, sync, stats, list, test, upgrade, uninstall, prune, version, help, workflow (list/audit/query/enable/disable/start/status/complete/reset), perf, export

--- a/scripts/test/test-T113-workflow-create.sh
+++ b/scripts/test/test-T113-workflow-create.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Test T113: --workflow create command
+# WHY: Manual workflow creation requires editing 3+ files. This test ensures
+# the CLI automates YAML generation, module stubs, and live sync correctly.
+set -euo pipefail
+REPO_DIR="$(cd "$(dirname "$0")/../.." && (pwd -W 2>/dev/null || pwd))"
+PASS=0; FAIL=0
+check() {
+  if eval "$2"; then PASS=$((PASS+1)); echo "  PASS: $1"
+  else FAIL=$((FAIL+1)); echo "  FAIL: $1"; fi
+}
+echo "=== hook-runner: workflow create ==="
+
+TMPDIR="$REPO_DIR/.test-tmp-T113-$$"
+mkdir -p "$TMPDIR/workflows"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# 1. Create a workflow
+CREATE_OUT=$(cd "$REPO_DIR" && node setup.js --workflow create test-wf --dir "$TMPDIR" 2>&1) || true
+check "create succeeds" 'echo "$CREATE_OUT" | grep -qi "created"'
+
+# 2. YAML file exists
+check "YAML file created" '[ -f "$TMPDIR/workflows/test-wf.yml" ]'
+
+# 3. YAML has correct name
+check "YAML has name field" 'grep -q "name: test-wf" "$TMPDIR/workflows/test-wf.yml"'
+
+# 4. YAML has description field
+check "YAML has description" 'grep -q "description:" "$TMPDIR/workflows/test-wf.yml"'
+
+# 5. YAML has modules section
+check "YAML has modules section" 'grep -q "modules:" "$TMPDIR/workflows/test-wf.yml"'
+
+# 6. YAML has steps section
+check "YAML has steps section" 'grep -q "steps:" "$TMPDIR/workflows/test-wf.yml"'
+
+# 7. No arg shows usage
+NOARG_OUT=$(cd "$REPO_DIR" && node setup.js --workflow create 2>&1) || true
+check "no arg shows usage" 'echo "$NOARG_OUT" | grep -qi "usage"'
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/scripts/test/test-T114-workflow-add-module.sh
+++ b/scripts/test/test-T114-workflow-add-module.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Test T114: --workflow add-module and --workflow sync-live
+# WHY: Automating module creation prevents tag mismatches, missing WHY stubs,
+# and forgotten live sync — the three most common workflow maintenance errors.
+set -euo pipefail
+REPO_DIR="$(cd "$(dirname "$0")/../.." && (pwd -W 2>/dev/null || pwd))"
+PASS=0; FAIL=0
+check() {
+  if eval "$2"; then PASS=$((PASS+1)); echo "  PASS: $1"
+  else FAIL=$((FAIL+1)); echo "  FAIL: $1"; fi
+}
+echo "=== hook-runner: workflow add-module ==="
+
+# Test add-module to existing workflow (code-quality)
+# Use a temp module name that won't conflict
+TMPMOD="test-tmp-mod-$$"
+
+ADD_OUT=$(cd "$REPO_DIR" && node setup.js --workflow add-module code-quality "$TMPMOD" 2>&1) || true
+check "add-module succeeds" 'echo "$ADD_OUT" | grep -qi "created"'
+
+# Module file exists
+check "module file created" '[ -f "$REPO_DIR/modules/PreToolUse/$TMPMOD.js" ]'
+
+# Module has WORKFLOW tag
+check "module has WORKFLOW tag" 'head -1 "$REPO_DIR/modules/PreToolUse/$TMPMOD.js" | grep -q "WORKFLOW: code-quality"'
+
+# Module has WHY stub
+check "module has WHY stub" 'grep -q "WHY: TODO" "$REPO_DIR/modules/PreToolUse/$TMPMOD.js"'
+
+# Module added to YAML
+check "module in YAML" 'grep -q "$TMPMOD" "$REPO_DIR/workflows/code-quality.yml"'
+
+# No arg shows usage
+NOARG_OUT=$(cd "$REPO_DIR" && node setup.js --workflow add-module 2>&1) || true
+check "no arg shows usage" 'echo "$NOARG_OUT" | grep -qi "usage"'
+
+# Test sync-live
+SYNC_OUT=$(cd "$REPO_DIR" && node setup.js --workflow sync-live 2>&1) || true
+check "sync-live succeeds" 'echo "$SYNC_OUT" | grep -qi "synced"'
+
+# Live copy exists
+check "live copy exists" '[ -f "$HOME/.claude/hooks/run-modules/PreToolUse/$TMPMOD.js" ]'
+
+# Cleanup: remove temp module from repo and live
+rm -f "$REPO_DIR/modules/PreToolUse/$TMPMOD.js"
+rm -f "$HOME/.claude/hooks/run-modules/PreToolUse/$TMPMOD.js"
+# Remove from YAML
+cd "$REPO_DIR" && git checkout -- workflows/code-quality.yml 2>/dev/null || true
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/setup.js
+++ b/setup.js
@@ -1636,8 +1636,147 @@ function cmdWorkflow(args) {
     return;
   }
 
+  if (sub === "create") {
+    var createName = args[args.indexOf("create") + 1];
+    if (!createName) { console.error("Usage: --workflow create <name> [--dir <path>]"); process.exit(1); }
+    // WHY: Manual workflow creation requires editing YAML, module files, and live copies.
+    // This command generates a complete scaffold so workflows are a first-class CLI citizen.
+    var dirIdx = args.indexOf("--dir");
+    var targetBase = dirIdx !== -1 && args[dirIdx + 1] ? args[dirIdx + 1] : __dirname;
+    var wfDir = path.join(targetBase, "workflows");
+    if (!fs.existsSync(wfDir)) fs.mkdirSync(wfDir, { recursive: true });
+    var wfPath = path.join(wfDir, createName + ".yml");
+    if (fs.existsSync(wfPath)) {
+      console.error('Workflow "' + createName + '" already exists at ' + wfPath);
+      process.exit(1);
+    }
+    var yaml = [
+      "name: " + createName,
+      "description: TODO — explain WHY this workflow exists and what problem it solves",
+      "version: 1",
+      "steps:",
+      "  - id: active",
+      "    name: Workflow is active",
+      "    gate:",
+      "      require_files: []",
+      "    completion:",
+      "      require_files: []",
+      "",
+      "modules: []",
+      "",
+    ].join("\n");
+    fs.writeFileSync(wfPath, yaml);
+    console.log('Created workflow "' + createName + '" at ' + wfPath);
+    console.log("Next steps:");
+    console.log("  1. Edit description to explain WHY this workflow exists");
+    console.log("  2. Add modules: --workflow add-module " + createName + " <module-name>");
+    console.log("  3. Enable: --workflow enable " + createName);
+    return;
+  }
+
+  if (sub === "add-module") {
+    var addWfName = args[args.indexOf("add-module") + 1];
+    var addModName = args[args.indexOf("add-module") + 2];
+    if (!addWfName || !addModName) {
+      console.error("Usage: --workflow add-module <workflow> <module-name> [--event <Event>]");
+      process.exit(1);
+    }
+    // WHY: Adding a module to a workflow requires creating a JS file with the right tag,
+    // updating the YAML modules list, and copying to live hooks. Automate all three.
+    var evIdx = args.indexOf("--event");
+    var event = evIdx !== -1 && args[evIdx + 1] ? args[evIdx + 1] : "PreToolUse";
+    var modDir = path.join(__dirname, "modules", event);
+    if (!fs.existsSync(modDir)) fs.mkdirSync(modDir, { recursive: true });
+    var modPath = path.join(modDir, addModName + ".js");
+    if (fs.existsSync(modPath)) {
+      console.log('Module "' + addModName + '" already exists. Updating WORKFLOW tag and YAML.');
+    } else {
+      // WHY: Every module must trace back to a real incident or design decision.
+      // The stub forces the author to fill in WHY before the module does anything.
+      var stub = [
+        "// WORKFLOW: " + addWfName,
+        '// WHY: TODO — describe the real incident or problem that caused this module.',
+        '"use strict";',
+        "",
+        "module.exports = function(input) {",
+        "  // TODO: implement gate logic",
+        "  return null;",
+        "};",
+        "",
+      ].join("\n");
+      fs.writeFileSync(modPath, stub);
+      console.log("Created module: " + modPath);
+    }
+    // Update YAML modules list
+    var wfDir2 = path.join(__dirname, "workflows");
+    var wfPath2 = path.join(wfDir2, addWfName + ".yml");
+    if (fs.existsSync(wfPath2)) {
+      var content = fs.readFileSync(wfPath2, "utf-8");
+      if (content.indexOf("  - " + addModName) === -1) {
+        // Add module to modules list
+        content = content.replace(/^modules:\s*\[?\]?/m, "modules:\n  - " + addModName);
+        if (content.indexOf("modules:") === -1) {
+          content += "\nmodules:\n  - " + addModName + "\n";
+        } else if (content.indexOf("  - " + addModName) === -1) {
+          content = content.replace(/(modules:.*\n(?:\s+-\s+\S+\n)*)/m, "$1  - " + addModName + "\n");
+        }
+        fs.writeFileSync(wfPath2, content);
+        console.log("Added to " + wfPath2);
+      } else {
+        console.log("Module already listed in " + wfPath2);
+      }
+    } else {
+      console.log("Warning: workflow YAML not found at " + wfPath2);
+    }
+    // Copy to live hooks
+    var liveDir = path.join(HOME, ".claude", "hooks", "run-modules", event);
+    if (fs.existsSync(liveDir)) {
+      try {
+        fs.copyFileSync(modPath, path.join(liveDir, addModName + ".js"));
+        console.log("Copied to live: " + path.join(liveDir, addModName + ".js"));
+      } catch(e) {
+        console.log("Warning: could not copy to live hooks: " + e.message);
+      }
+    }
+    return;
+  }
+
+  if (sub === "sync-live") {
+    // WHY: After editing modules/workflows in the repo, the live hooks dir
+    // needs to be updated. This copies all workflow YAMLs and tagged modules.
+    var home = process.env.HOME || process.env.USERPROFILE || "";
+    var liveHooksDir = path.join(home, ".claude", "hooks");
+    var liveWfDir = path.join(liveHooksDir, "workflows");
+    if (!fs.existsSync(liveWfDir)) fs.mkdirSync(liveWfDir, { recursive: true });
+    // Sync workflow YAMLs
+    var srcWfDir = path.join(__dirname, "workflows");
+    var copied = 0;
+    if (fs.existsSync(srcWfDir)) {
+      var wfFiles = fs.readdirSync(srcWfDir).filter(function(f) { return f.endsWith(".yml") || f.endsWith(".yaml"); });
+      for (var wi2 = 0; wi2 < wfFiles.length; wi2++) {
+        fs.copyFileSync(path.join(srcWfDir, wfFiles[wi2]), path.join(liveWfDir, wfFiles[wi2]));
+        copied++;
+      }
+    }
+    // Sync modules
+    var events = ["PreToolUse", "PostToolUse", "SessionStart", "Stop", "UserPromptSubmit"];
+    for (var ei2 = 0; ei2 < events.length; ei2++) {
+      var srcModDir = path.join(__dirname, "modules", events[ei2]);
+      var dstModDir = path.join(liveHooksDir, "run-modules", events[ei2]);
+      if (!fs.existsSync(srcModDir)) continue;
+      if (!fs.existsSync(dstModDir)) fs.mkdirSync(dstModDir, { recursive: true });
+      var mods = fs.readdirSync(srcModDir).filter(function(f) { return f.endsWith(".js"); });
+      for (var mi4 = 0; mi4 < mods.length; mi4++) {
+        fs.copyFileSync(path.join(srcModDir, mods[mi4]), path.join(dstModDir, mods[mi4]));
+        copied++;
+      }
+    }
+    console.log("Synced " + copied + " files to " + liveHooksDir);
+    return;
+  }
+
   console.error("Unknown workflow subcommand: " + sub);
-  console.error("Usage: --workflow [list|audit|query <tool>|enable <name>|disable <name>|start <name>|status|complete <step>|reset]");
+  console.error("Usage: --workflow [list|audit|query|create|add-module|sync-live|enable|disable|start|status|complete|reset]");
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary
- `--workflow create <name>` — generates YAML scaffold with WHY stub and next-steps guidance
- `--workflow add-module <workflow> <module>` — creates tagged JS module, updates YAML, copies to live hooks
- `--workflow sync-live` — copies all workflows + modules from repo to ~/.claude/hooks/
- 15 new tests across 2 suites, 264 total passing

## Test plan
- [x] `bash scripts/test/test-T113-workflow-create.sh` — 7 pass
- [x] `bash scripts/test/test-T114-workflow-add-module.sh` — 8 pass
- [x] `node setup.js --test` — 264/264 pass (24 suites)