### PR TITLE
T351: Session collision detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ Full catalog in `modules/` directory:
 | `project-health` | Runs health check, warns about issues |
 | `reflection-score-inject` | Injects reflection score/level/streak into session context |
 | `session-cleanup` | Sweeps orphaned session-scoped temp files from crashed sessions |
+| `session-collision-detector` | Warns if another Claude Code session is active on the same project |
 | `terminal-title` | Sets terminal title to project folder name |
 | `workflow-summary` | Injects active workflow summary |
 

--- a/TODO.md
+++ b/TODO.md
@@ -641,6 +641,8 @@ TOP PRIORITY — self-reflection scope enforcement + future architecture:
 
 - [x] T340: TODO.md fallback tightened — on main branch in projects with specs/ (mature projects), spec-gate now requires a feature branch instead of allowing blanket edits via TODO.md. Simple projects (no specs/) still use TODO.md directly. Feature branches enforce task ID matching via T321. 3 tests pass.
 
+- [ ] T351: Session collision detector — SessionStart module that detects multiple Claude Code sessions on the same project. Context-reset spawns new tabs that work simultaneously, causing branch conflicts, index.lock contention, and parallel commits. Module writes a session lock file per project+PID, checks for other active sessions on SessionStart, and warns loudly. Belt: hook-based detection here. Suspenders: system-monitor T027 for process-level detection.
+
 ## UserPromptSubmit Safety & Self-Reflection Improvements (session 2026-04-07)
 - [x] T341: hook-editing-gate blocks ALL UserPromptSubmit module creation. Any bug in a UPS module locks the user out with no recovery. Learned from frustration-detector incident (2026-04-07): module blocked every user prompt, making it impossible to fix. All UPS functionality must live in PreToolUse/PostToolUse/Stop instead.
 - [x] T342: Self-reflection removes hasEdits guard — sessions with user frustration/corrections but no edits now get reflected on (previously the worst sessions were skipped entirely)

--- a/modules/SessionStart/session-cleanup.js
+++ b/modules/SessionStart/session-cleanup.js
@@ -63,6 +63,24 @@ module.exports = function() {
         }
       }
     }
+    // T351: Also clean session-lock files from collision detector
+    // Pattern: .claude-session-lock-<hash>-<pid>
+    var LOCK_PREFIX = ".claude-session-lock-";
+    for (var k = 0; k < files.length; k++) {
+      var lf = files[k];
+      if (lf.indexOf(LOCK_PREFIX) !== 0) continue;
+      // Extract PID from end of filename (after last dash)
+      var lastDash = lf.lastIndexOf("-");
+      if (lastDash <= LOCK_PREFIX.length) continue;
+      var lockPidStr = lf.substring(lastDash + 1);
+      var lockPid = parseInt(lockPidStr, 10);
+      if (!isNaN(lockPid) && lockPid > 0 && lockPid !== process.ppid && !isPidRunning(lockPid)) {
+        try {
+          fs.unlinkSync(path.join(TMP, lf));
+          cleaned++;
+        } catch (e) { /* skip */ }
+      }
+    }
   } catch (e) { /* tmpdir read failed */ }
 
   return null; // SessionStart modules should not block

