### PR TITLE
T279: Version bump to 2.5.4 + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.5.4] — 2026-04-05
+
+### Improved
+- Watchdog `required_runners` now checks all deployed files including `constants.js` (#154)
+- `healthCheck()` and `project-health` module now use shared `RUNNER_FILES` constant (72→76 checks) (#155)
+
 ## [2.5.3] — 2026-04-05
 
 ### Fixed

--- a/TODO.md
+++ b/TODO.md
@@ -314,10 +314,13 @@ See `specs/watchdog/tasks.md` for full task list.
 - [x] T274: DRY — extract RUNNER_FILES to constants.js shared by setup.js and workflow-cli.js (#151)
 - [x] T275: Fix uninstall leaving report.js behind + add constants.js to package.json (#152)
 - [x] T276: Version bump to 2.5.3 + CHANGELOG
+- [x] T277: Add missing files to watchdog required_runners (#154)
+- [x] T278: Use RUNNER_FILES constant in health checks — 72→76 checks (#155)
+- [x] T279: Version bump to 2.5.4 + CHANGELOG
 
 ## Status
-- 199 tasks completed, 0 pending
-- Version: 2.5.3 (released, tagged, marketplace synced, live hooks synced)
+- 202 tasks completed, 0 pending
+- Version: 2.5.4 (released, tagged, marketplace synced, live hooks synced)
 - Clones: 2055 total, 0 stars/forks/issues — stable utility, no community demand for features
 - 544 tests passing across 40 test suites
 - CI: GitHub Actions runs tests + secret-scan on push/PR — badge in README

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"

--- a/setup.js
+++ b/setup.js
@@ -46,7 +46,7 @@ var SCRIPT_DIR = __dirname;
 var REPO_DIR = SCRIPT_DIR;
 
 var HOOK_LOG_PATH = path.join(HOOKS_DIR, "hook-log.jsonl");
-var VERSION = "2.5.3";
+var VERSION = "2.5.4";
 
 // Shared file lists — single source of truth (see constants.js)
 var RUNNER_FILES = require(path.join(__dirname, "constants.js")).RUNNER_FILES;


### PR DESCRIPTION
## Summary
- Version bump for T277-T278 (watchdog + health check runner list fixes)

## Test plan
- [x] `test-setup-wizard.sh` passes (7/7)