### PR TITLE
T257: Version bump to 2.4.0 + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.4.0] — 2026-04-05
+
+### Added
+- `--test-module <path>` command — test a single module with sample inputs, supports `--input <json>` for custom test data (#134)
+
+### Fixed
+- Workflow YAML/tag mismatches: dispatcher-worker 9→1, cross-project-reset 0→1, shtd 17→16 (#133)
+- Removed empty enforce-shtd.yml workflow (0 modules, dead placeholder) (#133)
+
 ## [2.3.2] — 2026-04-05
 
 ### Fixed

--- a/TODO.md
+++ b/TODO.md
@@ -279,9 +279,12 @@ See `specs/watchdog/tasks.md` for full task list.
 ## Developer Experience
 - [x] T256: Add --test-module command (test a single module with sample inputs, supports --input for custom JSON)
 
+## Release
+- [x] T257: Version bump to 2.4.0 + CHANGELOG
+
 ## Status
-- 179 tasks completed, 0 pending
-- Version: 2.3.2
+- 180 tasks completed, 0 pending
+- Version: 2.4.0
 - 394 tests passing across 39 test suites
 - CI: GitHub Actions runs tests + secret-scan on push/PR — badge in README
 - Workflow engine: workflow.js + workflow-gate.js + 9 built-in workflow templates

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"

--- a/setup.js
+++ b/setup.js
@@ -46,7 +46,7 @@ var SCRIPT_DIR = __dirname;
 var REPO_DIR = SCRIPT_DIR;
 
 var HOOK_LOG_PATH = path.join(HOOKS_DIR, "hook-log.jsonl");
-var VERSION = "2.3.2";
+var VERSION = "2.4.0";
 
 // ============================================================
 // 0. Hook Log Stats


### PR DESCRIPTION
## Summary
- Version 2.4.0 — adds --test-module, fixes workflow mismatches
- CHANGELOG entry for T255 + T256

## Test plan
- [x] Setup wizard tests pass (7/7)
- [x] Module docs tests pass (7/7)