### PR TITLE
T266: Version bump to 2.5.0 + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 All notable changes to hook-runner are documented here.
 
-## [2.4.3] — 2026-04-05
+## [2.5.0] — 2026-04-05
 
 ### Improved
 - Shared git context in PreToolUse runner — one `git rev-parse` call shared across 4 modules instead of each spawning independently (~80ms savings per tool call) (#140)
+- `--workflow sync-live` now copies core files (runners, loader, logger) and project-scoped module subdirectories (#142)
+  - File count: 66 → 78. Runner changes are now deployed automatically.
 
 ## [2.4.2] — 2026-04-05
 

--- a/TODO.md
+++ b/TODO.md
@@ -293,13 +293,15 @@ See `specs/watchdog/tasks.md` for full task list.
 - [x] T261: Remove dead hasAsync var + --perf labels removed modules and excludes from overhead estimates
 - [x] T262: Version bump to 2.4.2 + CHANGELOG
 
-## Performance
+## Performance & sync-live
 - [x] T263: Shared git context in PreToolUse runner — one git call shared across 4 modules (~80ms savings per tool call)
 - [x] T264: Version bump to 2.4.3 + CHANGELOG
+- [x] T265: sync-live now copies runners + project-scoped module subdirs (66→78 files)
+- [x] T266: Version bump to 2.5.0 + CHANGELOG
 
 ## Status
-- 187 tasks completed, 0 pending
-- Version: 2.4.3 (released, tagged, marketplace synced, live hooks synced)
+- 189 tasks completed, 0 pending
+- Version: 2.5.0 (released, tagged, marketplace synced, live hooks synced)
 - 402 tests passing across 40 test suites
 - CI: GitHub Actions runs tests + secret-scan on push/PR — badge in README
 - Workflow engine: workflow.js + workflow-gate.js + 9 built-in workflow templates

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.4.3",
+  "version": "2.5.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"

--- a/setup.js
+++ b/setup.js
@@ -46,7 +46,7 @@ var SCRIPT_DIR = __dirname;
 var REPO_DIR = SCRIPT_DIR;
 
 var HOOK_LOG_PATH = path.join(HOOKS_DIR, "hook-log.jsonl");
-var VERSION = "2.4.3";
+var VERSION = "2.5.0";
 
 // ============================================================
 // 0. Hook Log Stats


### PR DESCRIPTION
## Summary
- Version bump to 2.5.0
- CHANGELOG entries for T263 (git context perf) and T265 (sync-live runners)

## Test plan
- [x] Setup wizard tests pass