### PR TITLE
T362: Code review — DRY brain URL, fix deprecation, update docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Modular hook runner for Claude Code. Workflows group modules into enforceable pi
 - `modules/` — distributable module catalog organized by event type
 - `workflows/` — built-in workflow definitions (YAML)
 - `specs/` — feature specs with tasks and checkpoints
-- `scripts/test/` — test scripts (40 suites, 532 tests)
+- `scripts/test/` — test scripts (49 suites)
 - `package.json` — npm package (enables `npx grobomo/hook-runner`)
 
 ## Testing
@@ -66,8 +66,7 @@ node setup.js --help         # show all commands
 - The `hook-editing-gate` module enforces these rules at edit time (including the UPS no-block rule).
 
 ## Self-Reflection Architecture
-- **Current (interim)**: `self-reflection.js` (Stop module) calls `claude -p` directly for LLM analysis. No memory across sessions. Expensive.
-- **Target (T331)**: self-reflection becomes a thin bridge to unified-brain service. Brain handles LLM analysis with three-tier memory (hot events → session summaries → global patterns). Self-reflection just sends events and reads back results.
+- **Brain bridge (T331)**: `self-reflection.js` (Stop module) tries unified-brain `/ask` endpoint first (fast, has three-tier memory). Falls back to direct LLM call when brain is unavailable. `BRAIN_URL` env var configurable (default `http://localhost:8790`).
 - **Scope rule**: self-reflection can self-repair hook-runner modules. For everything else, it only writes TODOs. reflection-gate.js enforces this — allows edits to `run-modules/` and `hook-runner/modules/`, blocks other production code when issues exist.
 - **Scoring**: reflection-score.json persists across sessions, injected at SessionStart. Levels (Novice→Master) based on clean reflections, autonomy streaks, user corrections.
 

--- a/TODO.md
+++ b/TODO.md
@@ -521,8 +521,11 @@ What was done:
 - system-monitor T027: TODO added for process-level Claude tab detection
 - Next: version bump for T361, marketplace sync, code review pass
 
+## Code Review & Cleanup
+- [ ] T362: Code review pass — update CLAUDE.md (stale self-reflection architecture, test counts), DRY brain URL parsing in self-reflection.js, marketplace sync to v2.15.0
+
 ## Status
-- 285 tasks completed, 0 pending
+- 285 tasks completed, 1 pending
 - Version: 2.15.0
 - Marketplace: claude-code-skills synced to v2.14.3 (needs commit+push from that project)
 - CI: ALL GREEN (Linux + Windows)

--- a/modules/Stop/self-reflection.js
+++ b/modules/Stop/self-reflection.js
@@ -14,13 +14,15 @@ var os = require("os");
 var cp = require("child_process");
 
 var http = require("http");
-var url = require("url");
 
 var HOOKS_DIR = path.join(os.homedir(), ".claude", "hooks");
 var LOG_PATH = path.join(HOOKS_DIR, "hook-log.jsonl");
 var REFLECTION_PATH = path.join(HOOKS_DIR, "self-reflection.jsonl");
 var SESSIONS_PATH = path.join(HOOKS_DIR, "reflection-sessions.jsonl");
 var BRAIN_URL = process.env.BRAIN_URL || "http://localhost:8790";
+var _brainParsed = new URL(BRAIN_URL);
+var BRAIN_HOST = _brainParsed.hostname || "localhost";
+var BRAIN_PORT = parseInt(_brainParsed.port, 10) || 8790;
 var CLAUDE_LOG_PATH = path.join(HOOKS_DIR, "reflection-claude-log.jsonl");
 var MAX_ENTRIES = 50; // last N hook-log entries to analyze
 var CLAUDE_TIMEOUT = 60000; // 60s for claude -p (runs every Stop, needs room)
