### PR TITLE
T250: Version bump to 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.3.1] — 2026-04-05
+
+### Fixed
+- watchdog.js converted from ES6 to ES5 for consistency with all other files (#126)
+- Cron install/uninstall: replaced `execSync echo pipe` with `execFileSync stdin` to prevent shell injection from crontab content (#126)
+
 ## [2.3.0] — 2026-04-05
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -258,12 +258,16 @@ See `specs/watchdog/tasks.md` for full task list.
 - [x] T246: Community adoption: "Why hook-runner?" section in README — raw hooks vs modules vs workflows progression (#124)
 - [x] T247: Integration guide in README — context-reset, skill-maker, mcp-manager, marketplace (#124)
 
+## Code Review (session 2026-04-05f continued)
+- [x] T249: Convert watchdog.js from ES6 to ES5 + fix cron shell injection (#126)
+- [x] T250: Version bump to 2.3.1 + marketplace sync (#127)
+
 ## Release
 - [x] T248: Version bump to 2.3.0 + CHANGELOG + marketplace sync (#125)
 
 ## Status
-- 171 tasks completed, 0 pending
-- Version: 2.3.0
+- 173 tasks completed, 0 pending
+- Version: 2.3.1
 - 394 tests passing across 39 test suites
 - CI: GitHub Actions runs tests + secret-scan on push/PR — badge in README
 - Workflow engine: workflow.js + workflow-gate.js + 10 built-in workflow templates

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"

--- a/setup.js
+++ b/setup.js
@@ -46,7 +46,7 @@ var SCRIPT_DIR = __dirname;
 var REPO_DIR = SCRIPT_DIR;
 
 var HOOK_LOG_PATH = path.join(HOOKS_DIR, "hook-log.jsonl");
-var VERSION = "2.3.0";
+var VERSION = "2.3.1";
 
 // ============================================================
 // 0. Hook Log Stats


### PR DESCRIPTION
## Summary
- Version bump to 2.3.1
- CHANGELOG entry for #126 (watchdog ES5 + cron injection fix)

## Test plan
- [x] setup-wizard and docs-release tests pass locally
- [ ] CI passes (all 4 jobs)