### PR TITLE
T226: Version bump to 2.2.0

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -211,9 +211,12 @@ See `specs/watchdog/tasks.md` for full task list.
 ## Refactor
 - [x] T225: Extract cmdWorkflow into workflow-cli.js (setup.js 2041→1598 lines, PR #106)
 
+## Release
+- [x] T226: Version bump to 2.2.0
+
 ## Status
-- 147 tasks completed, 1 pending (T215 delegated to claude-code-skills)
-- Version: 2.1.0
+- 148 tasks completed, 1 pending (T215 delegated to claude-code-skills)
+- Version: 2.2.0
 - 369 tests passing across 38 test suites
 - CI: GitHub Actions runs tests + secret-scan on push/PR — badge in README
 - Workflow engine: workflow.js + workflow-gate.js + 10 built-in workflow templates

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"

--- a/scripts/test/test-T105-docs-release.sh
+++ b/scripts/test/test-T105-docs-release.sh
@@ -9,11 +9,14 @@ check() {
 }
 echo "=== hook-runner: docs & release ==="
 
-# 1. Version bumped in setup.js
-check "setup.js version is 2.1.0" 'grep -q "2.1.0" "$REPO_DIR/setup.js"'
+# Extract expected version from setup.js
+EXPECTED_VER=$(grep -oP 'VERSION = "\K[^"]+' "$REPO_DIR/setup.js")
 
-# 2. Version bumped in package.json
-check "package.json version is 2.1.0" 'grep -q "2.1.0" "$REPO_DIR/package.json"'
+# 1. Version in setup.js matches package.json
+check "setup.js version is $EXPECTED_VER" 'grep -q "\"$EXPECTED_VER\"" "$REPO_DIR/setup.js"'
+
+# 2. package.json version matches setup.js
+check "package.json version is $EXPECTED_VER" 'grep -q "\"$EXPECTED_VER\"" "$REPO_DIR/package.json"'
 
 # 3. CLAUDE.md has updated test counts
 check "CLAUDE.md has updated test counts" 'grep -qE "[0-9]+ suites" "$REPO_DIR/CLAUDE.md"'

--- a/scripts/test/test-T216-e2e-fresh-install.sh
+++ b/scripts/test/test-T216-e2e-fresh-install.sh
@@ -18,11 +18,12 @@ assert() {
 }
 
 # Test 1: setup.js loads and shows version
+EXPECTED_VER=$(grep -oP 'VERSION = "\K[^"]+' setup.js)
 OUT=$(node setup.js --version 2>&1)
-if echo "$OUT" | grep -q "2.1.0"; then
-  assert "version is 2.1.0" "0" "0"
+if echo "$OUT" | grep -q "$EXPECTED_VER"; then
+  assert "version is $EXPECTED_VER" "0" "0"
 else
-  assert "version is 2.1.0" "0" "1"
+  assert "version is $EXPECTED_VER" "0" "1"
 fi
 
 # Test 2: --dry-run --yes completes without error

--- a/setup.js
+++ b/setup.js
@@ -46,7 +46,7 @@ var SCRIPT_DIR = __dirname;
 var REPO_DIR = SCRIPT_DIR;
 
 var HOOK_LOG_PATH = path.join(HOOKS_DIR, "hook-log.jsonl");
-var VERSION = "2.1.0";
+var VERSION = "2.2.0";
 
 // ============================================================
 // 0. Hook Log Stats


### PR DESCRIPTION
## Summary
- Version bump 2.1.0 → 2.2.0 for 8 PRs since last release (#100-#107)
- Fixed hardcoded version strings in test-T105 and test-T216 — tests now dynamically extract expected version from setup.js

## Changes since v2.1.0
- T218: Write Your First Module tutorial
- T220: Fix 34 workflow tag mismatches
- T221: README workflow table update
- T222: Watchdog required workflows update
- T223: Duplicate module detection in health check
- T224: --list skips archive/ dirs
- T225: Extract workflow-cli.js (setup.js 2041→1598 lines)

## Test plan
- [x] test-T105 and test-T216 pass with dynamic version
- [x] Full suite running in background