### PR TITLE
T241: Cache module header reads, TODO update

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -246,8 +246,12 @@ See `specs/watchdog/tasks.md` for full task list.
 - [x] T238: Update CLAUDE.md and TODO.md test counts (39 suites, 394 tests)
 - [x] T239: Version bump to 2.2.2 + CHANGELOG entry
 
+## Code Review (session 2026-04-05e)
+- [x] T240: Code review fixes — ES5 consistency in workflow.js, path require cleanup in run-async.js, --confirm in help text (#120)
+- [x] T241: Optimize load-modules.js — cache header reads so each module file is read once instead of twice per invocation
+
 ## Status
-- 162 tasks completed, 0 pending
+- 164 tasks completed, 0 pending
 - Version: 2.2.2
 - 394 tests passing across 39 test suites
 - CI: GitHub Actions runs tests + secret-scan on push/PR — badge in README

--- a/load-modules.js
+++ b/load-modules.js
@@ -13,25 +13,36 @@
 var fs = require("fs");
 var path = require("path");
 
+// Cache header lines (first 5) per file path within a single loadModules() call.
+// Each hook invocation is a fresh Node process, so no stale cache risk.
+var _headerCache = {};
+
+function getHeaderLines(filePath) {
+  if (_headerCache[filePath]) return _headerCache[filePath];
+  try {
+    var content = fs.readFileSync(filePath, "utf-8");
+    var lines = content.split("\n").slice(0, 5);
+    _headerCache[filePath] = lines;
+    return lines;
+  } catch (e) { return []; }
+}
+
 /**
  * Parse "// requires: mod1, mod2" from the first 5 lines of a module file.
  * Only matches module-name patterns (lowercase with hyphens, no spaces in names).
  * Returns array of required module base names (without .js).
  */
 function parseRequires(filePath) {
-  try {
-    var content = fs.readFileSync(filePath, "utf-8");
-    var lines = content.split("\n").slice(0, 5);
-    for (var i = 0; i < lines.length; i++) {
-      var match = lines[i].match(/^\/\/\s*requires:\s*(.+)/i);
-      if (match) {
-        var deps = match[1].split(",").map(function(s) { return s.trim(); }).filter(Boolean);
-        // Only accept valid module names (lowercase, hyphens, digits — no spaces/descriptions)
-        var valid = deps.filter(function(d) { return /^[a-z0-9][-a-z0-9]*$/.test(d); });
-        if (valid.length > 0) return valid;
-      }
+  var lines = getHeaderLines(filePath);
+  for (var i = 0; i < lines.length; i++) {
+    var match = lines[i].match(/^\/\/\s*requires:\s*(.+)/i);
+    if (match) {
+      var deps = match[1].split(",").map(function(s) { return s.trim(); }).filter(Boolean);
+      // Only accept valid module names (lowercase, hyphens, digits — no spaces/descriptions)
+      var valid = deps.filter(function(d) { return /^[a-z0-9][-a-z0-9]*$/.test(d); });
+      if (valid.length > 0) return valid;
     }
-  } catch (e) { /* can't read, no deps */ }
+  }
   return [];
 }
 
@@ -40,14 +51,11 @@ function parseRequires(filePath) {
  * Returns the workflow name or null if no tag found.
  */
 function parseWorkflowTag(filePath) {
-  try {
-    var content = fs.readFileSync(filePath, "utf-8");
-    var lines = content.split("\n").slice(0, 5);
-    for (var i = 0; i < lines.length; i++) {
-      var match = lines[i].match(/^\/\/\s*WORKFLOW:\s*(\S+)/i);
-      if (match) return match[1];
-    }
-  } catch (e) { /* can't read */ }
+  var lines = getHeaderLines(filePath);
+  for (var i = 0; i < lines.length; i++) {
+    var match = lines[i].match(/^\/\/\s*WORKFLOW:\s*(\S+)/i);
+    if (match) return match[1];
+  }
   return null;
 }
 


### PR DESCRIPTION
## Summary
- Cache module file header reads in `load-modules.js` — each file was read twice per hook invocation (once for workflow tag, once for requires). Now read once via shared cache. Cache is fresh per invocation since each hook spawns a new Node process.
- Add T240-T241 to TODO.md

## Test plan
- [x] Workflow tests pass (16 tests)
- [x] Module validation tests pass (114 tests)
- [x] Runner tests pass (16 tests)