### PR TITLE
T277: Add missing files to watchdog required_runners

### DIFF
--- a/scripts/test/test-T122-watchdog.sh
+++ b/scripts/test/test-T122-watchdog.sh
@@ -21,7 +21,7 @@ mkdir -p "$TMPDIR/run-modules/Stop" "$TMPDIR/run-modules/PreToolUse"
 trap 'rm -rf "$TMPDIR"' EXIT
 
 # Create minimal runner files
-for r in run-pretooluse.js run-posttooluse.js run-stop.js run-sessionstart.js run-userpromptsubmit.js load-modules.js workflow.js; do
+for r in run-pretooluse.js run-posttooluse.js run-stop.js run-sessionstart.js run-userpromptsubmit.js load-modules.js hook-log.js run-async.js workflow.js workflow-cli.js constants.js; do
   echo "// stub" > "$TMPDIR/$r"
 done
 

--- a/watchdog.js
+++ b/watchdog.js
@@ -27,7 +27,8 @@ var DEFAULT_CONFIG = {
   required_runners: [
     "run-pretooluse.js", "run-posttooluse.js", "run-stop.js",
     "run-sessionstart.js", "run-userpromptsubmit.js",
-    "load-modules.js", "workflow.js"
+    "load-modules.js", "hook-log.js", "run-async.js",
+    "workflow.js", "workflow-cli.js", "constants.js"
   ],
   required_modules: ["Stop/auto-continue.js", "PreToolUse/branch-pr-gate.js"]
 };


### PR DESCRIPTION
## Summary
- Watchdog `DEFAULT_CONFIG.required_runners` was missing `hook-log.js`, `run-async.js`, `workflow-cli.js`, and `constants.js`
- These files are deployed by install/sync-live but watchdog wouldn't detect if they went missing
- Updated test stubs to create all runner files

## Test plan
- [x] `test-T122-watchdog.sh` passes (8/8)