### PR TITLE
T224: Exclude archive/ from --list project-scoped scan

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -1004,7 +1004,7 @@ function cmdList() {
     try {
       var liveEvtDir = path.join(liveDir, events[pe]);
       var liveEntries = fs.readdirSync(liveEvtDir, { withFileTypes: true });
-      var projDirs = liveEntries.filter(function(e) { return e.isDirectory(); });
+      var projDirs = liveEntries.filter(function(e) { return e.isDirectory() && e.name !== "archive"; });
       for (var pd = 0; pd < projDirs.length; pd++) {
         var projPath = path.join(liveEvtDir, projDirs[pd].name);
         var projMods = fs.readdirSync(projPath).filter(function(f) { return f.endsWith(".js"); });


### PR DESCRIPTION
## Summary
- `--list` was showing archived modules under "Project-scoped" because it scanned all subdirectories including `archive/`
- Now skips `archive/` directories, matching `load-modules.js` behavior (line 164)
- Also cleaned up 6 redundant `shtd_*` live modules (archived, saving ~140ms per tool call)

## Test plan
- [x] `--list` no longer shows archive/ entries
- [x] 38 suites, 369 tests passing