### PR TITLE
T242: Version bump to 2.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.2.3] — 2026-04-05
+
+### Fixed
+- workflow.js converted from ES6 to ES5 for consistency with all other files (#120)
+- `require("path")` moved from inner function to module level in run-async.js (#120)
+- Missing `--confirm` flag added to `--help` output (#120)
+
+### Changed
+- Module header cache in load-modules.js — each file read once instead of twice per invocation (#121)
+
 ## [2.2.2] — 2026-04-05
 
 ### Fixed

--- a/TODO.md
+++ b/TODO.md
@@ -249,10 +249,11 @@ See `specs/watchdog/tasks.md` for full task list.
 ## Code Review (session 2026-04-05e)
 - [x] T240: Code review fixes — ES5 consistency in workflow.js, path require cleanup in run-async.js, --confirm in help text (#120)
 - [x] T241: Optimize load-modules.js — cache header reads so each module file is read once instead of twice per invocation
+- [x] T242: Version bump to 2.2.3 + CHANGELOG entry + marketplace sync
 
 ## Status
-- 164 tasks completed, 0 pending
-- Version: 2.2.2
+- 165 tasks completed, 0 pending
+- Version: 2.2.3
 - 394 tests passing across 39 test suites
 - CI: GitHub Actions runs tests + secret-scan on push/PR — badge in README
 - Workflow engine: workflow.js + workflow-gate.js + 10 built-in workflow templates

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"

--- a/setup.js
+++ b/setup.js
@@ -46,7 +46,7 @@ var SCRIPT_DIR = __dirname;
 var REPO_DIR = SCRIPT_DIR;
 
 var HOOK_LOG_PATH = path.join(HOOKS_DIR, "hook-log.jsonl");
-var VERSION = "2.2.2";
+var VERSION = "2.2.3";
 
 // ============================================================
 // 0. Hook Log Stats


### PR DESCRIPTION
## Summary
- Version bump to 2.2.3
- CHANGELOG entry for T240-T241 fixes
- TODO.md updated with T242

## Test plan
- [x] Setup wizard tests pass (7 tests)
- [x] CI will validate full suite