### PR TITLE
T240: Code review — ES5 consistency, require cleanup

### DIFF
--- a/run-async.js
+++ b/run-async.js
@@ -11,6 +11,7 @@
  *   runAsync(modules, input, EVENT, handleResult, handleDone);
  */
 
+var path = require("path");
 var DEFAULT_TIMEOUT = 4000; // 4s per module (Claude Code hook timeout is 5s)
 
 /**
@@ -58,7 +59,6 @@ function runModules(modulePaths, input, handleResult, handleDone, timeout) {
     }
 
     var modPath = modulePaths[i];
-    var path = require("path");
     var modName = path.basename(modPath, ".js");
     i++;
 

--- a/setup.js
+++ b/setup.js
@@ -715,6 +715,7 @@ function cmdHelp() {
   console.log("  --install       Skip report, just install runners");
   console.log("  --open          Open report in browser (default: don't open)");
   console.log("  --force         With --uninstall: also remove non-empty module dirs");
+  console.log("  --confirm       With --uninstall: restore original settings.json from backup");
   console.log("  --yes           Non-interactive: auto-confirm install + enable default workflows");
   console.log("");
   console.log("Examples:");

--- a/workflow.js
+++ b/workflow.js
@@ -7,37 +7,38 @@
 //   2. Global:  ~/.claude/hooks/workflows/*.yml
 //   3. Built-in: <hook-runner>/workflows/*.yml (shipped with hook-runner)
 
-const fs = require('fs');
-const path = require('path');
+"use strict";
+var fs = require("fs");
+var path = require("path");
 
-const STATE_FILE = '.workflow-state.json';
+var STATE_FILE = ".workflow-state.json";
 
 // --- YAML Parser (minimal, no deps) ---
 // Handles the subset of YAML used in workflow definitions:
 // top-level scalars, step arrays with nested objects, string arrays, inline arrays
 
 function parseYaml(text) {
-  const result = {};
-  const lines = text.split('\n');
-  let i = 0;
-  let currentArray = null;
-  let currentArrayKey = null;
-  let currentObj = null;
+  var result = {};
+  var lines = text.split("\n");
+  var i = 0;
+  var currentArray = null;
+  var currentArrayKey = null;
+  var currentObj = null;
 
   while (i < lines.length) {
-    const line = lines[i];
-    const trimmed = line.trimEnd();
+    var line = lines[i];
+    var trimmed = line.trimEnd();
 
-    if (!trimmed || trimmed.startsWith('#')) { i++; continue; }
+    if (!trimmed || trimmed.startsWith("#")) { i++; continue; }
 
-    const indent = line.length - line.trimStart().length;
+    var indent = line.length - line.trimStart().length;
 
     // Top-level scalar: "key: value"
-    if (indent === 0 && !trimmed.startsWith('-')) {
-      const m = trimmed.match(/^(\w+):\s*(.*)/);
+    if (indent === 0 && !trimmed.startsWith("-")) {
+      var m = trimmed.match(/^(\w+):\s*(.*)/);
       if (m) {
         currentArray = null; currentArrayKey = null; currentObj = null;
-        const val = m[2].trim();
+        var val = m[2].trim();
         if (!val) {
           currentArrayKey = m[1];
           result[m[1]] = [];
@@ -50,9 +51,9 @@ function parseYaml(text) {
     }
 
     // Array item: "  - id: value" or "  - value"
-    if (trimmed.startsWith('- ') || (indent > 0 && trimmed.trimStart().startsWith('- '))) {
-      const content = trimmed.trimStart().slice(2).trim();
-      const kvMatch = content.match(/^(\w+):\s*(.*)/);
+    if (trimmed.startsWith("- ") || (indent > 0 && trimmed.trimStart().startsWith("- "))) {
+      var content = trimmed.trimStart().slice(2).trim();
+      var kvMatch = content.match(/^(\w+):\s*(.*)/);
       if (kvMatch) {
         currentObj = {};
         currentObj[kvMatch[1]] = parseScalar(kvMatch[2]);
@@ -64,25 +65,25 @@ function parseYaml(text) {
     }
 
     // Nested key under array item
-    if (indent > 0 && currentObj && !trimmed.trimStart().startsWith('-')) {
-      const nested = trimmed.trim();
-      const kvMatch = nested.match(/^(\w+):\s*(.*)/);
-      if (kvMatch) {
-        const key = kvMatch[1];
-        const val = kvMatch[2].trim();
-        if (!val) {
+    if (indent > 0 && currentObj && !trimmed.trimStart().startsWith("-")) {
+      var nested = trimmed.trim();
+      var kvMatch2 = nested.match(/^(\w+):\s*(.*)/);
+      if (kvMatch2) {
+        var key = kvMatch2[1];
+        var val2 = kvMatch2[2].trim();
+        if (!val2) {
           // Sub-object (like gate: or completion:)
-          const subObj = {};
+          var subObj = {};
           i++;
-          let subBaseIndent = -1;
+          var subBaseIndent = -1;
           while (i < lines.length) {
-            const subLine = lines[i];
-            const subTrimmed = subLine.trimEnd();
+            var subLine = lines[i];
+            var subTrimmed = subLine.trimEnd();
             if (!subTrimmed) { i++; continue; }
-            const subIndent = subLine.length - subLine.trimStart().length;
+            var subIndent = subLine.length - subLine.trimStart().length;
             if (subBaseIndent === -1) subBaseIndent = subIndent;
             if (subIndent < subBaseIndent) break;
-            const subKv = subTrimmed.trim().match(/^(\w+):\s*(.*)/);
+            var subKv = subTrimmed.trim().match(/^(\w+):\s*(.*)/);
             if (subKv) {
               subObj[subKv[1]] = parseScalar(subKv[2]);
             }
@@ -91,7 +92,7 @@ function parseYaml(text) {
           currentObj[key] = subObj;
           continue;
         } else {
-          currentObj[key] = parseScalar(val);
+          currentObj[key] = parseScalar(val2);
         }
       }
       i++; continue;
@@ -104,17 +105,17 @@ function parseYaml(text) {
 }
 
 function parseScalar(val) {
-  if (!val || val === '~' || val === 'null') return null;
-  if (val === 'true') return true;
-  if (val === 'false') return false;
+  if (!val || val === "~" || val === "null") return null;
+  if (val === "true") return true;
+  if (val === "false") return false;
   if (/^\d+$/.test(val)) return parseInt(val, 10);
   if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
     return val.slice(1, -1);
   }
-  if (val.startsWith('[') && val.endsWith(']')) {
-    const inner = val.slice(1, -1).trim();
+  if (val.startsWith("[") && val.endsWith("]")) {
+    var inner = val.slice(1, -1).trim();
     if (!inner) return [];
-    return inner.split(',').map(s => parseScalar(s.trim()));
+    return inner.split(",").map(function(s) { return parseScalar(s.trim()); });
   }
   return val;
 }
@@ -122,46 +123,51 @@ function parseScalar(val) {
 // --- Workflow Loading ---
 
 function loadWorkflow(yamlPath) {
-  const text = fs.readFileSync(yamlPath, 'utf-8');
-  const parsed = parseYaml(text);
+  var text = fs.readFileSync(yamlPath, "utf-8");
+  var parsed = parseYaml(text);
   // Parse modules list (array of module base names)
   var modules = [];
   if (Array.isArray(parsed.modules)) {
-    modules = parsed.modules.filter(m => typeof m === 'string');
+    modules = parsed.modules.filter(function(m) { return typeof m === "string"; });
   }
 
   return {
-    name: parsed.name || path.basename(yamlPath, '.yml'),
-    description: parsed.description || '',
+    name: parsed.name || path.basename(yamlPath, ".yml"),
+    description: parsed.description || "",
     version: parsed.version || 1,
-    steps: (parsed.steps || []).filter(s => s && s.id).map(s => ({
-      id: s.id,
-      name: s.name || s.id,
-      gate: s.gate || {},
-      completion: s.completion || {},
-    })),
+    steps: (parsed.steps || []).filter(function(s) { return s && s.id; }).map(function(s) {
+      return {
+        id: s.id,
+        name: s.name || s.id,
+        gate: s.gate || {},
+        completion: s.completion || {},
+      };
+    }),
     modules: modules,
     _path: yamlPath,
   };
 }
 
 function findWorkflows(projectDir) {
-  const home = process.env.HOME || process.env.USERPROFILE || '';
-  const dirs = [
-    path.join(projectDir, 'workflows'),
-    path.join(home, '.claude', 'hooks', 'workflows'),
-    path.join(__dirname, 'workflows'),
+  var home = process.env.HOME || process.env.USERPROFILE || "";
+  var dirs = [
+    path.join(projectDir, "workflows"),
+    path.join(home, ".claude", "hooks", "workflows"),
+    path.join(__dirname, "workflows"),
   ];
-  const workflows = [];
-  const seen = new Set();
-  for (const dir of dirs) {
+  var workflows = [];
+  var seen = {};
+  for (var i = 0; i < dirs.length; i++) {
+    var dir = dirs[i];
     if (!fs.existsSync(dir)) continue;
-    for (const f of fs.readdirSync(dir)) {
-      if (!(f.endsWith('.yml') || f.endsWith('.yaml'))) continue;
+    var files = fs.readdirSync(dir);
+    for (var j = 0; j < files.length; j++) {
+      var f = files[j];
+      if (!(f.endsWith(".yml") || f.endsWith(".yaml"))) continue;
       try {
-        const wf = loadWorkflow(path.join(dir, f));
-        if (!seen.has(wf.name)) {
-          seen.add(wf.name);
+        var wf = loadWorkflow(path.join(dir, f));
+        if (!seen[wf.name]) {
+          seen[wf.name] = true;
           workflows.push(wf);
         }
       } catch(e) {}
@@ -177,49 +183,50 @@ function statePath(projectDir) {
 }
 
 function readState(projectDir) {
-  const p = statePath(projectDir);
+  var p = statePath(projectDir);
   if (!fs.existsSync(p)) return null;
-  try { return JSON.parse(fs.readFileSync(p, 'utf-8')); } catch(e) { return null; }
+  try { return JSON.parse(fs.readFileSync(p, "utf-8")); } catch(e) { return null; }
 }
 
 function writeState(state, projectDir) {
-  fs.writeFileSync(statePath(projectDir), JSON.stringify(state, null, 2) + '\n');
+  fs.writeFileSync(statePath(projectDir), JSON.stringify(state, null, 2) + "\n");
   return state;
 }
 
 function initState(workflowName, yamlPath, projectDir) {
-  const def = loadWorkflow(yamlPath);
-  const steps = {};
-  for (const step of def.steps) {
-    steps[step.id] = { status: 'pending' };
+  var def = loadWorkflow(yamlPath);
+  var steps = {};
+  for (var i = 0; i < def.steps.length; i++) {
+    steps[def.steps[i].id] = { status: "pending" };
   }
-  const state = {
+  var state = {
     workflow: workflowName,
     workflow_path: yamlPath,
     started_at: new Date().toISOString(),
-    steps,
+    steps: steps,
   };
   return writeState(state, projectDir);
 }
 
 function resetState(projectDir) {
-  const p = statePath(projectDir);
+  var p = statePath(projectDir);
   if (fs.existsSync(p)) fs.unlinkSync(p);
 }
 
 function completeStep(stepId, projectDir) {
-  const state = readState(projectDir);
-  if (!state) throw new Error('No active workflow');
-  if (!state.steps[stepId]) throw new Error(`Unknown step: ${stepId}`);
+  var state = readState(projectDir);
+  if (!state) throw new Error("No active workflow");
+  if (!state.steps[stepId]) throw new Error("Unknown step: " + stepId);
   state.steps[stepId] = {
-    status: 'completed',
+    status: "completed",
     completed_at: new Date().toISOString(),
   };
   // Advance next pending step to in_progress
-  const def = loadWorkflow(state.workflow_path);
-  for (const step of def.steps) {
-    if (state.steps[step.id]?.status === 'pending') {
-      state.steps[step.id].status = 'in_progress';
+  var def = loadWorkflow(state.workflow_path);
+  for (var i = 0; i < def.steps.length; i++) {
+    var s = state.steps[def.steps[i].id];
+    if (s && s.status === "pending") {
+      s.status = "in_progress";
       break;
     }
   }
@@ -227,16 +234,16 @@ function completeStep(stepId, projectDir) {
 }
 
 function currentStep(projectDir) {
-  const state = readState(projectDir);
+  var state = readState(projectDir);
   if (!state) return null;
-  const def = loadWorkflow(state.workflow_path);
-  for (const step of def.steps) {
-    const s = state.steps[step.id];
-    if (s?.status === 'in_progress') return step.id;
+  var def = loadWorkflow(state.workflow_path);
+  for (var i = 0; i < def.steps.length; i++) {
+    var s = state.steps[def.steps[i].id];
+    if (s && s.status === "in_progress") return def.steps[i].id;
   }
-  for (const step of def.steps) {
-    const s = state.steps[step.id];
-    if (s?.status === 'pending') return step.id;
+  for (var j = 0; j < def.steps.length; j++) {
+    var s2 = state.steps[def.steps[j].id];
+    if (s2 && s2.status === "pending") return def.steps[j].id;
   }
   return null; // All done
 }
@@ -244,43 +251,47 @@ function currentStep(projectDir) {
 // --- Gate Checking ---
 
 function checkGate(stepId, projectDir) {
-  const state = readState(projectDir);
-  if (!state) return { allowed: true, reason: 'no active workflow' };
+  var state = readState(projectDir);
+  if (!state) return { allowed: true, reason: "no active workflow" };
 
-  const def = loadWorkflow(state.workflow_path);
-  const stepDef = def.steps.find(s => s.id === stepId);
-  if (!stepDef) return { allowed: true, reason: 'unknown step' };
+  var def = loadWorkflow(state.workflow_path);
+  var stepDef = null;
+  for (var i = 0; i < def.steps.length; i++) {
+    if (def.steps[i].id === stepId) { stepDef = def.steps[i]; break; }
+  }
+  if (!stepDef) return { allowed: true, reason: "unknown step" };
 
-  const gate = stepDef.gate;
-  const reasons = [];
+  var gate = stepDef.gate;
+  var reasons = [];
 
   if (gate.require_step) {
-    const reqStatus = state.steps[gate.require_step];
-    if (!reqStatus || reqStatus.status !== 'completed') {
-      reasons.push(`Step "${gate.require_step}" not completed`);
+    var reqStatus = state.steps[gate.require_step];
+    if (!reqStatus || reqStatus.status !== "completed") {
+      reasons.push('Step "' + gate.require_step + '" not completed');
     }
   }
 
   if (gate.require_files && Array.isArray(gate.require_files) && gate.require_files.length > 0) {
-    for (const f of gate.require_files) {
-      const fullPath = path.isAbsolute(f) ? f : path.join(projectDir, f);
+    for (var j = 0; j < gate.require_files.length; j++) {
+      var f = gate.require_files[j];
+      var fullPath = path.isAbsolute(f) ? f : path.join(projectDir, f);
       if (!fs.existsSync(fullPath)) {
-        reasons.push(`Required file missing: ${f}`);
+        reasons.push("Required file missing: " + f);
       }
     }
   }
 
   if (reasons.length > 0) {
-    return { allowed: false, step: stepId, reasons };
+    return { allowed: false, step: stepId, reasons: reasons };
   }
   return { allowed: true, step: stepId };
 }
 
 function checkEditAllowed(filePath, projectDir) {
-  const state = readState(projectDir);
+  var state = readState(projectDir);
   if (!state) return { allowed: true };
 
-  const current = currentStep(projectDir);
+  var current = currentStep(projectDir);
   if (!current) return { allowed: true };
 
   return checkGate(current, projectDir);
@@ -289,62 +300,62 @@ function checkEditAllowed(filePath, projectDir) {
 // --- Workflow Config (enable/disable) ---
 // Stored in <dir>/workflow-config.json (global: ~/.claude/hooks/, per-project: $CLAUDE_PROJECT_DIR)
 
-const CONFIG_FILE = 'workflow-config.json';
+var CONFIG_FILE = "workflow-config.json";
 
 function configPath(dir) {
   return path.join(dir, CONFIG_FILE);
 }
 
 function readConfig(dir) {
-  const p = configPath(dir);
+  var p = configPath(dir);
   if (!fs.existsSync(p)) return {};
-  try { return JSON.parse(fs.readFileSync(p, 'utf-8')); } catch(e) { return {}; }
+  try { return JSON.parse(fs.readFileSync(p, "utf-8")); } catch(e) { return {}; }
 }
 
 function writeConfig(config, dir) {
-  fs.writeFileSync(configPath(dir), JSON.stringify(config, null, 2) + '\n');
+  fs.writeFileSync(configPath(dir), JSON.stringify(config, null, 2) + "\n");
 }
 
 function enableWorkflow(name, dir) {
-  const config = readConfig(dir);
+  var config = readConfig(dir);
   config[name] = true;
   writeConfig(config, dir);
 }
 
 function disableWorkflow(name, dir) {
-  const config = readConfig(dir);
+  var config = readConfig(dir);
   config[name] = false;
   writeConfig(config, dir);
 }
 
 function isWorkflowEnabled(name, dir) {
-  const config = readConfig(dir);
+  var config = readConfig(dir);
   return config[name] === true;
 }
 
 function enabledWorkflows(dir) {
-  const config = readConfig(dir);
-  return Object.keys(config).filter(k => config[k] === true);
+  var config = readConfig(dir);
+  return Object.keys(config).filter(function(k) { return config[k] === true; });
 }
 
 module.exports = {
-  parseYaml,
-  loadWorkflow,
-  findWorkflows,
-  readState,
-  writeState,
-  initState,
-  resetState,
-  completeStep,
-  currentStep,
-  checkGate,
-  checkEditAllowed,
-  readConfig,
-  writeConfig,
-  enableWorkflow,
-  disableWorkflow,
-  isWorkflowEnabled,
-  enabledWorkflows,
-  STATE_FILE,
-  CONFIG_FILE,
+  parseYaml: parseYaml,
+  loadWorkflow: loadWorkflow,
+  findWorkflows: findWorkflows,
+  readState: readState,
+  writeState: writeState,
+  initState: initState,
+  resetState: resetState,
+  completeStep: completeStep,
+  currentStep: currentStep,
+  checkGate: checkGate,
+  checkEditAllowed: checkEditAllowed,
+  readConfig: readConfig,
+  writeConfig: writeConfig,
+  enableWorkflow: enableWorkflow,
+  disableWorkflow: disableWorkflow,
+  isWorkflowEnabled: isWorkflowEnabled,
+  enabledWorkflows: enabledWorkflows,
+  STATE_FILE: STATE_FILE,
+  CONFIG_FILE: CONFIG_FILE,
 };


### PR DESCRIPTION
## Summary
- Convert `workflow.js` from ES6 (`const`/`let`/arrow functions/template literals) to ES5 (`var`/function expressions) for consistency with all other files in the project
- Move `require("path")` from inside `next()` closure to module level in `run-async.js`
- Add missing `--confirm` flag documentation to `--help` output in `setup.js`

## Test plan
- [x] All 394 tests pass across 39 suites
- [x] All 9 workflow test suites pass (77 tests)
- [x] Async test suite passes (13 tests)
- [x] Setup wizard test suite passes (7 tests)