### PR TITLE
T297: Fix spec-gate test + README module docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,9 @@ Full catalog in `modules/` directory:
 #### Project-Scoped PreToolUse
 | Module | Project | Description |
 |--------|---------|-------------|
+| `no-customer-env-changes` | ep-incident-response | Blocks infrastructure changes during incident response |
+| `no-data-exfil` | ep-incident-response | Blocks data export/download during incident response |
+| `v1-read-only` | ep-incident-response | Blocks Vision One write operations during incident response |
 | `share-is-generic` | ddei-email-security | Domain-specific gate for email security project |
 | `use-workers` | hackathon26 | Forces delegation to fleet workers |
 

--- a/scripts/test/test-T106-spec-gate-relaxed.sh
+++ b/scripts/test/test-T106-spec-gate-relaxed.sh
@@ -91,14 +91,17 @@ else
   fail "No task sources should block: $OUTPUT"
 fi
 
-# 4. Project with specs/*/tasks.md (original behavior still works)
+# 4. Project with specs/*/tasks.md + spec.md (original behavior still works)
 PROJ4="$TMPDIR/proj-specs"
 mkdir -p "$PROJ4/specs/feat1" "$PROJ4/src"
 git init -q "$PROJ4"
+echo "# Feature 1 Spec" > "$PROJ4/specs/feat1/spec.md"
 cat > "$PROJ4/specs/feat1/tasks.md" <<'EOF'
 - [ ] T001: Build it
 EOF
 echo "x" > "$PROJ4/src/app.js"
+# Need at least one commit for git rev-parse HEAD to work
+(cd "$PROJ4" && git add -A && git commit -q -m "init" 2>/dev/null) || true
 
 OUTPUT=$(run_gate "$PROJ4" "$PROJ4/src/app.js")
 if echo "$OUTPUT" | grep -q "PASSED"; then


### PR DESCRIPTION
## Summary
- Add 3 ep-incident-response modules to README project-scoped table
- Fix spec-gate relaxed test — updated spec-gate requires spec.md to exist

## Test plan
- [x] test-T106-spec-gate-relaxed.sh passes with updated test