### PR TITLE
T267: Fix uninstall leaving workflow.js and workflow-cli.js behind

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -847,7 +847,7 @@ function cmdUninstall(args, dryRun) {
   } else {
     uninstallChanges.push({ what: "settings.json", status: "not found" });
   }
-  var runnerFiles = ["run-pretooluse.js", "run-posttooluse.js", "run-stop.js", "run-sessionstart.js", "run-userpromptsubmit.js", "load-modules.js", "hook-log.js", "run-async.js", "setup.js"];
+  var runnerFiles = ["run-pretooluse.js", "run-posttooluse.js", "run-stop.js", "run-sessionstart.js", "run-userpromptsubmit.js", "load-modules.js", "hook-log.js", "run-async.js", "workflow.js", "workflow-cli.js", "setup.js"];
   for (var uf = 0; uf < runnerFiles.length; uf++) {
     var fp = path.join(HOOKS_DIR, runnerFiles[uf]);
     if (fs.existsSync(fp)) {


### PR DESCRIPTION
## Summary
- `installRunners` copies `workflow.js` and `workflow-cli.js` to `~/.claude/hooks/`
- `cmdUninstall` file list was missing both, leaving orphan files after `--uninstall`
- Added both to the uninstall cleanup list

## Test plan
- [x] `bash scripts/test/test-setup-wizard.sh` — 7/7 pass