### PR TITLE
T239: Version bump to 2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.2.2] — 2026-04-05
+
+### Fixed
+- config-sync: detect and remove stale git `index.lock` (>60s) before `git add` (#115)
+- config-sync: push current branch instead of hardcoded `main` (#115)
+- archive-not-delete: allow `rm .git/*.lock` for standard git recovery (#116)
+
+### Added
+- Module behavior test suite: 15 tests for archive-not-delete exceptions + config-sync logic (#117)
+
 ## [2.2.1] — 2026-04-05
 
 ### Fixed

--- a/TODO.md
+++ b/TODO.md
@@ -244,10 +244,11 @@ See `specs/watchdog/tasks.md` for full task list.
 - [x] T236: Add `.git/*.lock` exception to archive-not-delete gate (stale lock cleanup is standard git recovery)
 - [x] T237: Add module behavior test suite (archive-not-delete exceptions, config-sync structure)
 - [x] T238: Update CLAUDE.md and TODO.md test counts (39 suites, 394 tests)
+- [x] T239: Version bump to 2.2.2 + CHANGELOG entry
 
 ## Status
-- 161 tasks completed, 0 pending
-- Version: 2.2.1
+- 162 tasks completed, 0 pending
+- Version: 2.2.2
 - 394 tests passing across 39 test suites
 - CI: GitHub Actions runs tests + secret-scan on push/PR — badge in README
 - Workflow engine: workflow.js + workflow-gate.js + 10 built-in workflow templates

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"

--- a/setup.js
+++ b/setup.js
@@ -46,7 +46,7 @@ var SCRIPT_DIR = __dirname;
 var REPO_DIR = SCRIPT_DIR;
 
 var HOOK_LOG_PATH = path.join(HOOKS_DIR, "hook-log.jsonl");
-var VERSION = "2.2.1";
+var VERSION = "2.2.2";
 
 // ============================================================
 // 0. Hook Log Stats


### PR DESCRIPTION
## Summary
- Version bump to 2.2.2
- CHANGELOG entry for T234-T237 (config-sync fixes, archive gate fix, behavior tests)

## Changes in 2.2.2
- Fix: config-sync stale lock detection + branch-aware push (#115)
- Fix: archive-not-delete allows .git/*.lock removal (#116)
- Add: module behavior test suite with 15 tests (#117)