### PR TITLE
T361: DRY — extract shared isPidRunning helper

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -510,10 +510,12 @@ What was done:
 - [x] T356: test-modules timeout fixed — removed timeout wrapper (Git Bash returns 124 for success). Added batch test script (_batch-module-test.js) for fast single-process validation. All 78 modules pass.
 - [x] T357: Not a module bug — all 78 modules pass with HOOK_RUNNER_TEST=1. Failures were test runner timeouts on Windows.
 - [x] T358: README refresh — module count updated (80+), SessionStart table verified (8 modules), all sections accurate
-- [ ] T359: npm package publish — enable `npx grobomo/hook-runner` for zero-clone install
+- [x] T359: N/A — `npx grobomo/hook-runner` already works via GitHub direct install. npm registry publish skipped (name `hook-runner` taken, would need `@grobomo/hook-runner` scoped package + npm org setup). GitHub install is the intended distribution path.
+
+- [ ] T361: DRY — extract shared `isPidRunning` helper from session-cleanup.js and session-collision-detector.js into `modules/SessionStart/is-pid-running.js`. Both modules duplicate the same 15-line function.
 
 ## Status
-- 280 tasks completed, 1 pending (T331 brain integration — cross-project)
+- 282 tasks completed, 2 pending (T331 brain integration, T361 DRY)
 - Version: 2.14.5
 - Marketplace: claude-code-skills synced to v2.14.3 (needs commit+push from that project)
 - CI: ALL GREEN (Linux + Windows)
@@ -641,7 +643,7 @@ TOP PRIORITY — self-reflection scope enforcement + future architecture:
 
 - [x] T340: TODO.md fallback tightened — on main branch in projects with specs/ (mature projects), spec-gate now requires a feature branch instead of allowing blanket edits via TODO.md. Simple projects (no specs/) still use TODO.md directly. Feature branches enforce task ID matching via T321. 3 tests pass.
 
