### PR TITLE
T237: Add module behavior test suite

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -242,9 +242,10 @@ See `specs/watchdog/tasks.md` for full task list.
 - [x] T234: Fix config-sync module to detect and remove stale git index.lock before `git add`
 - [x] T235: Fix config-sync to push current branch (not hardcoded `main`)
 - [x] T236: Add `.git/*.lock` exception to archive-not-delete gate (stale lock cleanup is standard git recovery)
+- [x] T237: Add module behavior test suite (archive-not-delete exceptions, config-sync structure)
 
 ## Status
-- 159 tasks completed, 0 pending
+- 160 tasks completed, 0 pending
 - Version: 2.2.1
 - 379 tests passing across 38 test suites
 - CI: GitHub Actions runs tests + secret-scan on push/PR — badge in README

--- a/scripts/test/test-module-behaviors.sh
+++ b/scripts/test/test-module-behaviors.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# Test specific module behaviors — edge cases, exceptions, and regression tests.
+# Unlike test-modules.sh (which validates load/call), this tests logic.
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && (pwd -W 2>/dev/null || pwd))"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+echo "=== hook-runner: module behavior tests ==="
+
+# ============================================================
+# archive-not-delete: exception patterns
+# ============================================================
+
+ARCHIVE_MOD="$REPO_DIR/modules/PreToolUse/archive-not-delete.js"
+
+test_archive_block() {
+  local desc="$1" cmd="$2"
+  local input="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"$cmd\"}}"
+  local result
+  result=$(node -e "
+    var m = require('$ARCHIVE_MOD');
+    var r = m($input);
+    console.log(r && r.decision === 'block' ? 'block' : 'pass');
+  " 2>/dev/null)
+  if [ "$result" = "block" ]; then
+    pass "archive-not-delete blocks: $desc"
+  else
+    fail "archive-not-delete should block: $desc"
+  fi
+}
+
+test_archive_pass() {
+  local desc="$1" cmd="$2"
+  local input="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"$cmd\"}}"
+  local result
+  result=$(node -e "
+    var m = require('$ARCHIVE_MOD');
+    var r = m($input);
+    console.log(r && r.decision === 'block' ? 'block' : 'pass');
+  " 2>/dev/null)
+  if [ "$result" = "pass" ]; then
+    pass "archive-not-delete allows: $desc"
+  else
+    fail "archive-not-delete should allow: $desc"
+  fi
+}
+
+echo ""
+echo "[archive-not-delete] destructive commands blocked"
+test_archive_block "rm user file" "rm ~/Documents/important.txt"
+test_archive_block "rm -rf directory" "rm -rf some-project"
+test_archive_block "rmdir" "rmdir /some/dir"
+
+echo ""
+echo "[archive-not-delete] exceptions allowed"
+test_archive_pass "rm .log file" "rm debug.log"
+test_archive_pass "rm .tmp file" "rm session.tmp"
+test_archive_pass "rm node_modules" "rm -rf node_modules"
+test_archive_pass "git rm --cached" "git rm --cached file.txt"
+test_archive_pass "git rm -r --cached" "git rm -r --cached dir/"
+test_archive_pass "rm .git/index.lock" "rm ~/.claude/.git/index.lock"
+test_archive_pass "rm .git/refs lock" "rm /repo/.git/refs/heads/main.lock"
+test_archive_pass "non-Bash tool" "echo not-bash"
+
+echo ""
+echo "[archive-not-delete] non-Bash tools ignored"
+EDIT_INPUT='{"tool_name":"Edit","tool_input":{"file_path":"/tmp/test.js"}}'
+RESULT=$(node -e "
+  var m = require('$ARCHIVE_MOD');
+  var r = m($EDIT_INPUT);
+  console.log(r === null ? 'pass' : 'block');
+" 2>/dev/null)
+if [ "$RESULT" = "pass" ]; then
+  pass "archive-not-delete ignores Edit tool"
+else
+  fail "archive-not-delete should ignore Edit tool"
+fi
+
+# ============================================================
+# config-sync: stale lock detection + branch-aware push
+# ============================================================
+
+CONFIG_SYNC_MOD="$REPO_DIR/modules/SessionStart/config-sync.js"
+
+echo ""
+echo "[config-sync] module structure"
+
+# Verify stale lock handling code exists
+if node -e "
+  var src = require('fs').readFileSync('$CONFIG_SYNC_MOD', 'utf-8');
+  if (src.indexOf('index.lock') === -1) process.exit(1);
+  if (src.indexOf('unlinkSync') === -1) process.exit(1);
+" 2>/dev/null; then
+  pass "config-sync has stale lock removal logic"
+else
+  fail "config-sync missing stale lock removal logic"
+fi
+
+# Verify branch-aware push (no hardcoded 'main')
+if node -e "
+  var src = require('fs').readFileSync('$CONFIG_SYNC_MOD', 'utf-8');
+  if (src.indexOf('git push origin main') !== -1) process.exit(1);
+  if (src.indexOf('rev-parse --abbrev-ref HEAD') === -1) process.exit(1);
+" 2>/dev/null; then
+  pass "config-sync pushes current branch (not hardcoded main)"
+else
+  fail "config-sync still has hardcoded 'main' push"
+fi
+
+# Verify 60s threshold for stale lock
+if node -e "
+  var src = require('fs').readFileSync('$CONFIG_SYNC_MOD', 'utf-8');
+  if (src.indexOf('60000') === -1) process.exit(1);
+" 2>/dev/null; then
+  pass "config-sync uses 60s stale lock threshold"
+else
+  fail "config-sync missing 60s stale lock threshold"
+fi
+
+# ============================================================
+# Summary
+# ============================================================
+
+echo ""
+echo "========================"
+echo "$PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then exit 1; fi


### PR DESCRIPTION
## Summary
- New test script `test-module-behaviors.sh` — tests specific module logic (not just load/call)
- 15 tests covering:
  - archive-not-delete: block patterns (rm, rm -rf, rmdir) + exception patterns (.log, .tmp, node_modules, git rm --cached, .git/*.lock)
  - config-sync: stale lock removal logic, branch-aware push, 60s threshold

## Context
T234-T236 fixed real bugs in archive-not-delete and config-sync but had no regression tests. This prevents future regressions.

## Test plan
- [x] All 15 tests pass locally
- [x] CI will run this as part of `--test` (auto-discovered)