--- a/modules/SessionStart/session-collision-detector.js
+++ b/modules/SessionStart/session-collision-detector.js
@@ -1,0 +1,117 @@
+// WORKFLOW: shtd
+// WHY: Context-reset spawns new Claude Code tabs that all work on the same project
+// simultaneously. This caused 4-5 parallel sessions doing git checkout, git commit,
+// branch switching — total chaos. index.lock contention, parallel commits stomping
+// each other, branches switching under your feet mid-edit. This module writes a
+// session lock file per project and warns if another session is already active.
+"use strict";
+var fs = require("fs");
+var path = require("path");
+var os = require("os");
+var cp = require("child_process");
+
+var TMP = os.tmpdir();
+var PREFIX = ".claude-session-lock-";
+
+// Hash project dir to a safe filename component
+function hashDir(dir) {
+  return dir.replace(/[^a-zA-Z0-9]/g, "-").replace(/-+/g, "-").substring(0, 80);
+}
+
+function isPidRunning(pid) {
+  try {
+    if (process.platform === "win32") {
+      var out = cp.execSync("tasklist /FI \"PID eq " + pid + "\" /NH", {
+        encoding: "utf-8",
+        timeout: 3000,
+        stdio: ["pipe", "pipe", "pipe"]
+      });
+      return out.indexOf("" + pid) !== -1;
+    } else {
+      process.kill(pid, 0);
+      return true;
+    }
+  } catch (e) {
+    return false;
+  }
+}
+
+module.exports = function() {
+  var projectDir = process.env.CLAUDE_PROJECT_DIR || "";
+  if (!projectDir) return null;
+
+  var myPpid = process.ppid;
+  var lockPrefix = PREFIX + hashDir(projectDir) + "-";
+  var myLockFile = path.join(TMP, lockPrefix + myPpid);
+  var collisions = [];
+
+  try {
+    // Scan for other session locks on the same project
+    var files = fs.readdirSync(TMP);
+    for (var i = 0; i < files.length; i++) {
+      var f = files[i];
+      if (f.indexOf(lockPrefix) !== 0) continue;
+
+      var pidStr = f.substring(lockPrefix.length);
+      var pid = parseInt(pidStr, 10);
+      if (isNaN(pid) || pid <= 0) continue;
+
+      if (pid === myPpid) continue; // that's us
+
+      if (isPidRunning(pid)) {
+        // Another active session on the same project!
+        var lockData = {};
+        try {
+          lockData = JSON.parse(fs.readFileSync(path.join(TMP, f), "utf-8"));
+        } catch (e) {}
+        collisions.push({
+          pid: pid,
+          startedAt: lockData.ts || "unknown",
+          branch: lockData.branch || "unknown"
+        });
+      } else {
+        // Stale lock — clean it up
+        try { fs.unlinkSync(path.join(TMP, f)); } catch (e) {}
+      }
+    }
+
+    // Write our own lock file
+    var branch = "";
+    try {
+      branch = cp.execSync("git branch --show-current", {
+        cwd: projectDir,
+        encoding: "utf-8",
+        timeout: 3000,
+        stdio: ["pipe", "pipe", "pipe"]
+      }).trim();
+    } catch (e) {}
+
+    fs.writeFileSync(myLockFile, JSON.stringify({
+      ts: new Date().toISOString(),
+      pid: myPpid,
+      project: projectDir,
+      branch: branch
+    }));
+  } catch (e) {
+    // Never fail
+    return null;
+  }
+
+  if (collisions.length > 0) {
+    var msg = "SESSION COLLISION WARNING: " + collisions.length +
+      " other Claude Code session(s) are working on this same project!\n\n" +
+      "Project: " + projectDir + "\n\n";
+    for (var c = 0; c < collisions.length; c++) {
+      msg += "  - PID " + collisions[c].pid +
+        " (started " + collisions[c].startedAt +
+        ", branch: " + collisions[c].branch + ")\n";
+    }
+    msg += "\nRISK: Parallel sessions cause branch switching, index.lock contention, " +
+      "and commits stomping each other. Close extra tabs before continuing.\n\n" +
+      "If you just did a context-reset, the old tab should have been closed. " +
+      "Check for orphaned Claude Code windows and close them.";
+    return msg;
+  }
+
+  return null;
+};

--- a/run-modules/SessionStart/session-cleanup.js
+++ b/run-modules/SessionStart/session-cleanup.js
@@ -63,6 +63,24 @@ module.exports = function() {
         }
       }
     }
