### PR TITLE
T291: Version bump to 2.5.8 + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.5.8] — 2026-04-05
+
+### Fixed
+- Replace `.startsWith()` and `.endsWith()` ES6 methods with `indexOf()` in 9 module files for ES5 consistency (#166)
+
 ## [2.5.7] — 2026-04-05
 
 ### Performance

--- a/TODO.md
+++ b/TODO.md
@@ -337,8 +337,10 @@ See `specs/watchdog/tasks.md` for full task list.
 - [x] T289: Version bump to 2.5.7 + CHANGELOG (#165)
 - [x] T290: Replace .startsWith()/.endsWith() ES6 with indexOf() in 9 module files
 
+- [x] T291: Version bump to 2.5.8 + CHANGELOG (#167)
+
 ## Status
-- 213 tasks completed, 0 pending
+- 214 tasks completed, 0 pending
 - Version: 2.5.6 (released, tagged, marketplace synced, live hooks synced)
 - 58 modules across 9 workflows, 536 tests passing across 40 test suites
 - Health: 77 OK, 0 warnings, 0 failures

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.5.7",
+  "version": "2.5.8",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"

--- a/setup.js
+++ b/setup.js
@@ -46,7 +46,7 @@ var SCRIPT_DIR = __dirname;
 var REPO_DIR = SCRIPT_DIR;
 
 var HOOK_LOG_PATH = path.join(HOOKS_DIR, "hook-log.jsonl");
-var VERSION = "2.5.7";
+var VERSION = "2.5.8";
 
 // Shared file lists — single source of truth (see constants.js)
 var RUNNER_FILES = require(path.join(__dirname, "constants.js")).RUNNER_FILES;


### PR DESCRIPTION
## Summary
- Version bump to 2.5.8
- CHANGELOG entry for T290 ES5 fixes

## Test plan
- [x] Setup wizard: 7 passed