### PR TITLE
T280: Replace .forEach() with for-loops for ES5 consistency

### DIFF
--- a/modules/SessionStart/load-lessons.js
+++ b/modules/SessionStart/load-lessons.js
@@ -17,12 +17,14 @@ var MAX_LESSONS = 10; // inject the 10 most recent
 function checkBgErrors() {
   // Surface background script errors that the user can't see
   var msgs = [];
-  [ERROR_LOG, ANALYSIS_LOG].forEach(function(logFile) {
+  var logFiles = [ERROR_LOG, ANALYSIS_LOG];
+  for (var i = 0; i < logFiles.length; i++) {
+    var logFile = logFiles[i];
     try {
-      if (!fs.existsSync(logFile)) return;
+      if (!fs.existsSync(logFile)) continue;
       var stat = fs.statSync(logFile);
       // Only report if modified in last 24 hours
-      if (Date.now() - stat.mtimeMs > 86400000) return;
+      if (Date.now() - stat.mtimeMs > 86400000) continue;
       var lines = fs.readFileSync(logFile, "utf-8").trim().split("\n");
       var errors = lines.filter(function(l) {
         return /error|fail|stderr/i.test(l);
@@ -32,7 +34,7 @@ function checkBgErrors() {
           errors.join("\n"));
       }
     } catch(e) {}
-  });
+  }
   return msgs.length > 0 ? msgs.join("\n\n") : "";
 }
 

--- a/setup.js
+++ b/setup.js
@@ -1296,11 +1296,12 @@ function cmdPerf() {
       var evDir = path.join(modsDir, modEvents[me]);
       if (fs.existsSync(evDir)) {
         try {
-          fs.readdirSync(evDir, { withFileTypes: true }).forEach(function(e) {
-            if (e.isFile() && e.name.endsWith(".js")) {
-              installedModules[modEvents[me] + "/" + e.name.replace(".js", "")] = true;
+          var entries = fs.readdirSync(evDir, { withFileTypes: true });
+          for (var ei = 0; ei < entries.length; ei++) {
+            if (entries[ei].isFile() && entries[ei].name.endsWith(".js")) {
+              installedModules[modEvents[me] + "/" + entries[ei].name.replace(".js", "")] = true;
             }
-          });
+          }
         } catch(e) {}
       }
     }


### PR DESCRIPTION
## Summary
- Replace `.forEach()` in `cmdPerf()` (setup.js:1299) with a standard for-loop
- Replace `.forEach()` in `load-lessons.js` (modules/SessionStart) with a for-loop
- All other JS files already use ES5 for-loops consistently

## Test plan
- [x] setup wizard tests pass (7/7)
- [x] module validation tests pass (244/244)