+    // T351: Also clean session-lock files from collision detector
+    // Pattern: .claude-session-lock-<hash>-<pid>
+    var LOCK_PREFIX = ".claude-session-lock-";
+    for (var k = 0; k < files.length; k++) {
+      var lf = files[k];
+      if (lf.indexOf(LOCK_PREFIX) !== 0) continue;
+      // Extract PID from end of filename (after last dash)
+      var lastDash = lf.lastIndexOf("-");
+      if (lastDash <= LOCK_PREFIX.length) continue;
+      var lockPidStr = lf.substring(lastDash + 1);
+      var lockPid = parseInt(lockPidStr, 10);
+      if (!isNaN(lockPid) && lockPid > 0 && lockPid !== process.ppid && !isPidRunning(lockPid)) {
+        try {
+          fs.unlinkSync(path.join(TMP, lf));
+          cleaned++;
+        } catch (e) { /* skip */ }
+      }
+    }
   } catch (e) { /* tmpdir read failed */ }
 
   return null; // SessionStart modules should not block

--- a/run-modules/SessionStart/session-collision-detector.js
+++ b/run-modules/SessionStart/session-collision-detector.js
@@ -1,0 +1,117 @@
+// WORKFLOW: shtd
+// WHY: Context-reset spawns new Claude Code tabs that all work on the same project
+// simultaneously. This caused 4-5 parallel sessions doing git checkout, git commit,
+// branch switching — total chaos. index.lock contention, parallel commits stomping
+// each other, branches switching under your feet mid-edit. This module writes a
+// session lock file per project and warns if another session is already active.
+"use strict";
+var fs = require("fs");
+var path = require("path");
+var os = require("os");
+var cp = require("child_process");
+
+var TMP = os.tmpdir();
+var PREFIX = ".claude-session-lock-";
+
+// Hash project dir to a safe filename component
+function hashDir(dir) {
+  return dir.replace(/[^a-zA-Z0-9]/g, "-").replace(/-+/g, "-").substring(0, 80);
+}
+
+function isPidRunning(pid) {
+  try {
+    if (process.platform === "win32") {
+      var out = cp.execSync("tasklist /FI \"PID eq " + pid + "\" /NH", {
+        encoding: "utf-8",
+        timeout: 3000,
+        stdio: ["pipe", "pipe", "pipe"]
+      });
+      return out.indexOf("" + pid) !== -1;
+    } else {
+      process.kill(pid, 0);
+      return true;
+    }
+  } catch (e) {
+    return false;
+  }
+}
+
+module.exports = function() {
+  var projectDir = process.env.CLAUDE_PROJECT_DIR || "";
+  if (!projectDir) return null;
+
+  var myPpid = process.ppid;
+  var lockPrefix = PREFIX + hashDir(projectDir) + "-";
+  var myLockFile = path.join(TMP, lockPrefix + myPpid);
+  var collisions = [];
+
+  try {
+    // Scan for other session locks on the same project
+    var files = fs.readdirSync(TMP);
+    for (var i = 0; i < files.length; i++) {
+      var f = files[i];
+      if (f.indexOf(lockPrefix) !== 0) continue;
+
+      var pidStr = f.substring(lockPrefix.length);
+      var pid = parseInt(pidStr, 10);
+      if (isNaN(pid) || pid <= 0) continue;
+
+      if (pid === myPpid) continue; // that's us
+
+      if (isPidRunning(pid)) {
+        // Another active session on the same project!
+        var lockData = {};
+        try {
+          lockData = JSON.parse(fs.readFileSync(path.join(TMP, f), "utf-8"));
+        } catch (e) {}
+        collisions.push({
+          pid: pid,
+          startedAt: lockData.ts || "unknown",
+          branch: lockData.branch || "unknown"
+        });
+      } else {
+        // Stale lock — clean it up
+        try { fs.unlinkSync(path.join(TMP, f)); } catch (e) {}
+      }
+    }
+
+    // Write our own lock file
+    var branch = "";
+    try {
+      branch = cp.execSync("git branch --show-current", {
+        cwd: projectDir,
+        encoding: "utf-8",
+        timeout: 3000,
+        stdio: ["pipe", "pipe", "pipe"]
+      }).trim();
+    } catch (e) {}
+
+    fs.writeFileSync(myLockFile, JSON.stringify({
+      ts: new Date().toISOString(),
+      pid: myPpid,
+      project: projectDir,
+      branch: branch
+    }));
+  } catch (e) {
+    // Never fail
+    return null;
+  }
+
+  if (collisions.length > 0) {
+    var msg = "SESSION COLLISION WARNING: " + collisions.length +
+      " other Claude Code session(s) are working on this same project!\n\n" +
+      "Project: " + projectDir + "\n\n";
+    for (var c = 0; c < collisions.length; c++) {
+      msg += "  - PID " + collisions[c].pid +
+        " (started " + collisions[c].startedAt +
+        ", branch: " + collisions[c].branch + ")\n";
+    }
+    msg += "\nRISK: Parallel sessions cause branch switching, index.lock contention, " +
+      "and commits stomping each other. Close extra tabs before continuing.\n\n" +
+      "If you just did a context-reset, the old tab should have been closed. " +
+      "Check for orphaned Claude Code windows and close them.";
+    return msg;
+  }
+
+  return null;
+};

