### PR TITLE
T251: Increase per-suite test timeout to 120s

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -1082,7 +1082,7 @@ function cmdTest() {
         cwd: REPO_DIR,
         encoding: "utf-8",
         stdio: ["pipe", "pipe", "pipe"],
-        timeout: 60000
+        timeout: 120000
       });
       var match = result.match(/(\d+) passed, (\d+) failed/);
       if (match) {


### PR DESCRIPTION
## Summary
- Bump per-suite test timeout from 60s to 120s in the `--test` runner
- The module validation suite (114 tests) can timeout under system load, causing undercounted results

## Test plan
- [x] `bash scripts/test/test-setup-wizard.sh` — 7 passed
- CI will validate full suite on both Ubuntu and Windows