### PR TITLE
T293: Version bump to 2.5.9 + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.5.9] — 2026-04-05
+
+### Added
+- **Report: Workflow summary** — clickable cards showing each workflow and its modules, with block counts (#168)
+- **Report: Workflow filter** — toolbar buttons to filter all modules by workflow name (#168)
+- **Report: Workflow badge** — colored badge on each module card showing its workflow (#168)
+- **Report: WHY text** — incident description shown prominently below module name, no longer buried in source (#168)
+
 ## [2.5.8] — 2026-04-05
 
 ### Fixed

--- a/TODO.md
+++ b/TODO.md
@@ -339,9 +339,12 @@ See `specs/watchdog/tasks.md` for full task list.
 
 - [x] T291: Version bump to 2.5.8 + CHANGELOG (#167)
 
+## Report Enhancement
+- [x] T292: Add workflow + WHY metadata to HTML report — workflow summary cards, filter buttons, workflow badge per module, WHY text shown prominently (#168)
+
 ## Status
-- 214 tasks completed, 0 pending
-- Version: 2.5.6 (released, tagged, marketplace synced, live hooks synced)
+- 215 tasks completed, 0 pending
+- Version: 2.5.8 (released, tagged, marketplace synced, live hooks synced)
 - 58 modules across 9 workflows, 536 tests passing across 40 test suites
 - Health: 77 OK, 0 warnings, 0 failures
 - Performance: PreToolUse ~228ms/call (25 modules), SessionStart ~4s (8 modules, config-sync dominates)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.5.8",
+  "version": "2.5.9",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"

--- a/setup.js
+++ b/setup.js
@@ -46,7 +46,7 @@ var SCRIPT_DIR = __dirname;
 var REPO_DIR = SCRIPT_DIR;
 
 var HOOK_LOG_PATH = path.join(HOOKS_DIR, "hook-log.jsonl");
-var VERSION = "2.5.8";
+var VERSION = "2.5.9";
 
 // Shared file lists — single source of truth (see constants.js)
 var RUNNER_FILES = require(path.join(__dirname, "constants.js")).RUNNER_FILES;


### PR DESCRIPTION
## Summary
- Version bump to 2.5.9
- CHANGELOG entry for T292 report enhancements
- TODO.md updated with T292

## Test plan
- [x] Setup wizard tests pass (7/7)