--- a/scripts/test/test-T351-session-collision.sh
+++ b/scripts/test/test-T351-session-collision.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Test T351: Session collision detection
+set -euo pipefail
+REPO_DIR="$(cd "$(dirname "$0")/../.." && (pwd -W 2>/dev/null || pwd))"
+PASS=0; FAIL=0
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+echo "=== hook-runner: session-collision-detector (T351) ==="
+
+MODULE="$REPO_DIR/modules/SessionStart/session-collision-detector.js"
+CLEANUP="$REPO_DIR/modules/SessionStart/session-cleanup.js"
+TMPDIR_PATH="$(node -e "console.log(require('os').tmpdir())")"
+
+# 1. Module loads and exports function
+OUTPUT=$(node -e "var m = require('$MODULE'); console.log(typeof m)" 2>&1)
+if [ "$OUTPUT" = "function" ]; then pass "exports function"; else fail "bad export: $OUTPUT"; fi
+
+# 2. Returns null when no collisions (clean state)
+OUTPUT=$(node -e "
+  // Clean any existing lock files for this test
+  var fs = require('fs'), os = require('os'), path = require('path');
+  var tmp = os.tmpdir();
+  var files = fs.readdirSync(tmp);
+  for (var i = 0; i < files.length; i++) {
+    if (files[i].indexOf('.claude-session-lock-') === 0) {
+      try { fs.unlinkSync(path.join(tmp, files[i])); } catch(e) {}
+    }
+  }
+  var m = require('$MODULE');
+  var result = m();
+  console.log(result === null ? 'NULL' : 'NOT_NULL');
+" 2>&1)
+if echo "$OUTPUT" | grep -q "NULL"; then pass "returns null with no collisions"; else fail "should return null: $OUTPUT"; fi
+
+# 3. Writes a lock file on invocation
+OUTPUT=$(node -e "
+  var fs = require('fs'), os = require('os'), path = require('path');
+  process.env.CLAUDE_PROJECT_DIR = '$REPO_DIR';
+  // Clear require cache
+  delete require.cache[require.resolve('$MODULE')];
+  var m = require('$MODULE');
+  m();
+  var tmp = os.tmpdir();
+  var found = false;
+  var files = fs.readdirSync(tmp);
+  for (var i = 0; i < files.length; i++) {
+    if (files[i].indexOf('.claude-session-lock-') === 0 &&
+        files[i].indexOf('-' + process.ppid) !== -1) {
+      found = true;
+      // Clean up
+      fs.unlinkSync(path.join(tmp, files[i]));
+      break;
+    }
+  }
+  console.log(found ? 'FOUND' : 'MISSING');
+" 2>&1)
+if echo "$OUTPUT" | grep -q "FOUND"; then pass "writes lock file with ppid"; else fail "no lock file written: $OUTPUT"; fi
+
+# 4. Lock file contains JSON with project + branch + pid
+OUTPUT=$(node -e "
+  var fs = require('fs'), os = require('os'), path = require('path');
+  process.env.CLAUDE_PROJECT_DIR = '$REPO_DIR';
+  delete require.cache[require.resolve('$MODULE')];
+  var m = require('$MODULE');
+  m();
+  var tmp = os.tmpdir();
+  var files = fs.readdirSync(tmp);
+  for (var i = 0; i < files.length; i++) {
+    if (files[i].indexOf('.claude-session-lock-') === 0 &&
+        files[i].indexOf('-' + process.ppid) !== -1) {
+      var data = JSON.parse(fs.readFileSync(path.join(tmp, files[i]), 'utf-8'));
+      var ok = data.pid && data.project && data.ts;
+      console.log(ok ? 'VALID' : 'INVALID');
+      fs.unlinkSync(path.join(tmp, files[i]));
+      break;
+    }
+  }
+" 2>&1)
+if echo "$OUTPUT" | grep -q "VALID"; then pass "lock file has pid+project+ts"; else fail "lock data invalid: $OUTPUT"; fi
+
+# 5. Detects collision when another lock exists with running PID
+OUTPUT=$(node -e "
+  var fs = require('fs'), os = require('os'), path = require('path');
+  var dir = '$REPO_DIR';
+  process.env.CLAUDE_PROJECT_DIR = dir;
+  var hash = dir.replace(/[^a-zA-Z0-9]/g, '-').replace(/-+/g, '-').substring(0, 80);
+  var tmp = os.tmpdir();
+  // Write a fake lock for PID 4 (System process, always running on Windows)
+  // On Linux, use PID 1 (init)
+  var fakePid = process.platform === 'win32' ? 4 : 1;
+  var fakeLock = path.join(tmp, '.claude-session-lock-' + hash + '-' + fakePid);
+  fs.writeFileSync(fakeLock, JSON.stringify({ ts: new Date().toISOString(), pid: fakePid, project: dir, branch: 'main' }));
+  delete require.cache[require.resolve('$MODULE')];
+  var m = require('$MODULE');
+  var result = m();
+  // Clean up both locks
+  try { fs.unlinkSync(fakeLock); } catch(e) {}
+  var files = fs.readdirSync(tmp);
+  for (var i = 0; i < files.length; i++) {
+    if (files[i].indexOf('.claude-session-lock-') === 0 && files[i].indexOf('-' + process.ppid) !== -1) {
+      try { fs.unlinkSync(path.join(tmp, files[i])); } catch(e) {}
+    }
+  }
+  if (result && typeof result === 'string' && result.indexOf('SESSION COLLISION WARNING') !== -1) {
+    console.log('COLLISION_DETECTED');
+  } else {
+    console.log('NO_COLLISION: ' + JSON.stringify(result));
+  }
+" 2>&1)
+if echo "$OUTPUT" | grep -q "COLLISION_DETECTED"; then pass "detects collision with running PID"; else fail "missed collision: $OUTPUT"; fi
+
+# 6. Ignores lock files for dead PIDs (cleans them up)
+OUTPUT=$(node -e "
+  var fs = require('fs'), os = require('os'), path = require('path');
+  var dir = '$REPO_DIR';
+  process.env.CLAUDE_PROJECT_DIR = dir;
+  var hash = dir.replace(/[^a-zA-Z0-9]/g, '-').replace(/-+/g, '-').substring(0, 80);
+  var tmp = os.tmpdir();
+  // Write a fake lock for a PID that definitely doesn't exist
+  var deadPid = 99999;
+  var fakeLock = path.join(tmp, '.claude-session-lock-' + hash + '-' + deadPid);
+  fs.writeFileSync(fakeLock, JSON.stringify({ ts: '2026-01-01T00:00:00Z', pid: deadPid, project: dir, branch: 'old-branch' }));
+  delete require.cache[require.resolve('$MODULE')];
+  var m = require('$MODULE');
+  var result = m();
+  // Check that the stale lock was cleaned up
+  var staleExists = false;
+  try { fs.statSync(fakeLock); staleExists = true; } catch(e) {}
+  // Clean up our own lock
+  var files = fs.readdirSync(tmp);
+  for (var i = 0; i < files.length; i++) {
+    if (files[i].indexOf('.claude-session-lock-') === 0 && files[i].indexOf('-' + process.ppid) !== -1) {
+      try { fs.unlinkSync(path.join(tmp, files[i])); } catch(e) {}
+    }
+  }
+  if (!staleExists && result === null) {
+    console.log('CLEANED');
+  } else {
+    console.log('NOT_CLEANED staleExists=' + staleExists + ' result=' + JSON.stringify(result));
+  }
+" 2>&1)
+if echo "$OUTPUT" | grep -q "CLEANED"; then pass "cleans stale lock for dead PID"; else fail "didn't clean stale lock: $OUTPUT"; fi
+
+# 7. No false positive for different project
+OUTPUT=$(node -e "
+  var fs = require('fs'), os = require('os'), path = require('path');
+  process.env.CLAUDE_PROJECT_DIR = '/tmp/project-A';
+  var hashA = '/tmp/project-A'.replace(/[^a-zA-Z0-9]/g, '-').replace(/-+/g, '-').substring(0, 80);
+  var tmp = os.tmpdir();
+  // Write a lock for a different project with a running PID
+  var fakePid = process.platform === 'win32' ? 4 : 1;
+  var otherHash = '/tmp/project-B'.replace(/[^a-zA-Z0-9]/g, '-').replace(/-+/g, '-').substring(0, 80);
+  var fakeLock = path.join(tmp, '.claude-session-lock-' + otherHash + '-' + fakePid);
+  fs.writeFileSync(fakeLock, JSON.stringify({ ts: new Date().toISOString(), pid: fakePid, project: '/tmp/project-B', branch: 'main' }));
+  delete require.cache[require.resolve('$MODULE')];
+  var m = require('$MODULE');
+  var result = m();
+  try { fs.unlinkSync(fakeLock); } catch(e) {}
+  // Clean our lock
+  var files = fs.readdirSync(tmp);
+  for (var i = 0; i < files.length; i++) {
+    if (files[i].indexOf('.claude-session-lock-') === 0 && files[i].indexOf('-' + process.ppid) !== -1) {
+      try { fs.unlinkSync(path.join(tmp, files[i])); } catch(e) {}
+    }
+  }
+  console.log(result === null ? 'NO_FALSE_POSITIVE' : 'FALSE_POSITIVE');
+" 2>&1)
+if echo "$OUTPUT" | grep -q "NO_FALSE_POSITIVE"; then pass "no false positive for different project"; else fail "false positive: $OUTPUT"; fi
+
+# 8. session-cleanup cleans stale lock files
+OUTPUT=$(node -e "
+  var fs = require('fs'), os = require('os'), path = require('path');
+  var tmp = os.tmpdir();
+  var deadPid = 99998;
+  var fakeLock = path.join(tmp, '.claude-session-lock-test-project-' + deadPid);
+  fs.writeFileSync(fakeLock, JSON.stringify({ ts: '2026-01-01', pid: deadPid }));
+  delete require.cache[require.resolve('$CLEANUP')];
+  var cleanup = require('$CLEANUP');
+  cleanup();
+  var exists = false;
+  try { fs.statSync(fakeLock); exists = true; } catch(e) {}
+  console.log(exists ? 'STILL_EXISTS' : 'CLEANED');
+" 2>&1)
+if echo "$OUTPUT" | grep -q "CLEANED"; then pass "session-cleanup sweeps stale lock files"; else fail "cleanup missed lock file: $OUTPUT"; fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed (total $((PASS + FAIL)))"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/specs/session-collision/spec.md
+++ b/specs/session-collision/spec.md
@@ -1,0 +1,32 @@
+# Session Collision Detection
+
+## Problem
+
+Context-reset spawns new Claude Code tabs without killing the old one. Multiple sessions
+work on the same project simultaneously, causing:
+- Git branch switching under each other's feet
+- index.lock contention (fatal errors on every git operation)
+- Parallel commits stomping each other
+- Race conditions in file edits
+
+On 2026-04-07, the user returned to find 4-5 simultaneous tabs all working on hook-runner.
+
+## Solution: Belt and Suspenders
+
+### Belt: Hook-based (this spec)
+SessionStart module writes a lock file per project+PID in tmpdir. On start, scans for
+other active lock files on the same project. If found, warns loudly with PIDs and branches
+so the user can close duplicates.
+
+Lock file: `.claude-session-lock-<project-hash>-<ppid>` in tmpdir.
+- Written at SessionStart
+- Cleaned up by session-cleanup.js (stale PID check)
+- Read by this module to detect collisions
+
+### Suspenders: system-monitor (T027 in that project)
+Process-level detection via Win32 API — scan running node.exe processes, group by
+CLAUDE_PROJECT_DIR, flag projects with 2+ active sessions. Dashboard panel + API endpoint.
+
+## Affected Modules
+- NEW: `modules/SessionStart/session-collision-detector.js`
+- UPDATE: `modules/SessionStart/session-cleanup.js` — add lock file pattern to cleanup list

--- a/specs/session-collision/tasks.md
+++ b/specs/session-collision/tasks.md
@@ -1,0 +1,8 @@
+# Tasks: Session Collision Detection
+
+## T351: Detect parallel Claude Code sessions on same project
+- [ ] T351a: Create session-collision-detector.js SessionStart module
+- [ ] T351b: Add session-lock pattern to session-cleanup.js STATE_NAMES
+- [ ] T351c: Copy to run-modules + sync to live hooks
+- [ ] T351d: Test suite: collision detection, stale cleanup, no false positives
+- [ ] T351e: Version bump + push

--- a/specs/session-collision/tasks.md
+++ b/specs/session-collision/tasks.md
@@ -1,8 +1,8 @@
 # Tasks: Session Collision Detection
 
 ## T351: Detect parallel Claude Code sessions on same project
-- [ ] T351a: Create session-collision-detector.js SessionStart module
-- [ ] T351b: Add session-lock pattern to session-cleanup.js STATE_NAMES
-- [ ] T351c: Copy to run-modules + sync to live hooks
-- [ ] T351d: Test suite: collision detection, stale cleanup, no false positives
+- [x] T351a: Create session-collision-detector.js SessionStart module (PR #223)
+- [x] T351b: Add session-lock pattern to session-cleanup.js cleanup scan (PR #223)
+- [x] T351c: Copy to run-modules + sync to live hooks (PR #223)
+- [x] T351d: Test suite: collision detection, stale cleanup, no false positives (PR #223)
 - [ ] T351e: Version bump + push


### PR DESCRIPTION
## Summary
- New `session-collision-detector.js` (SessionStart) detects multiple Claude Code sessions on the same project
- Writes lock file per project+PID, scans for other active sessions, warns loudly
- `session-cleanup.js` updated to sweep stale session-lock files
- Belt (hooks) + suspenders (system-monitor T027 for process-level detection)

## Context
Context-reset was spawning new tabs without killing old ones. User returned to 4-5 parallel sessions all doing git checkout/commit on hook-runner — total chaos.

## Test plan
- [x] `test-T351-session-collision.sh`: 8/8 pass
  - Exports function, returns null with no collisions
  - Writes lock file with ppid, lock has valid JSON
  - Detects collision with running PID
  - Cleans stale lock for dead PID
  - No false positive for different project
  - session-cleanup sweeps stale lock files