### PR TITLE
T249: Convert watchdog.js to ES5, fix cron injection

### DIFF
--- a/watchdog.js
+++ b/watchdog.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+"use strict";
 // hook-runner — Watchdog
 // WHY: A test suite silently disabled shtd globally. No independent monitor caught it.
 // This runs on a schedule (OS scheduler) to detect and auto-repair config drift.
@@ -7,34 +8,34 @@
 // Output: JSON to stdout with check results
 // Side effects: auto-repairs disabled workflows, writes .watchdog-alert, logs to watchdog-log.jsonl
 
-const fs = require('fs');
-const path = require('path');
+var fs = require("fs");
+var path = require("path");
 
 // --- CLI args ---
-const args = process.argv.slice(2);
+var args = process.argv.slice(2);
 function getArg(name) {
-  const idx = args.indexOf(name);
+  var idx = args.indexOf(name);
   return idx >= 0 && idx + 1 < args.length ? args[idx + 1] : null;
 }
 
-const hooksDir = getArg('--hooks-dir') || path.join(process.env.HOME || process.env.USERPROFILE || '', '.claude', 'hooks');
-const configFile = getArg('--config') || path.join(hooksDir, 'watchdog-config.json');
+var hooksDir = getArg("--hooks-dir") || path.join(process.env.HOME || process.env.USERPROFILE || "", ".claude", "hooks");
+var configFile = getArg("--config") || path.join(hooksDir, "watchdog-config.json");
 
 // --- Load watchdog config (what "healthy" looks like) ---
