### PR TITLE
T222: Add split workflows to watchdog required list

### DIFF
--- a/scripts/test/test-T122-watchdog.sh
+++ b/scripts/test/test-T122-watchdog.sh
@@ -80,7 +80,7 @@ fi
 # Test 7: missing config file → uses defaults
 rm -f "$TMPDIR/watchdog-config.json"
 echo "// stub" > "$TMPDIR/run-stop.js"
-echo '{"shtd": true}' > "$TMPDIR/workflow-config.json"
+echo '{"shtd": true, "code-quality": true, "self-improvement": true, "session-management": true, "messaging-safety": true}' > "$TMPDIR/workflow-config.json"
 EC4=0
 OUT4=$(node watchdog.js --hooks-dir "$TMPDIR" 2>&1) || EC4=$?
 assert "no config file uses defaults" "0" "$EC4"

--- a/scripts/test/test-T216-e2e-fresh-install.sh
+++ b/scripts/test/test-T216-e2e-fresh-install.sh
@@ -76,7 +76,7 @@ for r in run-pretooluse.js run-posttooluse.js run-stop.js run-sessionstart.js ru
 done
 echo 'module.exports = function() { return null; };' > "$TMPDIR/run-modules/Stop/auto-continue.js"
 echo 'module.exports = function() { return null; };' > "$TMPDIR/run-modules/PreToolUse/branch-pr-gate.js"
-echo '{"shtd": true}' > "$TMPDIR/workflow-config.json"
+echo '{"shtd": true, "code-quality": true, "self-improvement": true, "session-management": true, "messaging-safety": true}' > "$TMPDIR/workflow-config.json"
 
 EC=0
 OUT=$(node watchdog.js --hooks-dir "$TMPDIR" --config watchdog-config.json 2>&1) || EC=$?

--- a/watchdog-config.json
+++ b/watchdog-config.json
@@ -1,5 +1,5 @@
 {
-  "required_workflows": ["shtd"],
+  "required_workflows": ["shtd", "code-quality", "self-improvement", "session-management", "messaging-safety"],
   "required_runners": [
     "run-pretooluse.js",
     "run-posttooluse.js",

--- a/watchdog.js
+++ b/watchdog.js
@@ -22,7 +22,7 @@ const configFile = getArg('--config') || path.join(hooksDir, 'watchdog-config.js
 
 // --- Load watchdog config (what "healthy" looks like) ---
 const DEFAULT_CONFIG = {
-  required_workflows: ['shtd'],
+  required_workflows: ['shtd', 'code-quality', 'self-improvement', 'session-management', 'messaging-safety'],
   required_runners: [
     'run-pretooluse.js', 'run-posttooluse.js', 'run-stop.js',
     'run-sessionstart.js', 'run-userpromptsubmit.js',


### PR DESCRIPTION
## Summary
- Watchdog now monitors all 5 enabled workflows (was only shtd)
- Updated DEFAULT_CONFIG in watchdog.js to match
- Fixed T122 and T216 tests to set all required workflows in temp environments

## Test plan
- [x] 38 suites, 369 passed, 0 failed