### PR TITLE
T274: Extract RUNNER_FILES to shared constants.js

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+"use strict";
+// Shared constants for hook-runner.
+// Single source of truth for file lists used by install, upgrade, uninstall, and sync-live.
+
+var RUNNER_FILES = [
+  "run-pretooluse.js", "run-posttooluse.js", "run-stop.js",
+  "run-sessionstart.js", "run-userpromptsubmit.js",
+  "load-modules.js", "hook-log.js", "run-async.js",
+  "workflow.js", "workflow-cli.js", "constants.js"
+];
+
+module.exports = { RUNNER_FILES: RUNNER_FILES };

--- a/setup.js
+++ b/setup.js
@@ -48,13 +48,8 @@ var REPO_DIR = SCRIPT_DIR;
 var HOOK_LOG_PATH = path.join(HOOKS_DIR, "hook-log.jsonl");
 var VERSION = "2.5.2";
 
-// Shared file lists — single source of truth for install/upgrade/uninstall
-var RUNNER_FILES = [
-  "run-pretooluse.js", "run-posttooluse.js", "run-stop.js",
-  "run-sessionstart.js", "run-userpromptsubmit.js",
-  "load-modules.js", "hook-log.js", "run-async.js",
-  "workflow.js", "workflow-cli.js"
-];
+// Shared file lists — single source of truth (see constants.js)
+var RUNNER_FILES = require(path.join(__dirname, "constants.js")).RUNNER_FILES;
 
 // ============================================================
 // 0. Hook Log Stats

--- a/workflow-cli.js
+++ b/workflow-cli.js
@@ -429,13 +429,8 @@ function cmdWorkflow(args) {
         copied++;
       }
     }
-    // Sync core files (runners, loader, logger, async helper, workflow engine)
-    var coreFiles = [
-      "run-pretooluse.js", "run-posttooluse.js", "run-stop.js",
-      "run-sessionstart.js", "run-userpromptsubmit.js",
-      "load-modules.js", "hook-log.js", "run-async.js",
-      "workflow.js", "workflow-cli.js"
-    ];
+    // Sync core files — shared constant (see constants.js)
+    var coreFiles = require(path.join(__dirname, "constants.js")).RUNNER_FILES;
     for (var ci2 = 0; ci2 < coreFiles.length; ci2++) {
       var srcCore = path.join(__dirname, coreFiles[ci2]);
       if (fs.existsSync(srcCore)) {


### PR DESCRIPTION
## Summary
- `RUNNER_FILES` was defined in `setup.js` but duplicated (incompletely) in `workflow-cli.js` sync-live
- Extract to `constants.js` so both import from one source — no more divergent lists
- `constants.js` is included in `RUNNER_FILES` itself so it gets deployed to live hooks

## Test plan
- [x] `test-setup-wizard.sh` passes (7/7)
- [x] `test-T101-workflow-cli.sh` passes (8/8)
- [x] `sync-live` copies 81 files (including constants.js)