### PR TITLE
T218: Write Your First Module tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,28 @@ Rules:
 | **PostToolUse** | After Edit/Write | `{decision: "block"}` or `null` |
 | **Stop** | Session ending | `{decision: "block"}` or `null` |
 
+### Write Your First Module
+
+Create a file that blocks `rm -rf` commands:
+
+```bash
+# Create the module file
+cat > ~/.claude/hooks/run-modules/PreToolUse/no-rm-rf.js << 'EOF'
+// WORKFLOW: shtd
+// WHY: Accidentally ran rm -rf on a project directory.
+module.exports = function(input) {
+  if (input.tool_name !== "Bash") return null;
+  var cmd = (input.tool_input || {}).command || "";
+  if (/rm\s+-rf/.test(cmd)) {
+    return { decision: "block", reason: "Blocked rm -rf. Use archive/ instead." };
+  }
+  return null;
+};
+EOF
+```
+
+That's it. Next time Claude tries `rm -rf`, this module blocks it with a helpful message. No settings.json changes needed — the runner auto-discovers modules in the folder.
+
 ### Project-Scoped Modules
 
 Modules in a subfolder matching your project name only run for that project:

--- a/TODO.md
+++ b/TODO.md
@@ -193,8 +193,12 @@ See `specs/watchdog/tasks.md` for full task list.
 - [x] T125-T127: Scheduler integration (--install, --uninstall, --status)
 - [x] T128-T129: SessionStart alert integration + --log command
 
+## Docs & Polish
+- [x] T217: Audit fixes — workflow-gate tag, gitignore cleanup, test count update
+- [x] T218: Write Your First Module tutorial in README
+
 ## Status
-- 138 tasks completed, 5 pending (1 delegated to claude-code-skills)
+- 140 tasks completed, 3 pending (1 delegated to claude-code-skills)
 - Active: T201+ (publish-ready), T116-T121 (drift detector + runner fixes), T106-T111 (dispatcher/worker)
 - Version: 2.0.0
 - 369 tests passing across 38 test suites


### PR DESCRIPTION
## Summary
- Adds a step-by-step tutorial showing how to create a custom module
- Uses a practical example (blocking rm -rf) that's immediately useful
- Placed after the Module Contract section, before Project-Scoped Modules

## Test plan
- No code changes — documentation only