### PR TITLE
T234-T235: Fix config-sync stale lock and hardcoded branch

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -238,9 +238,12 @@ See `specs/watchdog/tasks.md` for full task list.
   - All 42 rules are enforced by hook-runner modules at the tool-call level
   - 13 active knowledge/config rules remain in ~/.claude/rules/
 
+## Bug Fix: config-sync stale lock (session 2026-04-05d)
+- [x] T234: Fix config-sync module to detect and remove stale git index.lock before `git add`
+- [x] T235: Fix config-sync to push current branch (not hardcoded `main`)
+
 ## Status
-- 156 tasks completed, 0 pending
-- All tasks complete
+- 158 tasks completed, 0 pending
 - Version: 2.2.1
 - 379 tests passing across 38 test suites
 - CI: GitHub Actions runs tests + secret-scan on push/PR — badge in README

--- a/modules/SessionStart/config-sync.js
+++ b/modules/SessionStart/config-sync.js
@@ -34,6 +34,17 @@ module.exports = function(input) {
   var lines = status.split("\n").filter(function(l) { return l.trim(); });
   var count = lines.length;
 
+  // Remove stale index.lock if present (left by crashed git processes)
+  var fs = require("fs");
+  var lockFile = path.join(claudeDir, ".git", "index.lock");
+  try {
+    var lockStat = fs.statSync(lockFile);
+    // If lock is older than 60 seconds, it's stale — remove it
+    if (Date.now() - lockStat.mtimeMs > 60000) {
+      fs.unlinkSync(lockFile);
+    }
+  } catch (e) { /* no lock file — normal */ }
+
   // Auto-commit and push
   try {
     cp.execSync("git add -A", {
@@ -56,8 +67,16 @@ module.exports = function(input) {
       });
     }
 
+    // Push current branch (not hardcoded main — repo may be on a different branch)
+    var branch = "";
     try {
-      cp.execSync("git push origin main 2>&1", {
+      branch = cp.execSync("git rev-parse --abbrev-ref HEAD", {
+        cwd: claudeDir, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"]
+      }).trim();
+    } catch (e) { branch = "main"; }
+
+    try {
+      cp.execSync("git push origin " + branch + " 2>&1", {
         cwd: claudeDir, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"],
         timeout: 15000
       });


### PR DESCRIPTION
## Summary
- Detect and remove stale git `index.lock` (>60s old) before `git add -A` — fixes session start failures when a previous git process crashed
- Push current branch instead of hardcoded `main` — fixes push failures when `~/.claude` repo is on a non-main branch

## Test plan
- [x] Verified stale lock removal logic (60s threshold prevents removing active locks)
- [x] Copied fix to live `~/.claude/hooks/run-modules/SessionStart/config-sync.js`