### PR TITLE
T307: Fix 2 failing test suites (T105, T204)

### DIFF
--- a/scripts/test/test-T105-docs-release.sh
+++ b/scripts/test/test-T105-docs-release.sh
@@ -9,14 +9,15 @@ check() {
 }
 echo "=== hook-runner: docs & release ==="
 
-# Extract expected version from setup.js
-EXPECTED_VER=$(sed -n 's/.*VERSION = "\([^"]*\)".*/\1/p' "$REPO_DIR/setup.js")
+# Extract expected version from package.json (single source of truth)
+EXPECTED_VER=$(node -e "process.stdout.write(require('$REPO_DIR/package.json').version)")
 
-# 1. Version in setup.js matches package.json
-check "setup.js version is $EXPECTED_VER" 'grep -q "\"$EXPECTED_VER\"" "$REPO_DIR/setup.js"'
+# 1. setup.js reads version from package.json (dynamic, verify at runtime)
+RUNTIME_VER=$(node -e "process.stdout.write(require('$REPO_DIR/setup.js').VERSION)")
+check "setup.js version is $EXPECTED_VER" '[ "$RUNTIME_VER" = "$EXPECTED_VER" ]'
 
-# 2. package.json version matches setup.js
-check "package.json version is $EXPECTED_VER" 'grep -q "\"$EXPECTED_VER\"" "$REPO_DIR/package.json"'
+# 2. package.json has a version
+check "package.json version is $EXPECTED_VER" 'grep -q "\"version\": \"$EXPECTED_VER\"" "$REPO_DIR/package.json"'
 
 # 3. CLAUDE.md has updated test counts
 check "CLAUDE.md has updated test counts" 'grep -qE "[0-9]+ suites" "$REPO_DIR/CLAUDE.md"'

--- a/setup.js
+++ b/setup.js
@@ -1598,8 +1598,8 @@ function main() {
 // Decode .claude/projects/ encoded dir name back to a filesystem path.
 // Encoding replaces \ / : . with - (lossy). Greedy: try joining segments
 // left-to-right, checking which combinations exist on disk.
-// e.g. "C--Users-joelg-Documents-ProjectsCL1-hook-runner" → "C:\Users\joelg\Documents\ProjectsCL1\hook-runner"
-// e.g. "C--Users-joelg--claude" → "C:\Users\joelg\.claude" (-- mid-string = dot-prefix)
+// e.g. "X--home-dev-projects-my-app" → "X:\home\dev\projects\my-app"
+// e.g. "X--home-dev--config" → "X:\home\dev\.config" (-- mid-string = dot-prefix)
 function decodeProjectDir(encoded) {
   // Drive letter: first segment before first -- is the drive letter
   var driveIdx = encoded.indexOf("--");


### PR DESCRIPTION
## Summary
- T204 portable-paths: generic example path in decode comment triggered hardcoded-path detection
- T105 docs-release: VERSION extraction via sed broken since VERSION moved to package.json

## Test plan
- [x] test-T204-portable-paths.sh: 3/3
- [x] test-T105-docs-release.sh: 6/6
- [x] test-hook-integrity.sh: 20/20
- [x] test-setup-wizard.sh: 7/7