### PR TITLE
T273: Fix sync-live missing workflow.js and workflow-cli.js

### DIFF
--- a/workflow-cli.js
+++ b/workflow-cli.js
@@ -429,11 +429,12 @@ function cmdWorkflow(args) {
         copied++;
       }
     }
-    // Sync core files (runners, loader, logger, async helper)
+    // Sync core files (runners, loader, logger, async helper, workflow engine)
     var coreFiles = [
       "run-pretooluse.js", "run-posttooluse.js", "run-stop.js",
       "run-sessionstart.js", "run-userpromptsubmit.js",
-      "load-modules.js", "hook-log.js", "run-async.js"
+      "load-modules.js", "hook-log.js", "run-async.js",
+      "workflow.js", "workflow-cli.js"
     ];
     for (var ci2 = 0; ci2 < coreFiles.length; ci2++) {
       var srcCore = path.join(__dirname, coreFiles[ci2]);


### PR DESCRIPTION
## Summary
- `sync-live` had its own hardcoded `coreFiles` list missing `workflow.js` and `workflow-cli.js`
- T268 centralized the list in `RUNNER_FILES` for install/upgrade/uninstall, but sync-live wasn't updated
- Result: `workflow-cli.js` was absent from `~/.claude/hooks/` after sync-live (80 files now, was 78)

## Test plan
- [x] `test-T101-workflow-cli.sh` passes (8/8)
- [x] Manual verify: move workflow-cli.js aside → sync-live → file restored