### PR TITLE
T230: Version bump to 2.2.1

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -218,13 +218,14 @@ See `specs/watchdog/tasks.md` for full task list.
 - [x] T227: Add Windows path normalization to PreToolUse runner (PR #109)
 - [x] T228: Sync 4 live modules to catalog + fix README module table (PR #110)
 - [x] T229: Sync workflow YAML module lists with actual tags (PR #111)
+- [x] T230: Version bump to 2.2.1
 
 ## Live Cleanup (session 2026-04-05b)
 - [x] Archived 4 fleet-specific shtd_ modules (task-claim, e2e-merge-gate, audit-logger, task-release) — ~320ms/call savings
 
 ## Status
-- 151 tasks completed, 1 pending (T215 delegated to claude-code-skills)
-- Version: 2.2.0
+- 152 tasks completed, 1 pending (T215 delegated to claude-code-skills)
+- Version: 2.2.1
 - 371 tests passing across 38 test suites
 - CI: GitHub Actions runs tests + secret-scan on push/PR — badge in README
 - Workflow engine: workflow.js + workflow-gate.js + 10 built-in workflow templates

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"

--- a/setup.js
+++ b/setup.js
@@ -46,7 +46,7 @@ var SCRIPT_DIR = __dirname;
 var REPO_DIR = SCRIPT_DIR;
 
 var HOOK_LOG_PATH = path.join(HOOKS_DIR, "hook-log.jsonl");
-var VERSION = "2.2.0";
+var VERSION = "2.2.1";
 
 // ============================================================
 // 0. Hook Log Stats


### PR DESCRIPTION
## Summary
Patch release for T227-T229:
- T227: PreToolUse Windows path normalization (PR #109)
- T228: 4 new catalog modules + README table fix (PR #110)
- T229: Workflow YAML module list sync (PR #111)

## Test plan
- [x] Version tests: setup.js, package.json, e2e all show 2.2.1
- [x] 21 related tests passing