### PR TITLE
T306: Decode tests + version bump 2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.6.1] — 2026-04-05
+
+### Fixed
+- **Project dir decoding** — `--integrity` CLI now correctly resolves hyphenated names (`hook-runner`), dot-prefix dirs (`.claude`), and nested paths using greedy filesystem-aware decode (#180)
+
+### Added
+- **Decode tests** — `--integrity --json` validation and `decodeProjectDir` path resolution tests (#181)
+
 ## [2.6.0] — 2026-04-05
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"

--- a/scripts/test/test-hook-integrity.sh
+++ b/scripts/test/test-hook-integrity.sh
@@ -74,7 +74,37 @@ EXEOF
 RESULT=$(node "$TMPDIR_T/exc_test.js" 2>/dev/null || echo "error")
 [ "$RESULT" = "shtd" ] && pass "Exception whitelist JSON parsing" || fail "Exception whitelist: $RESULT"
 
-# --- Test 7: shtd.yml includes new modules ---
+# --- Test 7: decodeProjectDir resolves real paths ---
+cat > "$TMPDIR_T/decode_test.js" << 'DEOF'
+var fs = require("fs"), path = require("path");
+var setup = require(process.argv[2]);
+var fn = setup._decodeProjectDir;
+if (!fn) { process.stdout.write("NO_EXPORT"); process.exit(0); }
+var tests = [
+  ["C--Users-joelg-Documents-ProjectsCL1-hook-runner", "hook-runner"],
+  ["C--Users-joelg-Documents-ProjectsCL1-ep-incident-response", "ep-incident-response"],
+];
+var pass = 0;
+for (var i = 0; i < tests.length; i++) {
+  var decoded = fn(tests[i][0]);
+  if (decoded && decoded.indexOf(tests[i][1]) !== -1 && fs.existsSync(decoded)) pass++;
+}
+process.stdout.write(String(pass));
+DEOF
+RESULT=$(node "$TMPDIR_T/decode_test.js" "$REPO_DIR/setup.js" 2>/dev/null || echo "error")
+if [ "$RESULT" = "NO_EXPORT" ]; then
+  pass "decodeProjectDir: not exported (internal function)"
+elif [ "$RESULT" = "2" ]; then
+  pass "decodeProjectDir: resolves hyphenated paths"
+else
+  fail "decodeProjectDir: $RESULT/2 paths resolved"
+fi
+
+# --- Test 8: --integrity command runs without error ---
+RESULT=$(node "$REPO_DIR/setup.js" --integrity --json 2>/dev/null || echo "error")
+echo "$RESULT" | node -e "var d='';process.stdin.on('data',function(c){d+=c});process.stdin.on('end',function(){try{var j=JSON.parse(d);process.stdout.write(j.files&&j.workflows?'ok':'bad')}catch(e){process.stdout.write('parse-error')}})" | grep -q "ok" && pass "--integrity --json produces valid output" || fail "--integrity --json output invalid"
+
+# --- Test 9: shtd.yml includes new modules ---
 for mod in workflow-compliance-gate hook-integrity-check hook-integrity-monitor; do
   grep -q "$mod" "$REPO_DIR/workflows/shtd.yml" && pass "$mod in shtd.yml" || fail "$mod missing from shtd.yml"
 done

--- a/setup.js
+++ b/setup.js
@@ -1982,6 +1982,6 @@ function healthCheck() {
   return results;
 }
 
-module.exports = { scanHooks: scanHooks, generateReport: generateReport, backupHooks: backupHooks, installRunners: installRunners, parseModulesYaml: parseModulesYaml, syncModules: syncModules, readHookStats: readHookStats, healthCheck: healthCheck, pruneLog: pruneLog, VERSION: VERSION };
+module.exports = { scanHooks: scanHooks, generateReport: generateReport, backupHooks: backupHooks, installRunners: installRunners, parseModulesYaml: parseModulesYaml, syncModules: syncModules, readHookStats: readHookStats, healthCheck: healthCheck, pruneLog: pruneLog, VERSION: VERSION, _decodeProjectDir: decodeProjectDir };
 
 if (require.main === module) main();


### PR DESCRIPTION
## Summary
- Export `decodeProjectDir` for testability
- Add 2 new tests: decode resolves hyphenated paths, --integrity --json valid output
- Version bump to 2.6.1 + CHANGELOG

## Test plan
- [x] test-setup-wizard.sh: 7/7
- [x] test-hook-integrity.sh: 20/20