### PR TITLE
T298: DRY VERSION from package.json + ES5 consistency

### DIFF
--- a/run-modules/PostToolUse/rule-hygiene.js
+++ b/run-modules/PostToolUse/rule-hygiene.js
@@ -8,7 +8,7 @@ module.exports = function(input) {
   var normalized = filePath.replace(/\\/g, "/");
 
   // Only check files in rules directories
-  if (!normalized.includes("/rules/") || !normalized.endsWith(".md")) return null;
+  if (normalized.indexOf("/rules/") === -1 || normalized.slice(-3) !== ".md") return null;
 
   var warnings = [];
   var fileName = path.basename(normalized, ".md");

--- a/setup.js
+++ b/setup.js
@@ -46,7 +46,7 @@ var SCRIPT_DIR = __dirname;
 var REPO_DIR = SCRIPT_DIR;
 
 var HOOK_LOG_PATH = path.join(HOOKS_DIR, "hook-log.jsonl");
-var VERSION = "2.5.10";
+var VERSION = require(path.join(__dirname, "package.json")).version;
 
 // Shared file lists — single source of truth (see constants.js)
 var RUNNER_FILES = require(path.join(__dirname, "constants.js")).RUNNER_FILES;
@@ -764,7 +764,7 @@ function cmdUpgrade(args, dryRun) {
   console.log("  Local version:  " + VERSION);
   console.log("  Remote version: " + remoteVersion);
   console.log("");
-  if (remoteVersion === VERSION && !args.includes("--force")) {
+  if (remoteVersion === VERSION && args.indexOf("--force") === -1) {
     console.log("  Already up to date. Use --force to re-download anyway.");
     return;
   }

--- a/watchdog.js
+++ b/watchdog.js
@@ -313,7 +313,7 @@ function cmdInstall() {
       var crontab = "";
       try { crontab = execSync("crontab -l 2>/dev/null", { encoding: "utf-8" }); } catch(e) {}
       // Remove existing entry
-      var lines = crontab.split("\n").filter(function(l) { return !l.includes(TASK_NAME); });
+      var lines = crontab.split("\n").filter(function(l) { return l.indexOf(TASK_NAME) === -1; });
       lines.push(cronLine);
       var newCrontab = lines.filter(function(l) { return l.trim(); }).join("\n") + "\n";
       // WHY: Pipe via stdin to avoid shell injection from crontab content containing quotes
@@ -345,7 +345,7 @@ function cmdUninstall() {
     try {
       var crontab = "";
       try { crontab = execSync("crontab -l 2>/dev/null", { encoding: "utf-8" }); } catch(e) {}
-      var lines = crontab.split("\n").filter(function(l) { return !l.includes(TASK_NAME); });
+      var lines = crontab.split("\n").filter(function(l) { return l.indexOf(TASK_NAME) === -1; });
       var newCrontab = lines.filter(function(l) { return l.trim(); }).join("\n") + "\n";
       // WHY: Pipe via stdin to avoid shell injection from crontab content containing quotes
       require("child_process").execFileSync("crontab", ["-"], { input: newCrontab });
@@ -381,7 +381,7 @@ function cmdStatus() {
   } else {
     try {
       var crontab = execSync("crontab -l 2>/dev/null", { encoding: "utf-8" });
-      if (crontab.includes(TASK_NAME)) {
+      if (crontab.indexOf(TASK_NAME) !== -1) {
         registered = true;
         console.log("  Scheduler: registered (cron)");
       } else {
@@ -446,8 +446,8 @@ function cmdLog() {
 }
 
 // --- CLI dispatch ---
-if (args.includes("--install")) { cmdInstall(); }
-else if (args.includes("--uninstall")) { cmdUninstall(); }
-else if (args.includes("--status")) { cmdStatus(); }
-else if (args.includes("--log")) { cmdLog(); }
+if (args.indexOf("--install") !== -1) { cmdInstall(); }
+else if (args.indexOf("--uninstall") !== -1) { cmdUninstall(); }
+else if (args.indexOf("--status") !== -1) { cmdStatus(); }
+else if (args.indexOf("--log") !== -1) { cmdLog(); }
 else { main(); }


### PR DESCRIPTION
## Summary
- Read VERSION from package.json instead of hardcoding in setup.js (eliminates manual sync on version bumps)
- Replace ES6 `args.includes()` with `args.indexOf()` in setup.js for ES5 consistency
- Replace 6 `.includes()` calls in watchdog.js with `indexOf()` for ES5 consistency
- Sync drifted run-modules/PostToolUse/rule-hygiene.js with catalog (had ES6 `.includes()`)

## Test plan
- [x] `node setup.js --version` outputs correct version
- [x] setup wizard tests pass (7/7)
- [x] watchdog tests pass (8/8)