### PR TITLE
T276: Version bump to 2.5.3 + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.5.3] — 2026-04-05
+
+### Fixed
+- `sync-live` now copies `workflow.js` and `workflow-cli.js` to live hooks (#150)
+- `--uninstall` now removes `report.js` (was orphaned after uninstall) (#152)
+- Added `constants.js` to `package.json` files array (fixed broken `npx` install) (#152)
+
+### Improved
+- DRY: extracted `RUNNER_FILES` to `constants.js` shared by `setup.js` and `workflow-cli.js` (#151)
+
 ## [2.5.2] — 2026-04-05
 
 ### Improved

--- a/TODO.md
+++ b/TODO.md
@@ -309,9 +309,15 @@ See `specs/watchdog/tasks.md` for full task list.
 - [x] T271: Module validation tests check headers + traverse subdirs (100→244 tests) (#148)
 - [x] T272: Version bump to 2.5.2 + CHANGELOG
 
+## Bug Fixes & DRY (session 2026-04-05g)
+- [x] T273: Fix sync-live missing workflow.js and workflow-cli.js (#150)
+- [x] T274: DRY — extract RUNNER_FILES to constants.js shared by setup.js and workflow-cli.js (#151)
+- [x] T275: Fix uninstall leaving report.js behind + add constants.js to package.json (#152)
+- [x] T276: Version bump to 2.5.3 + CHANGELOG
+
 ## Status
-- 195 tasks completed, 0 pending
-- Version: 2.5.2 (released, tagged, marketplace synced, live hooks synced)
+- 199 tasks completed, 0 pending
+- Version: 2.5.3 (released, tagged, marketplace synced, live hooks synced)
 - Clones: 2055 total, 0 stars/forks/issues — stable utility, no community demand for features
 - 544 tests passing across 40 test suites
 - CI: GitHub Actions runs tests + secret-scan on push/PR — badge in README

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"

--- a/setup.js
+++ b/setup.js
@@ -46,7 +46,7 @@ var SCRIPT_DIR = __dirname;
 var REPO_DIR = SCRIPT_DIR;
 
 var HOOK_LOG_PATH = path.join(HOOKS_DIR, "hook-log.jsonl");
-var VERSION = "2.5.2";
+var VERSION = "2.5.3";
 
 // Shared file lists — single source of truth (see constants.js)
 var RUNNER_FILES = require(path.join(__dirname, "constants.js")).RUNNER_FILES;


### PR DESCRIPTION
## Summary
- Version bump for T273-T275 bug fixes
- sync-live, uninstall, and npx install all fixed

## Test plan
- [x] `test-setup-wizard.sh` passes (7/7)