### PR TITLE
T217: Audit fixes and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,5 @@ archive/
 .test-results/
 SESSION_STATE.md
 .test-tmp-*
-.test-debug-85134-done/
 .workflow-state.json
-.test-tmp-*
+workflow-config.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Modular hook runner for Claude Code. Workflows group modules into enforceable pi
 - `modules/` — distributable module catalog organized by event type
 - `workflows/` — built-in workflow definitions (YAML)
 - `specs/` — feature specs with tasks and checkpoints
-- `scripts/test/` — test scripts (37 suites, 360+ tests)
+- `scripts/test/` — test scripts (38 suites, 369+ tests)
 - `package.json` — npm package (enables `npx grobomo/hook-runner`)
 
 ## Testing

--- a/modules/PreToolUse/workflow-gate.js
+++ b/modules/PreToolUse/workflow-gate.js
@@ -1,3 +1,4 @@
+// WORKFLOW: shtd
 "use strict";
 // WHY: Steps in a workflow were skipped — build ran before setup, deploy before test.
 // Workflow gate: enforces step order in active workflows.


### PR DESCRIPTION
## Summary
- Add missing `// WORKFLOW: shtd` tag to workflow-gate.js
- Add workflow-config.json to .gitignore (local state)
- Remove duplicate .test-tmp-* and stale .test-debug entry from .gitignore
- Update CLAUDE.md test counts (38 suites, 369+ tests)

## Test plan
- 38 suites, 369 tests, 0 failures
- `--workflow audit` now shows 0 untagged modules