### PR TITLE
T248: Version bump to 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.3.0] — 2026-04-05
+
+### Added
+- Windows CI job (`windows-latest`) — cross-platform validation on every push (#123)
+- "Why hook-runner?" philosophy section in README — raw hooks → modules → workflows (#124)
+- Integration guide in README — context-reset, skill-maker, mcp-manager, marketplace (#124)
+
+### Fixed
+- `grep -P` (Perl regex) replaced with portable `grep -o` / `sed` in 3 test scripts (#123)
+
 ## [2.2.3] — 2026-04-05
 
 ### Fixed

--- a/TODO.md
+++ b/TODO.md
@@ -258,9 +258,12 @@ See `specs/watchdog/tasks.md` for full task list.
 - [x] T246: Community adoption: "Why hook-runner?" section in README — raw hooks vs modules vs workflows progression (#124)
 - [x] T247: Integration guide in README — context-reset, skill-maker, mcp-manager, marketplace (#124)
 
+## Release
+- [x] T248: Version bump to 2.3.0 + CHANGELOG + marketplace sync (#125)
+
 ## Status
-- 170 tasks completed, 0 pending
-- Version: 2.2.3
+- 171 tasks completed, 0 pending
+- Version: 2.3.0
 - 394 tests passing across 39 test suites
 - CI: GitHub Actions runs tests + secret-scan on push/PR — badge in README
 - Workflow engine: workflow.js + workflow-gate.js + 10 built-in workflow templates

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"

--- a/setup.js
+++ b/setup.js
@@ -46,7 +46,7 @@ var SCRIPT_DIR = __dirname;
 var REPO_DIR = SCRIPT_DIR;
 
 var HOOK_LOG_PATH = path.join(HOOKS_DIR, "hook-log.jsonl");
-var VERSION = "2.2.3";
+var VERSION = "2.3.0";
 
 // ============================================================
 // 0. Hook Log Stats


### PR DESCRIPTION
## Summary
- Version bump to 2.3.0
- CHANGELOG entry covering #123 (Windows CI) and #124 (philosophy + integration docs)

## Test plan
- [ ] CI passes (all 4 jobs)