### PR TITLE
T269: Version bump to 2.5.1 + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.5.1] — 2026-04-05
+
+### Fixed
+- `--uninstall` now removes `workflow.js` and `workflow-cli.js` (were installed but not cleaned up) (#144)
+
+### Improved
+- DRY: shared `RUNNER_FILES` constant eliminates 3 divergent file lists in install/upgrade/uninstall (#145)
+
 ## [2.5.0] — 2026-04-05
 
 ### Improved

--- a/TODO.md
+++ b/TODO.md
@@ -299,9 +299,14 @@ See `specs/watchdog/tasks.md` for full task list.
 - [x] T265: sync-live now copies runners + project-scoped module subdirs (66→78 files)
 - [x] T266: Version bump to 2.5.0 + CHANGELOG
 
+## Bug Fix & DRY
+- [x] T267: Fix uninstall leaving workflow.js and workflow-cli.js behind (#144)
+- [x] T268: DRY — shared RUNNER_FILES constant for install/upgrade/uninstall (#145)
+- [x] T269: Version bump to 2.5.1 + CHANGELOG
+
 ## Status
-- 189 tasks completed, 0 pending
-- Version: 2.5.0 (released, tagged, marketplace synced, live hooks synced)
+- 192 tasks completed, 0 pending
+- Version: 2.5.1 (released, tagged, marketplace synced, live hooks synced)
 - Clones: 2055 total, 0 stars/forks/issues — stable utility, no community demand for features
 - 402 tests passing across 40 test suites
 - CI: GitHub Actions runs tests + secret-scan on push/PR — badge in README

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"

--- a/setup.js
+++ b/setup.js
@@ -46,7 +46,7 @@ var SCRIPT_DIR = __dirname;
 var REPO_DIR = SCRIPT_DIR;
 
 var HOOK_LOG_PATH = path.join(HOOKS_DIR, "hook-log.jsonl");
-var VERSION = "2.5.0";
+var VERSION = "2.5.1";
 
 // Shared file lists — single source of truth for install/upgrade/uninstall
 var RUNNER_FILES = [


### PR DESCRIPTION
## Summary
- Version bump to 2.5.1
- CHANGELOG entries for T267 (uninstall fix) and T268 (DRY refactor)
- TODO.md updated with T267-T269

## Test plan
- [x] `bash scripts/test/test-setup-wizard.sh` — 7/7 pass