-const DEFAULT_CONFIG = {
-  required_workflows: ['shtd', 'code-quality', 'self-improvement', 'session-management', 'messaging-safety'],
+var DEFAULT_CONFIG = {
+  required_workflows: ["shtd", "code-quality", "self-improvement", "session-management", "messaging-safety"],
   required_runners: [
-    'run-pretooluse.js', 'run-posttooluse.js', 'run-stop.js',
-    'run-sessionstart.js', 'run-userpromptsubmit.js',
-    'load-modules.js', 'workflow.js'
+    "run-pretooluse.js", "run-posttooluse.js", "run-stop.js",
+    "run-sessionstart.js", "run-userpromptsubmit.js",
+    "load-modules.js", "workflow.js"
   ],
-  required_modules: ['Stop/auto-continue.js', 'PreToolUse/branch-pr-gate.js']
+  required_modules: ["Stop/auto-continue.js", "PreToolUse/branch-pr-gate.js"]
 };
 
 function loadConfig() {
   if (fs.existsSync(configFile)) {
     try {
-      return JSON.parse(fs.readFileSync(configFile, 'utf-8'));
+      return JSON.parse(fs.readFileSync(configFile, "utf-8"));
     } catch (e) {
       // corrupted config is itself a problem — use defaults
     }
@@ -44,112 +45,120 @@ function loadConfig() {
 
 // --- Checks ---
 function checkWorkflows(config) {
-  const results = [];
-  const wcPath = path.join(hooksDir, 'workflow-config.json');
+  var results = [];
+  var wcPath = path.join(hooksDir, "workflow-config.json");
 
   if (!fs.existsSync(wcPath)) {
-    results.push({ check: 'workflow-config-exists', ok: false, detail: 'workflow-config.json missing' });
+    results.push({ check: "workflow-config-exists", ok: false, detail: "workflow-config.json missing" });
     return results;
   }
 
-  let wc;
+  var wc;
   try {
-    wc = JSON.parse(fs.readFileSync(wcPath, 'utf-8'));
+    wc = JSON.parse(fs.readFileSync(wcPath, "utf-8"));
   } catch (e) {
-    results.push({ check: 'workflow-config-valid', ok: false, detail: 'workflow-config.json is invalid JSON' });
+    results.push({ check: "workflow-config-valid", ok: false, detail: "workflow-config.json is invalid JSON" });
     return results;
   }
 
-  for (const name of (config.required_workflows || [])) {
+  var requiredWorkflows = config.required_workflows || [];
+  for (var i = 0; i < requiredWorkflows.length; i++) {
+    var name = requiredWorkflows[i];
     if (wc[name] === true) {
-      results.push({ check: 'workflow-enabled', workflow: name, ok: true });
+      results.push({ check: "workflow-enabled", workflow: name, ok: true });
     } else {
-      results.push({ check: 'workflow-enabled', workflow: name, ok: false, detail: `${name} is disabled (value: ${wc[name]})`, repairable: true });
+      results.push({ check: "workflow-enabled", workflow: name, ok: false, detail: name + " is disabled (value: " + wc[name] + ")", repairable: true });
     }
   }
 
   // Check if ALL workflows are false (total shutdown) — repairable via per-workflow repair
-  const allFalse = Object.keys(wc).length > 0 && Object.values(wc).every(v => v === false);
+  var keys = Object.keys(wc);
+  var allFalse = keys.length > 0 && keys.every(function(k) { return wc[k] === false; });
   if (allFalse) {
-    results.push({ check: 'not-all-disabled', ok: false, detail: 'All workflows are disabled — total shutdown detected', repairable: true });
+    results.push({ check: "not-all-disabled", ok: false, detail: "All workflows are disabled — total shutdown detected", repairable: true });
   }
 
   return results;
 }
 
 function checkRunners(config) {
-  const results = [];
-  for (const runner of (config.required_runners || [])) {
-    const p = path.join(hooksDir, runner);
+  var results = [];
+  var runners = config.required_runners || [];
+  for (var i = 0; i < runners.length; i++) {
+    var runner = runners[i];
+    var p = path.join(hooksDir, runner);
     if (fs.existsSync(p)) {
-      results.push({ check: 'runner-exists', file: runner, ok: true });
+      results.push({ check: "runner-exists", file: runner, ok: true });
     } else {
-      results.push({ check: 'runner-exists', file: runner, ok: false, detail: `${runner} missing from ${hooksDir}` });
+      results.push({ check: "runner-exists", file: runner, ok: false, detail: runner + " missing from " + hooksDir });
     }
   }
   return results;
 }
 
 function checkModules(config) {
-  const results = [];
-  const modulesDir = path.join(hooksDir, 'run-modules');
-  for (const mod of (config.required_modules || [])) {
-    const p = path.join(modulesDir, mod);
+  var results = [];
+  var modulesDir = path.join(hooksDir, "run-modules");
+  var mods = config.required_modules || [];
+  for (var i = 0; i < mods.length; i++) {
+    var mod = mods[i];
+    var p = path.join(modulesDir, mod);
     if (!fs.existsSync(p)) {
-      results.push({ check: 'module-exists', module: mod, ok: false, detail: `${mod} missing` });
+      results.push({ check: "module-exists", module: mod, ok: false, detail: mod + " missing" });
       continue;
     }
     // Verify it exports a function
     try {
-      const m = require(p);
-      if (typeof m === 'function') {
-        results.push({ check: 'module-valid', module: mod, ok: true });
+      var m = require(p);
+      if (typeof m === "function") {
+        results.push({ check: "module-valid", module: mod, ok: true });
       } else {
-        results.push({ check: 'module-valid', module: mod, ok: false, detail: `${mod} does not export a function` });
+        results.push({ check: "module-valid", module: mod, ok: false, detail: mod + " does not export a function" });
       }
     } catch (e) {
-      results.push({ check: 'module-valid', module: mod, ok: false, detail: `${mod} failed to load: ${e.message}` });
+      results.push({ check: "module-valid", module: mod, ok: false, detail: mod + " failed to load: " + e.message });
     }
   }
   return results;
 }
 
 function checkSettings() {
-  const results = [];
-  const settingsPath = path.join(process.env.HOME || process.env.USERPROFILE || '', '.claude', 'settings.json');
+  var results = [];
+  var settingsPath = path.join(process.env.HOME || process.env.USERPROFILE || "", ".claude", "settings.json");
   if (!fs.existsSync(settingsPath)) {
-    results.push({ check: 'settings-exists', ok: false, detail: 'settings.json missing' });
+    results.push({ check: "settings-exists", ok: false, detail: "settings.json missing" });
     return results;
   }
 
   try {
-    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+    var settings = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
     // Verify hooks array exists and has entries
-    const hooks = settings.hooks || {};
-    const events = Object.keys(hooks);
+    var hooks = settings.hooks || {};
+    var events = Object.keys(hooks);
     if (events.length === 0) {
-      results.push({ check: 'settings-has-hooks', ok: false, detail: 'No hooks configured in settings.json' });
+      results.push({ check: "settings-has-hooks", ok: false, detail: "No hooks configured in settings.json" });
     } else {
-      results.push({ check: 'settings-has-hooks', ok: true, detail: `${events.length} hook events configured` });
+      results.push({ check: "settings-has-hooks", ok: true, detail: events.length + " hook events configured" });
     }
 
     // Verify hook commands reference existing files
-    for (const event of events) {
-      const entries = hooks[event] || [];
-      for (const entry of entries) {
-        const cmd = entry.command || '';
+    for (var i = 0; i < events.length; i++) {
+      var event = events[i];
+      var entries = hooks[event] || [];
+      for (var j = 0; j < entries.length; j++) {
+        var cmd = entries[j].command || "";
         // Extract script path from "node /path/to/script.js"
-        const match = cmd.match(/node\s+"?([^"\s]+\.js)"?/);
+        var match = cmd.match(/node\s+"?([^"\s]+\.js)"?/);
         if (match) {
-          const scriptPath = match[1].replace(/\//g, path.sep);
+          var scriptPath = match[1].replace(/\//g, path.sep);
           if (!fs.existsSync(scriptPath)) {
-            results.push({ check: 'hook-script-exists', ok: false, detail: `${event}: script not found: ${scriptPath}` });
+            results.push({ check: "hook-script-exists", ok: false, detail: event + ": script not found: " + scriptPath });
           }
         }
       }
     }
   } catch (e) {
-    results.push({ check: 'settings-valid', ok: false, detail: `settings.json parse error: ${e.message}` });
+    results.push({ check: "settings-valid", ok: false, detail: "settings.json parse error: " + e.message });
   }
 
   return results;
@@ -157,19 +166,19 @@ function checkSettings() {
 
 // --- Auto-repair ---
 function repair(failures) {
-  const repaired = [];
-  const wcPath = path.join(hooksDir, 'workflow-config.json');
+  var repaired = [];
+  var wcPath = path.join(hooksDir, "workflow-config.json");
 
   // Repair disabled workflows
-  const workflowFailures = failures.filter(f => f.check === 'workflow-enabled' && f.repairable);
+  var workflowFailures = failures.filter(function(f) { return f.check === "workflow-enabled" && f.repairable; });
   if (workflowFailures.length > 0 && fs.existsSync(wcPath)) {
     try {
-      const wc = JSON.parse(fs.readFileSync(wcPath, 'utf-8'));
-      for (const f of workflowFailures) {
-        wc[f.workflow] = true;
-        repaired.push({ action: 'enable-workflow', workflow: f.workflow });
+      var wc = JSON.parse(fs.readFileSync(wcPath, "utf-8"));
+      for (var i = 0; i < workflowFailures.length; i++) {
+        wc[workflowFailures[i].workflow] = true;
+        repaired.push({ action: "enable-workflow", workflow: workflowFailures[i].workflow });
       }
-      fs.writeFileSync(wcPath, JSON.stringify(wc, null, 2) + '\n');
+      fs.writeFileSync(wcPath, JSON.stringify(wc, null, 2) + "\n");
     } catch (e) {
       // Can't repair corrupted JSON
     }
@@ -180,56 +189,57 @@ function repair(failures) {
 
 // --- Alert flag ---
 function writeAlert(failures, repairs) {
-  const alertPath = path.join(hooksDir, '.watchdog-alert');
-  const alert = {
+  var alertPath = path.join(hooksDir, ".watchdog-alert");
+  var alert = {
     timestamp: new Date().toISOString(),
-    failures: failures.map(f => f.detail || f.check),
-    repairs: repairs.map(r => `${r.action}: ${r.workflow || r.file || ''}`)
+    failures: failures.map(function(f) { return f.detail || f.check; }),
+    repairs: repairs.map(function(r) { return (r.action + ": " + (r.workflow || r.file || "")).trim(); })
   };
-  fs.writeFileSync(alertPath, JSON.stringify(alert, null, 2) + '\n');
+  fs.writeFileSync(alertPath, JSON.stringify(alert, null, 2) + "\n");
 }
 
 // --- Logging ---
 function appendLog(entry) {
-  const logPath = path.join(hooksDir, 'watchdog-log.jsonl');
-  const line = JSON.stringify({ ...entry, timestamp: new Date().toISOString() }) + '\n';
+  var logPath = path.join(hooksDir, "watchdog-log.jsonl");
+  entry.timestamp = new Date().toISOString();
+  var line = JSON.stringify(entry) + "\n";
   fs.appendFileSync(logPath, line);
 }
 
 // --- Main ---
 function main() {
-  const config = loadConfig();
-  const allResults = [];
+  var config = loadConfig();
+  var allResults = [];
 
   // Run all checks
-  allResults.push(...checkWorkflows(config));
-  allResults.push(...checkRunners(config));
-  allResults.push(...checkModules(config));
+  allResults = allResults.concat(checkWorkflows(config));
+  allResults = allResults.concat(checkRunners(config));
+  allResults = allResults.concat(checkModules(config));
   // Only check settings if not using a custom hooks dir (CI/test mode)
-  if (!getArg('--hooks-dir')) {
-    allResults.push(...checkSettings());
+  if (!getArg("--hooks-dir")) {
+    allResults = allResults.concat(checkSettings());
   }
 
-  const failures = allResults.filter(r => !r.ok);
-  let exitCode = 0;
-  let repairs = [];
+  var failures = allResults.filter(function(r) { return !r.ok; });
+  var exitCode = 0;
+  var repairs = [];
 
   if (failures.length > 0) {
     // Attempt auto-repair
     repairs = repair(failures);
 
     // Determine exit code: 1 = repaired, 2 = broken (unrepairable failures remain)
-    const unrepairableCount = failures.length - failures.filter(f => f.repairable).length;
+    var unrepairableCount = failures.length - failures.filter(function(f) { return f.repairable; }).length;
     exitCode = unrepairableCount > 0 ? 2 : 1;
 
     // Write alert flag
     writeAlert(failures, repairs);
   }
 
-  const output = {
-    status: exitCode === 0 ? 'healthy' : exitCode === 1 ? 'repaired' : 'broken',
+  var output = {
+    status: exitCode === 0 ? "healthy" : exitCode === 1 ? "repaired" : "broken",
     checks: allResults.length,
-    passed: allResults.filter(r => r.ok).length,
+    passed: allResults.filter(function(r) { return r.ok; }).length,
     failed: failures.length,
     repaired: repairs.length,
     results: allResults,
@@ -243,74 +253,74 @@ function main() {
     passed: output.passed,
     failed: output.failed,
     repaired: output.repaired,
-    failures: failures.map(f => f.detail || f.check),
-    repairs: repairs.map(r => `${r.action}: ${r.workflow || ''}`.trim())
+    failures: failures.map(function(f) { return f.detail || f.check; }),
+    repairs: repairs.map(function(r) { return (r.action + ": " + (r.workflow || "")).trim(); })
   });
 
   // JSON output
-  process.stdout.write(JSON.stringify(output, null, 2) + '\n');
+  process.stdout.write(JSON.stringify(output, null, 2) + "\n");
   process.exit(exitCode);
 }
 
 // --- Scheduler Integration (T125-T127) ---
-const TASK_NAME = 'HookRunnerWatchdog';
-const isWindows = process.platform === 'win32';
+var TASK_NAME = "HookRunnerWatchdog";
+var isWindows = process.platform === "win32";
 
 function getWatchdogScriptPath() {
   // Resolve to absolute path of this script
-  return path.resolve(__dirname, 'watchdog.js');
+  return path.resolve(__dirname, "watchdog.js");
 }
 
 function getVbsWrapperPath() {
-  return path.join(hooksDir, 'watchdog-hidden.vbs');
+  return path.join(hooksDir, "watchdog-hidden.vbs");
 }
 
 function createVbsWrapper() {
-  const nodePath = process.execPath;
-  const scriptPath = getWatchdogScriptPath().replace(/\//g, '\\');
-  const vbs = `Set WshShell = CreateObject("WScript.Shell")
-WshShell.Run "cmd /c ""${nodePath}"" ""${scriptPath}""""", 0, True
-`;
-  const vbsPath = getVbsWrapperPath();
+  var nodePath = process.execPath;
+  var scriptPath = getWatchdogScriptPath().replace(/\//g, "\\");
+  var vbs = 'Set WshShell = CreateObject("WScript.Shell")\n' +
+    'WshShell.Run "cmd /c ""' + nodePath + '"" ""' + scriptPath + '""""", 0, True\n';
+  var vbsPath = getVbsWrapperPath();
   fs.writeFileSync(vbsPath, vbs);
   return vbsPath;
 }
 
 function cmdInstall() {
-  const { execSync } = require('child_process');
+  var execSync = require("child_process").execSync;
 
   if (isWindows) {
-    const vbsPath = createVbsWrapper();
+    var vbsPath = createVbsWrapper();
     // Delete existing task if any
-    try { execSync(`schtasks /Delete /TN "${TASK_NAME}" /F`, { stdio: 'pipe' }); } catch(e) {}
+    try { execSync('schtasks /Delete /TN "' + TASK_NAME + '" /F', { stdio: "pipe" }); } catch(e) {}
     // Create task: every 10 minutes, starts immediately
-    const cmd = `schtasks /Create /TN "${TASK_NAME}" /TR "wscript.exe \\"${vbsPath.replace(/\//g, '\\')}\\"" /SC MINUTE /MO 10 /F`;
+    var cmd = 'schtasks /Create /TN "' + TASK_NAME + '" /TR "wscript.exe \\"' + vbsPath.replace(/\//g, "\\") + '\\"" /SC MINUTE /MO 10 /F';
     try {
-      execSync(cmd, { stdio: 'pipe' });
-      console.log(`Installed scheduled task "${TASK_NAME}" (every 10 min)`);
-      console.log(`  VBS wrapper: ${vbsPath}`);
-      console.log(`  Script: ${getWatchdogScriptPath()}`);
+      execSync(cmd, { stdio: "pipe" });
+      console.log('Installed scheduled task "' + TASK_NAME + '" (every 10 min)');
+      console.log("  VBS wrapper: " + vbsPath);
+      console.log("  Script: " + getWatchdogScriptPath());
     } catch (e) {
-      console.error('Failed to create scheduled task:', e.message);
+      console.error("Failed to create scheduled task:", e.message);
       process.exit(2);
     }
   } else {
     // Linux/macOS: cron
-    const scriptPath = getWatchdogScriptPath();
-    const nodePath = process.execPath;
-    const cronLine = `*/10 * * * * ${nodePath} ${scriptPath} > /dev/null 2>&1 # ${TASK_NAME}`;
+    var scriptPath = getWatchdogScriptPath();
+    var nodePath = process.execPath;
+    var cronLine = "*/10 * * * * " + nodePath + " " + scriptPath + " > /dev/null 2>&1 # " + TASK_NAME;
     try {
-      let crontab = '';
-      try { crontab = execSync('crontab -l 2>/dev/null', { encoding: 'utf-8' }); } catch(e) {}
+      var crontab = "";
+      try { crontab = execSync("crontab -l 2>/dev/null", { encoding: "utf-8" }); } catch(e) {}
       // Remove existing entry
-      const lines = crontab.split('\n').filter(l => !l.includes(TASK_NAME));
+      var lines = crontab.split("\n").filter(function(l) { return !l.includes(TASK_NAME); });
       lines.push(cronLine);
-      const newCrontab = lines.filter(l => l.trim()).join('\n') + '\n';
-      execSync(`echo '${newCrontab}' | crontab -`, { stdio: 'pipe' });
-      console.log(`Installed cron job "${TASK_NAME}" (every 10 min)`);
-      console.log(`  Script: ${scriptPath}`);
+      var newCrontab = lines.filter(function(l) { return l.trim(); }).join("\n") + "\n";
+      // WHY: Pipe via stdin to avoid shell injection from crontab content containing quotes
+      require("child_process").execFileSync("crontab", ["-"], { input: newCrontab });
+      console.log('Installed cron job "' + TASK_NAME + '" (every 10 min)');
+      console.log("  Script: " + scriptPath);
     } catch (e) {
-      console.error('Failed to install cron job:', e.message);
+      console.error("Failed to install cron job:", e.message);
       process.exit(2);
     }
   }
@@ -318,91 +328,92 @@ function cmdInstall() {
 }
 
 function cmdUninstall() {
-  const { execSync } = require('child_process');
+  var execSync = require("child_process").execSync;
 
   if (isWindows) {
     try {
-      execSync(`schtasks /Delete /TN "${TASK_NAME}" /F`, { stdio: 'pipe' });
-      console.log(`Removed scheduled task "${TASK_NAME}"`);
+      execSync('schtasks /Delete /TN "' + TASK_NAME + '" /F', { stdio: "pipe" });
+      console.log('Removed scheduled task "' + TASK_NAME + '"');
     } catch (e) {
-      console.log(`Task "${TASK_NAME}" not found (already removed)`);
+      console.log('Task "' + TASK_NAME + '" not found (already removed)');
     }
     // Clean up VBS wrapper
-    const vbsPath = getVbsWrapperPath();
+    var vbsPath = getVbsWrapperPath();
     if (fs.existsSync(vbsPath)) fs.unlinkSync(vbsPath);
   } else {
     try {
-      let crontab = '';
-      try { crontab = execSync('crontab -l 2>/dev/null', { encoding: 'utf-8' }); } catch(e) {}
-      const lines = crontab.split('\n').filter(l => !l.includes(TASK_NAME));
-      const newCrontab = lines.filter(l => l.trim()).join('\n') + '\n';
-      execSync(`echo '${newCrontab}' | crontab -`, { stdio: 'pipe' });
-      console.log(`Removed cron job "${TASK_NAME}"`);
+      var crontab = "";
+      try { crontab = execSync("crontab -l 2>/dev/null", { encoding: "utf-8" }); } catch(e) {}
+      var lines = crontab.split("\n").filter(function(l) { return !l.includes(TASK_NAME); });
+      var newCrontab = lines.filter(function(l) { return l.trim(); }).join("\n") + "\n";
+      // WHY: Pipe via stdin to avoid shell injection from crontab content containing quotes
+      require("child_process").execFileSync("crontab", ["-"], { input: newCrontab });
+      console.log('Removed cron job "' + TASK_NAME + '"');
     } catch (e) {
-      console.log(`Cron job "${TASK_NAME}" not found (already removed)`);
+      console.log('Cron job "' + TASK_NAME + '" not found (already removed)');
     }
   }
   process.exit(0);
 }
 
 function cmdStatus() {
-  const { execSync } = require('child_process');
+  var execSync = require("child_process").execSync;
 
-  console.log('=== Watchdog Status ===');
+  console.log("=== Watchdog Status ===");
 
   // Check scheduler registration
-  let registered = false;
+  var registered = false;
   if (isWindows) {
     try {
-      const out = execSync(`schtasks /Query /TN "${TASK_NAME}" /FO LIST 2>&1`, { encoding: 'utf-8' });
+      var out = execSync('schtasks /Query /TN "' + TASK_NAME + '" /FO LIST 2>&1', { encoding: "utf-8" });
       registered = true;
-      const statusMatch = out.match(/Status:\s*(.+)/);
-      const nextMatch = out.match(/Next Run Time:\s*(.+)/);
-      const lastMatch = out.match(/Last Run Time:\s*(.+)/);
-      console.log(`  Scheduler: registered`);
-      if (statusMatch) console.log(`  Task status: ${statusMatch[1].trim()}`);
-      if (lastMatch) console.log(`  Last run: ${lastMatch[1].trim()}`);
-      if (nextMatch) console.log(`  Next run: ${nextMatch[1].trim()}`);
+      var statusMatch = out.match(/Status:\s*(.+)/);
+      var nextMatch = out.match(/Next Run Time:\s*(.+)/);
+      var lastMatch = out.match(/Last Run Time:\s*(.+)/);
+      console.log("  Scheduler: registered");
+      if (statusMatch) console.log("  Task status: " + statusMatch[1].trim());
+      if (lastMatch) console.log("  Last run: " + lastMatch[1].trim());
+      if (nextMatch) console.log("  Next run: " + nextMatch[1].trim());
     } catch (e) {
-      console.log('  Scheduler: not registered');
+      console.log("  Scheduler: not registered");
     }
   } else {
     try {
-      const crontab = execSync('crontab -l 2>/dev/null', { encoding: 'utf-8' });
+      var crontab = execSync("crontab -l 2>/dev/null", { encoding: "utf-8" });
       if (crontab.includes(TASK_NAME)) {
         registered = true;
-        console.log('  Scheduler: registered (cron)');
+        console.log("  Scheduler: registered (cron)");
       } else {
-        console.log('  Scheduler: not registered');
+        console.log("  Scheduler: not registered");
       }
     } catch (e) {
-      console.log('  Scheduler: not registered');
+      console.log("  Scheduler: not registered");
     }
   }
 
   // Check last log entry
-  const logPath = path.join(hooksDir, 'watchdog-log.jsonl');
+  var logPath = path.join(hooksDir, "watchdog-log.jsonl");
   if (fs.existsSync(logPath)) {
-    const lines = fs.readFileSync(logPath, 'utf-8').trim().split('\n');
+    var lines = fs.readFileSync(logPath, "utf-8").trim().split("\n");
     if (lines.length > 0) {
       try {
-        const last = JSON.parse(lines[lines.length - 1]);
-        console.log(`  Last check: ${last.timestamp} — ${last.status} (${last.passed}/${last.checks} passed)`);
+        var last = JSON.parse(lines[lines.length - 1]);
+        console.log("  Last check: " + last.timestamp + " — " + last.status + " (" + last.passed + "/" + last.checks + " passed)");
       } catch(e) {}
     }
-    console.log(`  Log entries: ${lines.length}`);
+    console.log("  Log entries: " + lines.length);
   } else {
-    console.log('  Log: no entries yet');
+    console.log("  Log: no entries yet");
   }
 
   // Check alert flag
-  const alertPath = path.join(hooksDir, '.watchdog-alert');
+  var alertPath = path.join(hooksDir, ".watchdog-alert");
   if (fs.existsSync(alertPath)) {
     try {
-      const alert = JSON.parse(fs.readFileSync(alertPath, 'utf-8'));
-      console.log(`  ALERT: ${alert.timestamp} — ${alert.failures.join(', ')}`);
+      var alert = JSON.parse(fs.readFileSync(alertPath, "utf-8"));
+      console.log("  ALERT: " + alert.timestamp + " — " + alert.failures.join(", "));
     } catch(e) {
-      console.log('  ALERT: flag exists but unreadable');
+      console.log("  ALERT: flag exists but unreadable");
     }
   }
 
@@ -411,31 +422,31 @@ function cmdStatus() {
 
 // --- Log viewer (T129) ---
 function cmdLog() {
-  const logPath = path.join(hooksDir, 'watchdog-log.jsonl');
+  var logPath = path.join(hooksDir, "watchdog-log.jsonl");
   if (!fs.existsSync(logPath)) {
-    console.log('No watchdog log found.');
+    console.log("No watchdog log found.");
     process.exit(0);
   }
 
-  const count = parseInt(getArg('--last') || '20', 10);
-  const lines = fs.readFileSync(logPath, 'utf-8').trim().split('\n');
-  const recent = lines.slice(-count);
+  var count = parseInt(getArg("--last") || "20", 10);
+  var lines = fs.readFileSync(logPath, "utf-8").trim().split("\n");
+  var recent = lines.slice(-count);
 
-  console.log(`=== Watchdog Log (last ${recent.length} of ${lines.length}) ===`);
-  for (const line of recent) {
+  console.log("=== Watchdog Log (last " + recent.length + " of " + lines.length + ") ===");
+  for (var i = 0; i < recent.length; i++) {
     try {
-      const e = JSON.parse(line);
-      const icon = e.status === 'healthy' ? 'OK' : e.status === 'repaired' ? 'REPAIRED' : 'BROKEN';
-      const detail = e.failures && e.failures.length > 0 ? ` — ${e.failures.join(', ')}` : '';
-      console.log(`  ${e.timestamp}  [${icon}]  ${e.passed}/${e.checks} checks${detail}`);
+      var e = JSON.parse(recent[i]);
+      var icon = e.status === "healthy" ? "OK" : e.status === "repaired" ? "REPAIRED" : "BROKEN";
+      var detail = e.failures && e.failures.length > 0 ? " — " + e.failures.join(", ") : "";
+      console.log("  " + e.timestamp + "  [" + icon + "]  " + e.passed + "/" + e.checks + " checks" + detail);
     } catch(e) {}
   }
   process.exit(0);
 }
 
 // --- CLI dispatch ---
-if (args.includes('--install')) { cmdInstall(); }
-else if (args.includes('--uninstall')) { cmdUninstall(); }
-else if (args.includes('--status')) { cmdStatus(); }
-else if (args.includes('--log')) { cmdLog(); }
+if (args.includes("--install")) { cmdInstall(); }
+else if (args.includes("--uninstall")) { cmdUninstall(); }
+else if (args.includes("--status")) { cmdStatus(); }
+else if (args.includes("--log")) { cmdLog(); }
 else { main(); }


### PR DESCRIPTION
## Summary
- Convert watchdog.js from ES6 (const/let/arrow/template/for-of/spread) to ES5 for project consistency
- Replace `execSync("echo '...' | crontab -")` with `execFileSync("crontab", ["-"], {input})` to prevent shell injection from crontab content containing quotes

## Test plan
- [x] All 8 watchdog tests pass locally
- [ ] CI passes (all 4 jobs)