### PR TITLE
T272: Version bump to 2.5.2 + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.5.2] — 2026-04-05
+
+### Improved
+- Added WORKFLOW/WHY header checks to module validation tests (#147, #148)
+- Module tests now traverse project-scoped subdirectories (test count: ~100 → 244)
+
 ## [2.5.1] — 2026-04-05
 
 ### Fixed

--- a/TODO.md
+++ b/TODO.md
@@ -304,11 +304,16 @@ See `specs/watchdog/tasks.md` for full task list.
 - [x] T268: DRY — shared RUNNER_FILES constant for install/upgrade/uninstall (#145)
 - [x] T269: Version bump to 2.5.1 + CHANGELOG
 
+## Code Quality
+- [x] T270: Add missing WORKFLOW/WHY headers to 4 project-scoped modules (#147)
+- [x] T271: Module validation tests check headers + traverse subdirs (100→244 tests) (#148)
+- [x] T272: Version bump to 2.5.2 + CHANGELOG
+
 ## Status
-- 192 tasks completed, 0 pending
-- Version: 2.5.1 (released, tagged, marketplace synced, live hooks synced)
+- 195 tasks completed, 0 pending
+- Version: 2.5.2 (released, tagged, marketplace synced, live hooks synced)
 - Clones: 2055 total, 0 stars/forks/issues — stable utility, no community demand for features
-- 402 tests passing across 40 test suites
+- 544 tests passing across 40 test suites
 - CI: GitHub Actions runs tests + secret-scan on push/PR — badge in README
 - Workflow engine: workflow.js + workflow-gate.js + 9 built-in workflow templates
 - CLI commands: setup, report, dry-run, health, sync, stats, list, test, upgrade, uninstall, prune, version, help, workflow (list/audit/query/enable/disable/start/status/complete/reset/create/add-module/sync-live), perf, export

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"

--- a/setup.js
+++ b/setup.js
@@ -46,7 +46,7 @@ var SCRIPT_DIR = __dirname;
 var REPO_DIR = SCRIPT_DIR;
 
 var HOOK_LOG_PATH = path.join(HOOKS_DIR, "hook-log.jsonl");
-var VERSION = "2.5.1";
+var VERSION = "2.5.2";
 
 // Shared file lists — single source of truth for install/upgrade/uninstall
 var RUNNER_FILES = [


### PR DESCRIPTION
## Summary
- Version bump to 2.5.2
- CHANGELOG for T270 (module headers) and T271 (test coverage)
- TODO.md updated with T270-T272

## Test plan
- [x] `bash scripts/test/test-setup-wizard.sh` — 7/7 pass