### PR TITLE
T232: Show changelog diff in --upgrade output

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -226,8 +226,11 @@ See `specs/watchdog/tasks.md` for full task list.
 ## Docs
 - [x] T231: Add CHANGELOG.md covering all versions from 1.0.0 to 2.2.1
 
+## Enhancements
+- [x] T232: Show changelog diff in --upgrade output
+
 ## Status
-- 153 tasks completed, 1 pending (T215 delegated to claude-code-skills)
+- 154 tasks completed, 1 pending (T215 delegated to claude-code-skills)
 - Version: 2.2.1
 - 371 tests passing across 38 test suites
 - CI: GitHub Actions runs tests + secret-scan on push/PR — badge in README

--- a/setup.js
+++ b/setup.js
@@ -724,6 +724,26 @@ function cmdHelp() {
   console.log("  node setup.js --uninstall --dry-run  # preview removal");
 }
 
+/**
+ * Extract changelog sections between two versions.
+ * Returns text of all ## [x.y.z] sections where x.y.z is newer than localVer.
+ */
+function extractChangelogBetween(changelog, localVer, remoteVer) {
+  var lines = changelog.split("\n");
+  var collecting = false;
+  var result = [];
+  for (var i = 0; i < lines.length; i++) {
+    var heading = lines[i].match(/^## \[([^\]]+)\]/);
+    if (heading) {
+      var ver = heading[1];
+      if (ver === localVer) break; // stop at current version
+      collecting = true;
+    }
+    if (collecting) result.push(lines[i]);
+  }
+  return result.length > 0 ? result.join("\n").trim() : null;
+}
+
 function cmdUpgrade(args, dryRun) {
   console.log("[hook-runner] Upgrade");
   console.log("========================");
@@ -748,6 +768,16 @@ function cmdUpgrade(args, dryRun) {
   if (remoteVersion === VERSION && !args.includes("--force")) {
     console.log("  Already up to date. Use --force to re-download anyway.");
     return;
+  }
+  // Show what changed between versions
+  var changelog = fetchFromGitHub(source, branch, "CHANGELOG.md");
+  if (changelog) {
+    var sections = extractChangelogBetween(changelog, VERSION, remoteVersion);
+    if (sections) {
+      console.log("  What's new:");
+      console.log("  " + sections.replace(/\n/g, "\n  "));
+      console.log("");
+    }
   }
   var updated = 0, skipped = 0;
   for (var ui = 0; ui < coreFiles.length; ui++) {


### PR DESCRIPTION
## Summary
- `--upgrade` now fetches CHANGELOG.md and shows what changed between local and remote versions
- Helps users understand what they're getting before files are updated
- New `extractChangelogBetween()` helper parses version sections

## Test plan
- [x] Setup wizard tests pass (7/7)
- [x] Manual verification of changelog extraction logic