@@ -404,10 +406,9 @@ var _brainAvailable = null;
 function isBrainAvailable() {
   if (_brainAvailable !== null) return Promise.resolve(_brainAvailable);
   return new Promise(function(resolve) {
-    var parsed = url.parse(BRAIN_URL);
     var req = http.get({
-      hostname: parsed.hostname,
-      port: parsed.port || 8790,
+      hostname: BRAIN_HOST,
+      port: BRAIN_PORT,
       path: "/healthz",
       timeout: 2000
     }, function(res) {
@@ -430,7 +431,6 @@ function isBrainAvailable() {
 function callBrain(prompt) {
   return new Promise(function(resolve) {
     var startMs = Date.now();
-    var parsed = url.parse(BRAIN_URL);
     var payload = JSON.stringify({
       question: prompt,
       source: "hook-runner",
@@ -439,8 +439,8 @@ function callBrain(prompt) {
       metadata: { type: "reflection", project: path.basename(process.env.CLAUDE_PROJECT_DIR || "unknown") }
     });
     var req = http.request({
-      hostname: parsed.hostname,
-      port: parsed.port || 8790,
+      hostname: BRAIN_HOST,
+      port: BRAIN_PORT,
       path: "/ask",
       method: "POST",
       headers: { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(payload) },

--- a/run-modules/Stop/self-reflection.js
+++ b/run-modules/Stop/self-reflection.js
@@ -14,13 +14,15 @@ var os = require("os");
 var cp = require("child_process");
 
 var http = require("http");
-var url = require("url");
 
 var HOOKS_DIR = path.join(os.homedir(), ".claude", "hooks");
 var LOG_PATH = path.join(HOOKS_DIR, "hook-log.jsonl");
 var REFLECTION_PATH = path.join(HOOKS_DIR, "self-reflection.jsonl");
 var SESSIONS_PATH = path.join(HOOKS_DIR, "reflection-sessions.jsonl");
 var BRAIN_URL = process.env.BRAIN_URL || "http://localhost:8790";
+var _brainParsed = new URL(BRAIN_URL);
+var BRAIN_HOST = _brainParsed.hostname || "localhost";
+var BRAIN_PORT = parseInt(_brainParsed.port, 10) || 8790;
 var CLAUDE_LOG_PATH = path.join(HOOKS_DIR, "reflection-claude-log.jsonl");
 var MAX_ENTRIES = 50; // last N hook-log entries to analyze
 var CLAUDE_TIMEOUT = 60000; // 60s for claude -p (runs every Stop, needs room)
@@ -404,10 +406,9 @@ var _brainAvailable = null;
 function isBrainAvailable() {
   if (_brainAvailable !== null) return Promise.resolve(_brainAvailable);
   return new Promise(function(resolve) {
-    var parsed = url.parse(BRAIN_URL);
     var req = http.get({
-      hostname: parsed.hostname,
-      port: parsed.port || 8790,
+      hostname: BRAIN_HOST,
+      port: BRAIN_PORT,
       path: "/healthz",
       timeout: 2000
     }, function(res) {
@@ -430,7 +431,6 @@ function isBrainAvailable() {
 function callBrain(prompt) {
   return new Promise(function(resolve) {
     var startMs = Date.now();
-    var parsed = url.parse(BRAIN_URL);
     var payload = JSON.stringify({
       question: prompt,
       source: "hook-runner",
@@ -439,8 +439,8 @@ function callBrain(prompt) {
       metadata: { type: "reflection", project: path.basename(process.env.CLAUDE_PROJECT_DIR || "unknown") }
     });
     var req = http.request({
-      hostname: parsed.hostname,
-      port: parsed.port || 8790,
+      hostname: BRAIN_HOST,
+      port: BRAIN_PORT,
       path: "/ask",
       method: "POST",
       headers: { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(payload) },

--- a/specs/code-review-cleanup/spec.md
+++ b/specs/code-review-cleanup/spec.md
@@ -1,0 +1,6 @@
+# T362: Code Review & Cleanup
+
+## Scope
+1. **CLAUDE.md** — update stale self-reflection architecture (T331 done), fix test counts (49 suites)
+2. **self-reflection.js** — DRY brain URL parsing (parsed twice), extract constants
+3. **Marketplace sync** — copy core files to claude-code-skills (v2.14.3 → v2.15.0)

--- a/specs/code-review-cleanup/tasks.md
+++ b/specs/code-review-cleanup/tasks.md
@@ -1,0 +1,5 @@
+# T362: Code Review & Cleanup — Tasks
+
+- [ ] T362a: Update CLAUDE.md — self-reflection architecture (T331 done), test counts (49 suites)
+- [ ] T362b: DRY brain URL parsing in self-reflection.js — extract parsed URL to module-level constants
+- [ ] T362c: Marketplace sync to v2.15.0 — copy core files to claude-code-skills


### PR DESCRIPTION
## Summary
- Replace deprecated `url.parse()` with `new URL()` in self-reflection.js (fixes Node.js DEP0169 warning)
- Extract brain host/port to module-level constants (was parsed twice per invocation)
- Update CLAUDE.md: self-reflection architecture reflects T331 completion, test count updated (49 suites)
- Marketplace files synced to v2.15.0

## Test plan
- [x] All 8 brain bridge tests pass
- [x] No deprecation warnings in test output
- [x] Module syntax check passes
- [x] Marketplace files copied