### PR TITLE
T253: Version bump to 2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.3.2] — 2026-04-05
+
+### Fixed
+- Per-suite test timeout increased from 60s to 120s — prevents false failures under load (#128)
+- `--test` now names which suites failed in summary line (#130)
+- `--test` prints `FAIL: suite crashed (exit code N)` when a suite crashes (#130)
+
 ## [2.3.1] — 2026-04-05
 
 ### Fixed

--- a/TODO.md
+++ b/TODO.md
@@ -267,10 +267,12 @@ See `specs/watchdog/tasks.md` for full task list.
 
 ## Robustness
 - [x] T251: Increase per-suite test timeout from 60s to 120s (module validation suite can timeout under load) (#128)
+- [x] T252: Show failed suite names in --test output + FAIL marker for crashed suites (#130)
+- [x] T253: Version bump to 2.3.2 + CHANGELOG + marketplace sync
 
 ## Status
-- 174 tasks completed, 0 pending
-- Version: 2.3.1
+- 176 tasks completed, 0 pending
+- Version: 2.3.2
 - 394 tests passing across 39 test suites
 - CI: GitHub Actions runs tests + secret-scan on push/PR — badge in README
 - Workflow engine: workflow.js + workflow-gate.js + 10 built-in workflow templates

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"

--- a/setup.js
+++ b/setup.js
@@ -46,7 +46,7 @@ var SCRIPT_DIR = __dirname;
 var REPO_DIR = SCRIPT_DIR;
 
 var HOOK_LOG_PATH = path.join(HOOKS_DIR, "hook-log.jsonl");
-var VERSION = "2.3.1";
+var VERSION = "2.3.2";
 
 // ============================================================
 // 0. Hook Log Stats


### PR DESCRIPTION
## Summary
- Version bump to 2.3.2
- CHANGELOG entry for T251 (test timeout) and T252 (failed suite names)
- TODO updated (176 tasks complete)

## Test plan
- [x] test-setup-wizard: 7 passed
- [x] test-T105-docs-release: 6 passed
- CI validates full suite