### PR TITLE
T278: Use RUNNER_FILES constant in health checks

### DIFF
--- a/modules/SessionStart/project-health.js
+++ b/modules/SessionStart/project-health.js
@@ -12,8 +12,12 @@ module.exports = function(input) {
   var settingsPath = path.join(home, ".claude", "settings.json");
   var warnings = [];
 
-  // 1. Check core runners exist
-  var runners = ["run-pretooluse.js", "run-posttooluse.js", "run-stop.js", "run-sessionstart.js", "run-userpromptsubmit.js", "load-modules.js", "hook-log.js"];
+  // 1. Check core runners exist (shared constant)
+  var constantsPath = path.join(hooksDir, "constants.js");
+  var runners;
+  try { runners = require(constantsPath).RUNNER_FILES; } catch(e) {
+    runners = ["run-pretooluse.js", "run-posttooluse.js", "run-stop.js", "run-sessionstart.js", "run-userpromptsubmit.js", "load-modules.js", "hook-log.js", "run-async.js", "workflow.js", "workflow-cli.js", "constants.js"];
+  }
   var missingRunners = [];
   for (var i = 0; i < runners.length; i++) {
     if (!fs.existsSync(path.join(hooksDir, runners[i]))) {

--- a/setup.js
+++ b/setup.js
@@ -1596,8 +1596,8 @@ function healthCheck() {
   var results = [];
   var events = ["PreToolUse", "PostToolUse", "Stop", "SessionStart", "UserPromptSubmit"];
 
-  // 1. Check runners exist
-  var runners = ["run-pretooluse.js", "run-posttooluse.js", "run-stop.js", "run-sessionstart.js", "run-userpromptsubmit.js", "load-modules.js", "hook-log.js"];
+  // 1. Check runners exist (uses shared constant)
+  var runners = RUNNER_FILES;
   for (var ri = 0; ri < runners.length; ri++) {
     var rPath = path.join(HOOKS_DIR, runners[ri]);
     if (fs.existsSync(rPath)) {


### PR DESCRIPTION
## Summary
- `healthCheck()` in setup.js and `project-health` SessionStart module had hardcoded runner lists missing 4 files
- Both now use `constants.js` as source of truth (health check: 72→76 checks)
- project-health falls back to inline list if constants.js not yet deployed

## Test plan
- [x] `test-setup-wizard.sh` passes (7/7)
- [x] `--health` shows 76 checks, 0 failures