-- [ ] T351: Session collision detector — SessionStart module that detects multiple Claude Code sessions on the same project. Context-reset spawns new tabs that work simultaneously, causing branch conflicts, index.lock contention, and parallel commits. Module writes a session lock file per project+PID, checks for other active sessions on SessionStart, and warns loudly. Belt: hook-based detection here. Suspenders: system-monitor T027 for process-level detection.
+- [x] T351: Session collision detector — SessionStart module detects multiple Claude Code sessions on same project. Lock file per project+PID, warns on collision. session-cleanup sweeps stale locks. 8 tests. (PR #223, #224)
 
 ## UserPromptSubmit Safety & Self-Reflection Improvements (session 2026-04-07)
 - [x] T341: hook-editing-gate blocks ALL UserPromptSubmit module creation. Any bug in a UPS module locks the user out with no recovery. Learned from frustration-detector incident (2026-04-07): module blocked every user prompt, making it impossible to fix. All UPS functionality must live in PreToolUse/PostToolUse/Stop instead.

--- a/load-modules.js
+++ b/load-modules.js
@@ -158,7 +158,7 @@ module.exports = function loadModules(eventDir) {
   // 1. Global modules: top-level .js files
   var entries = fs.readdirSync(eventDir, { withFileTypes: true });
   var globalFiles = entries
-    .filter(function(e) { return e.isFile() && e.name.indexOf(".js") === e.name.length - 3; })
+    .filter(function(e) { return e.isFile() && e.name.indexOf(".js") === e.name.length - 3 && e.name.charAt(0) !== "_"; })
     .map(function(e) { return e.name; })
     .sort()
     .map(function(f) { return path.join(eventDir, f); });

--- a/modules/SessionStart/_is-pid-running.js
+++ b/modules/SessionStart/_is-pid-running.js
@@ -1,0 +1,22 @@
+// Shared helper: check if a process ID is still running
+// Used by session-cleanup.js and session-collision-detector.js
+"use strict";
+var cp = require("child_process");
+
+module.exports = function isPidRunning(pid) {
+  try {
+    if (process.platform === "win32") {
+      var out = cp.execSync("tasklist /FI \"PID eq " + pid + "\" /NH", {
+        encoding: "utf-8",
+        timeout: 3000,
+        stdio: ["pipe", "pipe", "pipe"]
+      });
+      return out.indexOf("" + pid) !== -1;
+    } else {
+      process.kill(pid, 0);
+      return true;
+    }
+  } catch (e) {
+    return false;
+  }
+};

--- a/modules/SessionStart/session-cleanup.js
+++ b/modules/SessionStart/session-cleanup.js
@@ -6,7 +6,7 @@
 var fs = require("fs");
 var path = require("path");
 var os = require("os");
-var cp = require("child_process");
+var isPidRunning = require("./_is-pid-running");
 
 var TMP = os.tmpdir();
 var PREFIX = ".claude-";
@@ -18,24 +18,6 @@ var STATE_NAMES = [
   "self-analyze-cooldown-",
   "bash-failures-"
 ];
-
-function isPidRunning(pid) {
-  try {
-    if (process.platform === "win32") {
-      var out = cp.execSync("tasklist /FI \"PID eq " + pid + "\" /NH", {
-        encoding: "utf-8",
-        timeout: 3000,
-        stdio: ["pipe", "pipe", "pipe"]
-      });
-      return out.indexOf("" + pid) !== -1;
-    } else {
-      process.kill(pid, 0);
-      return true;
-    }
-  } catch (e) {
-    return false;
-  }
-}
 
 module.exports = function() {
   var cleaned = 0;

--- a/modules/SessionStart/session-collision-detector.js
+++ b/modules/SessionStart/session-collision-detector.js
@@ -9,6 +9,7 @@ var fs = require("fs");
 var path = require("path");
 var os = require("os");
 var cp = require("child_process");
+var isPidRunning = require("./_is-pid-running");
 
 var TMP = os.tmpdir();
 var PREFIX = ".claude-session-lock-";
@@ -16,24 +17,6 @@ var PREFIX = ".claude-session-lock-";
 // Hash project dir to a safe filename component
 function hashDir(dir) {
   return dir.replace(/[^a-zA-Z0-9]/g, "-").replace(/-+/g, "-").substring(0, 80);
-}
-
-function isPidRunning(pid) {
-  try {
-    if (process.platform === "win32") {
-      var out = cp.execSync("tasklist /FI \"PID eq " + pid + "\" /NH", {
-        encoding: "utf-8",
-        timeout: 3000,
-        stdio: ["pipe", "pipe", "pipe"]
-      });
-      return out.indexOf("" + pid) !== -1;
-    } else {
-      process.kill(pid, 0);
-      return true;
-    }
-  } catch (e) {
-    return false;
-  }
 }
 
 module.exports = function() {

--- a/run-modules/SessionStart/_is-pid-running.js
+++ b/run-modules/SessionStart/_is-pid-running.js
@@ -1,0 +1,22 @@
+// Shared helper: check if a process ID is still running
+// Used by session-cleanup.js and session-collision-detector.js
+"use strict";
+var cp = require("child_process");
+
+module.exports = function isPidRunning(pid) {
+  try {
+    if (process.platform === "win32") {
+      var out = cp.execSync("tasklist /FI \"PID eq " + pid + "\" /NH", {
+        encoding: "utf-8",
+        timeout: 3000,
+        stdio: ["pipe", "pipe", "pipe"]
+      });
+      return out.indexOf("" + pid) !== -1;
+    } else {
+      process.kill(pid, 0);
+      return true;
+    }
+  } catch (e) {
+    return false;
+  }
+};

--- a/run-modules/SessionStart/session-cleanup.js
+++ b/run-modules/SessionStart/session-cleanup.js
@@ -6,7 +6,7 @@
 var fs = require("fs");
 var path = require("path");
 var os = require("os");
-var cp = require("child_process");
+var isPidRunning = require("./_is-pid-running");
 
 var TMP = os.tmpdir();
 var PREFIX = ".claude-";
@@ -18,24 +18,6 @@ var STATE_NAMES = [
   "self-analyze-cooldown-",
   "bash-failures-"
 ];
-
-function isPidRunning(pid) {
-  try {
-    if (process.platform === "win32") {
-      var out = cp.execSync("tasklist /FI \"PID eq " + pid + "\" /NH", {
-        encoding: "utf-8",
-        timeout: 3000,
-        stdio: ["pipe", "pipe", "pipe"]
-      });
-      return out.indexOf("" + pid) !== -1;
-    } else {
-      process.kill(pid, 0);
-      return true;
-    }
-  } catch (e) {
-    return false;
-  }
-}
 
 module.exports = function() {
   var cleaned = 0;

--- a/run-modules/SessionStart/session-collision-detector.js
+++ b/run-modules/SessionStart/session-collision-detector.js
@@ -9,6 +9,7 @@ var fs = require("fs");
 var path = require("path");
 var os = require("os");
 var cp = require("child_process");
+var isPidRunning = require("./_is-pid-running");
 
 var TMP = os.tmpdir();
 var PREFIX = ".claude-session-lock-";
@@ -16,24 +17,6 @@ var PREFIX = ".claude-session-lock-";
 // Hash project dir to a safe filename component
 function hashDir(dir) {
   return dir.replace(/[^a-zA-Z0-9]/g, "-").replace(/-+/g, "-").substring(0, 80);
-}
-
-function isPidRunning(pid) {
-  try {
-    if (process.platform === "win32") {
-      var out = cp.execSync("tasklist /FI \"PID eq " + pid + "\" /NH", {
-        encoding: "utf-8",
-        timeout: 3000,
-        stdio: ["pipe", "pipe", "pipe"]
-      });
-      return out.indexOf("" + pid) !== -1;
-    } else {
-      process.kill(pid, 0);
-      return true;
-    }
-  } catch (e) {
-    return false;
-  }
 }
 
 module.exports = function() {

--- a/scripts/test/test-modules.sh
+++ b/scripts/test/test-modules.sh
@@ -39,6 +39,8 @@ collect_modules() {
   local event="$2"
   shopt -s nullglob
   for mod_file in "$event_dir"*.js; do
+    # Skip helper files (prefixed with _) — not modules
+    case "$(basename "$mod_file")" in _*) continue;; esac
     echo "$event|$(basename "$mod_file")|$mod_file"
   done
   for sub_dir in "$event_dir"*/; do

--- a/specs/session-collision/tasks.md
+++ b/specs/session-collision/tasks.md
@@ -5,4 +5,4 @@
 - [x] T351b: Add session-lock pattern to session-cleanup.js cleanup scan (PR #223)
 - [x] T351c: Copy to run-modules + sync to live hooks (PR #223)
 - [x] T351d: Test suite: collision detection, stale cleanup, no false positives (PR #223)
-- [ ] T351e: Version bump + push
+- [x] T351e: Version bump to 2.14.5 + push (PR #224)


### PR DESCRIPTION
## Summary
- Extract duplicated `isPidRunning` function into `_is-pid-running.js` shared helper
- Both `session-cleanup.js` and `session-collision-detector.js` now import it
- Underscore prefix convention: `_helper.js` files are utilities, not modules
- `load-modules.js` and `test-modules.sh` skip `_` prefixed files

## Test plan
- [x] `test-T351-session-collision.sh`: 8/8 pass after refactor
- [x] No new module appears in load-modules scan (underscore prefix skipped)