### PR TITLE
T263: Shared git context — eliminate redundant spawns

### DIFF
--- a/modules/PreToolUse/branch-pr-gate.js
+++ b/modules/PreToolUse/branch-pr-gate.js
@@ -98,7 +98,9 @@ function validateBranchName(name) {
   return null;
 }
 
-function getBranch() {
+function getBranch(input) {
+  // Use shared git context from runner if available (saves ~40ms)
+  if (input && input._git && input._git.branch) return input._git.branch;
   try {
     return cp.execSync("git rev-parse --abbrev-ref HEAD", {
       encoding: "utf-8", timeout: 5000
@@ -146,7 +148,7 @@ module.exports = function(input) {
       }
     }
 
-    var branch = getBranch();
+    var branch = getBranch(input);
     if (!branch) return null;
 
     if (branch === "main" || branch === "master") {
@@ -204,7 +206,7 @@ module.exports = function(input) {
     }
 
     // Only now spawn git — we know this is a state-changing command
-    var branch = getBranch();
+    var branch = getBranch(input);
     if (!branch) return null;
 
     if (branch === "main" || branch === "master") {

--- a/modules/PreToolUse/enforcement-gate.js
+++ b/modules/PreToolUse/enforcement-gate.js
@@ -52,9 +52,12 @@ module.exports = function(input) {
   // On task branches, iterative edits before committing are normal workflow.
   // The branch-pr-gate already ensures you're on the right branch.
   try {
-    var branch = child_process.execSync("git rev-parse --abbrev-ref HEAD", {
-      cwd: gitRoot, encoding: "utf-8", timeout: 5000
-    }).trim();
+    var branch = (input._git && input._git.branch) || "";
+    if (!branch) {
+      branch = child_process.execSync("git rev-parse --abbrev-ref HEAD", {
+        cwd: gitRoot, encoding: "utf-8", timeout: 5000
+      }).trim();
+    }
     if (branch === "main" || branch === "master") {
       var status = child_process.execSync("git status --porcelain", {
         cwd: gitRoot, encoding: "utf-8", timeout: 5000

--- a/modules/PreToolUse/remote-tracking-gate.js
+++ b/modules/PreToolUse/remote-tracking-gate.js
@@ -27,7 +27,8 @@ module.exports = function(input) {
   if (/specs\/|\.claude\/|\.github\/|cloudformation\//i.test(filePath)) return null;
 
   try {
-    var branch = cp.execSync("git branch --show-current", { cwd: process.cwd(), encoding: "utf-8" }).trim();
+    var branch = (input._git && input._git.branch) || "";
+    if (!branch) branch = cp.execSync("git branch --show-current", { cwd: process.cwd(), encoding: "utf-8" }).trim();
     if (!branch || branch === "main" || branch === "master") return null;
 
     try {

--- a/modules/PreToolUse/worker-loop.js
+++ b/modules/PreToolUse/worker-loop.js
@@ -22,10 +22,12 @@ module.exports = function(input) {
   if (!/gh\s+pr\s+create/.test(cmd)) return null;
 
   // Extract task ID from current branch name
-  var branch = "";
-  try {
-    branch = cp.execSync("git rev-parse --abbrev-ref HEAD", { encoding: "utf-8", timeout: 5000 }).trim();
-  } catch(e) { return null; }
+  var branch = (input._git && input._git.branch) || "";
+  if (!branch) {
+    try {
+      branch = cp.execSync("git rev-parse --abbrev-ref HEAD", { encoding: "utf-8", timeout: 5000 }).trim();
+    } catch(e) { return null; }
+  }
 
   var taskMatch = branch.match(/T(\d{3,4})/i);
   if (!taskMatch) return null;

--- a/run-pretooluse.js
+++ b/run-pretooluse.js
@@ -23,6 +23,19 @@ if (input && input.tool_input && typeof input.tool_input.path === "string") {
   input.tool_input.path = input.tool_input.path.replace(/\\/g, "/");
 }
 
+// WHY: 4 PreToolUse modules each spawn `git rev-parse --abbrev-ref HEAD` independently.
+// One shared call here saves ~80ms per tool invocation (3 redundant git spawns eliminated).
+try {
+  var cp = require("child_process");
+  var branch = cp.execSync("git rev-parse --abbrev-ref HEAD", {
+    encoding: "utf-8", timeout: 3000, stdio: ["pipe", "pipe", "pipe"]
+  }).trim();
+  if (branch) {
+    if (!input._git) input._git = {};
+    input._git.branch = branch;
+  }
+} catch (e) { /* not in a git repo — modules handle this gracefully */ }
+
 var ctx = hookLog.extractContext("PreToolUse", input);
 var modules = loadModules(path.join(__dirname, "run-modules", "PreToolUse"));
 


### PR DESCRIPTION
## Summary
- PreToolUse runner now calls `git rev-parse --abbrev-ref HEAD` once and injects `input._git.branch`
- 4 modules updated to use shared context with fallback: branch-pr-gate, enforcement-gate, remote-tracking-gate, worker-loop
- Saves ~80ms per PreToolUse invocation (3 redundant git spawns eliminated)

## Test plan
- [x] All 40 test suites pass (402 tests)
- [x] Manual verification: modules accept `_git.branch` and skip git spawn
- [x] Backwards compatible: modules fall back to own git call if `_git` not present