### PR TITLE
T284: Add --test-module to README CLI Reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ node setup.js --perf                   # module timing analysis
 node setup.js --prune [N]             # prune log entries older than N days
 
 # Development
+node setup.js --test-module <file> [--input <json>]  # test one module
 node setup.js --test                   # run all test suites
 node setup.js --version                # show version
 node setup.js --help                   # show all commands


### PR DESCRIPTION
## Summary
- `--test-module` was documented in the tutorial section but missing from the CLI Reference section
- Added it to the Development commands group