### PR TITLE
T227: Add Windows path normalization to PreToolUse runner

### DIFF
--- a/run-pretooluse.js
+++ b/run-pretooluse.js
@@ -15,6 +15,14 @@ try {
   process.exit(0);
 }
 
+// WHY: Windows tools pass backslash paths — modules expect forward slashes for consistent matching.
+if (input && input.tool_input && typeof input.tool_input.file_path === "string") {
+  input.tool_input.file_path = input.tool_input.file_path.replace(/\\/g, "/");
+}
+if (input && input.tool_input && typeof input.tool_input.path === "string") {
+  input.tool_input.path = input.tool_input.path.replace(/\\/g, "/");
+}
+
 var ctx = hookLog.extractContext("PreToolUse", input);
 var modules = loadModules(path.join(__dirname, "run-modules", "PreToolUse"));
 

--- a/scripts/test/test-T117-posttooluse-runner.sh
+++ b/scripts/test/test-T117-posttooluse-runner.sh
@@ -43,6 +43,19 @@ else
   assert "loads PostToolUse modules" "0" "1"
 fi
 
+# Test: PreToolUse runner also normalizes Windows paths (T227)
+if grep -q 'file_path.*replace.*\\\\' run-pretooluse.js 2>/dev/null; then
+  assert "PreToolUse has file_path backslash normalization" "0" "0"
+else
+  assert "PreToolUse has file_path backslash normalization" "0" "1"
+fi
+
+if grep -q 'tool_input.path.*replace.*\\\\' run-pretooluse.js 2>/dev/null; then
+  assert "PreToolUse has path backslash normalization" "0" "0"
+else
+  assert "PreToolUse has path backslash normalization" "0" "1"
+fi
+
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary
- PreToolUse runner now normalizes `\` to `/` in `tool_input.file_path` and `tool_input.path` before passing input to modules
- Matches existing PostToolUse behavior (added in T117)
- Prevents path matching failures on Windows for modules that don't do their own normalization
- Added test coverage for PreToolUse normalization

## Test plan
- [x] Runner tests pass (6/6)
- [x] Full test suite (background, 38 suites)