### PR TITLE
T311: Fix hook-integrity-monitor rate limiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.6.4] — 2026-04-05
+
+### Fixed
+- **hook-integrity-monitor rate limiter** — in-memory `_lastCheckTime` was always 0 (each hook invocation is a fresh Node process). Replaced with file-based timestamp in `~/.claude/hooks/.integrity-last-check`. Saves ~85ms per prompt when rate-limited.
+
 ## [2.6.3] — 2026-04-05
 
 ### Improved

--- a/modules/UserPromptSubmit/hook-integrity-monitor.js
+++ b/modules/UserPromptSubmit/hook-integrity-monitor.js
@@ -11,7 +11,6 @@ var crypto = require("crypto");
 
 var RATE_LIMIT_MS = 60000; // 60 seconds
 var SAMPLE_SIZE = 5; // random modules to spot-check per prompt
-var _lastCheckTime = 0;
 
 function md5(filePath) {
   try {
@@ -19,13 +18,26 @@ function md5(filePath) {
   } catch (e) { return null; }
 }
 
-module.exports = async function(input) {
-  var now = Date.now();
-  if (now - _lastCheckTime < RATE_LIMIT_MS) return null;
-  _lastCheckTime = now;
+// WHY: Each hook invocation is a fresh Node process — in-memory _lastCheckTime
+// was always 0. File-based timestamp persists across invocations.
+function getLastCheckTime(hooksDir) {
+  var stampPath = path.join(hooksDir, ".integrity-last-check");
+  try {
+    return parseInt(fs.readFileSync(stampPath, "utf-8").trim(), 10) || 0;
+  } catch (e) { return 0; }
+}
+function setLastCheckTime(hooksDir) {
+  var stampPath = path.join(hooksDir, ".integrity-last-check");
+  try { fs.writeFileSync(stampPath, String(Date.now())); } catch (e) { /* best effort */ }
+}
 
+module.exports = async function(input) {
   var home = process.env.HOME || process.env.USERPROFILE;
   var hooksDir = path.join(home, ".claude", "hooks");
+  var now = Date.now();
+  if (now - getLastCheckTime(hooksDir) < RATE_LIMIT_MS) return null;
+  setLastCheckTime(hooksDir);
+
   var liveModDir = path.join(hooksDir, "run-modules");
   var markerPath = path.join(hooksDir, ".hook-runner-repo");
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- In-memory `_lastCheckTime` was always 0 (each hook invocation is a fresh Node process)
- Replaced with file-based timestamp (`~/.claude/hooks/.integrity-last-check`)
- Saves ~85ms per prompt when rate-limited (60s cooldown between checks)

## Test plan
- [x] Smoke test: second invocation returns in 1ms (rate-limited)
- [x] Integrity test suite: 20/20 pass
- [x] Module validation: 272/272 pass