### PR TITLE
T286: Version bump to 2.5.6 + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.5.6] — 2026-04-05
+
+### Added
+- `terminal-title` SessionStart module — sets terminal title to project folder name for multi-tab disambiguation (#162)
+- `session-management` workflow now has 12 modules (was 11)
+
 ## [2.5.5] — 2026-04-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"

--- a/setup.js
+++ b/setup.js
@@ -46,7 +46,7 @@ var SCRIPT_DIR = __dirname;
 var REPO_DIR = SCRIPT_DIR;
 
 var HOOK_LOG_PATH = path.join(HOOKS_DIR, "hook-log.jsonl");
-var VERSION = "2.5.5";
+var VERSION = "2.5.6";
 
 // Shared file lists — single source of truth (see constants.js)
 var RUNNER_FILES = require(path.join(__dirname, "constants.js")).RUNNER_FILES;


### PR DESCRIPTION
## Summary
- Version bump to 2.5.6
- CHANGELOG entry for terminal-title module (#162)

## Test plan
- [ ] `node setup.js --version` shows 2.5.6
- [ ] CI passes