### PR TITLE
T270: Add missing headers to project-scoped modules

### DIFF
--- a/modules/PreToolUse/_example-project/use-workers.js
+++ b/modules/PreToolUse/_example-project/use-workers.js
@@ -1,3 +1,5 @@
+// WORKFLOW: dispatcher-worker
+// WHY: Example showing how project-scoped modules delegate work to remote workers.
 // Example project-scoped module: delegate implementation to remote workers.
 // Only runs when CLAUDE_PROJECT_DIR basename matches the folder name.
 // Blocks Edit/Write to implementation files — only specs/plans/infra allowed locally.

--- a/modules/PreToolUse/ddei-email-security/share-is-generic.js
+++ b/modules/PreToolUse/ddei-email-security/share-is-generic.js
@@ -1,3 +1,4 @@
+// WORKFLOW: code-quality
 // WHY: share/ is the customer deliverable shipped to many different customers.
 // Customer names, internal project codenames, meeting note references, and
 // employee names leaked into share/ files multiple times during development.

--- a/modules/PreToolUse/hackathon26/use-workers.js
+++ b/modules/PreToolUse/hackathon26/use-workers.js
@@ -1,3 +1,5 @@
+// WORKFLOW: dispatcher-worker
+// WHY: Local Claude implemented features directly instead of delegating to fleet workers.
 // Enforce: local Claude manages fleet, workers implement features.
 // Blocks Edit/Write to implementation files in any project with specs/.
 // Blocks Bash commands that look like implementation work (npm test, node app, etc.)

--- a/modules/Stop/hackathon26/delegate-and-monitor.js
+++ b/modules/Stop/hackathon26/delegate-and-monitor.js
@@ -1,3 +1,5 @@
+// WORKFLOW: dispatcher-worker
+// WHY: Stop hook kept stopping instead of monitoring fleet workers.
 // hackathon26 stop hook: delegate and monitor, never implement locally.
 // Complements global auto-continue (which says "never stop").
 // This adds: for hackathon26, "keep working" means monitor fleet, not code.


### PR DESCRIPTION
## Summary
- 4 project-scoped modules were missing required WORKFLOW tags and/or WHY comments
- Fixed: ddei-email-security/share-is-generic, hackathon26/use-workers, _example-project/use-workers, hackathon26/delegate-and-monitor
- All 57+ catalog modules now pass header validation

## Test plan
- [x] Module header validation script — 0 issues