### PR TITLE
T262: Version bump to 2.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.4.2] — 2026-04-05
+
+### Improved
+- `--perf` labels removed/archived modules with `[removed]` and excludes them from overhead estimates (#138)
+
+### Fixed
+- Remove unused `hasAsync` variable from run-async.js (#138)
+
 ## [2.4.1] — 2026-04-05
 
 ### Improved

--- a/TODO.md
+++ b/TODO.md
@@ -289,9 +289,13 @@ See `specs/watchdog/tasks.md` for full task list.
 ## Release
 - [x] T260: Version bump to 2.4.1 + CHANGELOG
 
+## Cleanup
+- [x] T261: Remove dead hasAsync var + --perf labels removed modules and excludes from overhead estimates
+- [x] T262: Version bump to 2.4.2 + CHANGELOG
+
 ## Status
-- 183 tasks completed, 0 pending
-- Version: 2.4.1
+- 185 tasks completed, 0 pending
+- Version: 2.4.2
 - 402 tests passing across 40 test suites
 - CI: GitHub Actions runs tests + secret-scan on push/PR — badge in README
 - Workflow engine: workflow.js + workflow-gate.js + 9 built-in workflow templates

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"

--- a/setup.js
+++ b/setup.js
@@ -46,7 +46,7 @@ var SCRIPT_DIR = __dirname;
 var REPO_DIR = SCRIPT_DIR;
 
 var HOOK_LOG_PATH = path.join(HOOKS_DIR, "hook-log.jsonl");
-var VERSION = "2.4.1";
+var VERSION = "2.4.2";
 
 // ============================================================
 // 0. Hook Log Stats


### PR DESCRIPTION
## Summary
- Version bump to 2.4.2
- CHANGELOG for T261 (dead code cleanup, perf accuracy)

## Test plan
- [x] All tests pass
- [x] CI validates