### PR TITLE
T366: Housekeeping — fix stale counts, marketplace sync, branch cleanup

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -527,17 +527,22 @@ What was done:
 ## Spec-Gate Improvements
 - [x] T363: Spec-gate subtask detection — when branch references T331, also check for unchecked T331a-T331z subtasks in specs/*/tasks.md. Fixes false-positive blocks when parent task is done but subtasks remain. (PR #232, #233)
 
+## Housekeeping
+- [ ] T364: Marketplace commit+push — claude-code-skills v2.15.1 sync (done, pending PR)
+- [ ] T365: Clean up 5 stale local branches (done, pending PR)
+- [ ] T366: Code review pass — fix stale counts in TODO/CLAUDE.md, verify runners match repo
+
 ## Status
-- 287 tasks completed, 0 pending
+- 287 tasks completed, 3 pending
 - Version: 2.15.1
-- Marketplace: claude-code-skills synced to v2.15.0 (needs commit+push from that project)
+- Marketplace: claude-code-skills synced to v2.15.1
 - CI: ALL GREEN (Linux + Windows)
-- 77 modules across 5 workflows (2 active: shtd + customer-data-guard), 47 test suites
+- 84 modules across 5 workflows (2 active: shtd + customer-data-guard), 49 test suites
 - Self-reflection system live: self-reflection (brain bridge) + reflection-gate + reflection-score + score-inject
 - Scoring: Novice→Master levels, intervention tracking, full audit logging
-- Health: 99 OK, 0 warnings, 0 failures
+- Health: 101 OK, 0 warnings, 0 failures
 - Analysis score: A (0 demerits)
-- Performance: PreToolUse ~913ms/call (45 modules, ~16ms avg each), SessionStart ~400ms (7 modules, debounced)
+- Performance: PreToolUse ~913ms/call (47 modules, ~16ms avg each), SessionStart ~400ms (11 modules, debounced)
 - CI: GitHub Actions runs tests + secret-scan on push/PR (Linux + Windows) — badge in README
 - Workflow engine: workflow.js + workflow-gate.js + 5 workflow templates
 - CLI: setup, report, health, sync, stats, list, test, test-module, upgrade, uninstall, prune, version, help, perf, export, workflow (list/audit/query/enable/disable/start/status/complete/reset/create/add-module/sync-live)

--- a/specs/housekeeping/spec.md
+++ b/specs/housekeeping/spec.md
@@ -1,0 +1,18 @@
+# Housekeeping (T364-T366)
+
+## Problem
+After the T363 release, several maintenance items accumulated:
+- Marketplace repo (claude-code-skills) had ~30 uncommitted files from v2.15.1 sync
+- 5 stale local branches from completed PRs
+- TODO.md Status section had stale module/test/health counts
+
+## Solution
+- Commit and push marketplace sync (T364)
+- Delete stale branches (T365)
+- Code review: verify counts, runner consistency, module contract compliance (T366)
+
+## Verification
+- All 84 modules pass contract validation (WHY + exports)
+- All 8 runners match repo ↔ live (checksum verified)
+- 4 UPS modules confirmed non-blocking (no `decision: "block"` returns)
+- Health check: 101 OK, 0 warnings, 0 failures

--- a/specs/housekeeping/tasks.md
+++ b/specs/housekeeping/tasks.md
@@ -1,0 +1,7 @@
+# T364-T366: Housekeeping — Tasks
+
+- [ ] T364: Marketplace commit+push — sync claude-code-skills to v2.15.1
+- [ ] T365: Delete 5 stale local branches
+- [ ] T366a: Fix stale module/test counts in TODO.md Status section
+- [ ] T366b: Verify UPS modules are non-blocking (CLAUDE.md says "ZERO modules" but 4 exist)
+- [ ] T366c: Verify runners in repo match live runners

--- a/specs/housekeeping/tasks.md
+++ b/specs/housekeeping/tasks.md
@@ -1,7 +1,7 @@
 # T364-T366: Housekeeping — Tasks
 
-- [ ] T364: Marketplace commit+push — sync claude-code-skills to v2.15.1
-- [ ] T365: Delete 5 stale local branches
+- [ ] T364: Marketplace commit+push — sync claude-code-skills to v2.15.1 (done pre-branch)
+- [ ] T365: Delete 5 stale local branches (done pre-branch)
 - [ ] T366a: Fix stale module/test counts in TODO.md Status section
-- [ ] T366b: Verify UPS modules are non-blocking (CLAUDE.md says "ZERO modules" but 4 exist)
-- [ ] T366c: Verify runners in repo match live runners
+- [ ] T366b: Verify UPS modules are non-blocking (CLAUDE.md says "ZERO modules" but 4 exist — confirmed non-blocking)
+- [ ] T366c: Verify runners in repo match live runners (all 8 match)


### PR DESCRIPTION
## Summary
- Fixed stale counts in TODO.md Status: 84 modules (was 77), 49 test suites (was 47), 101 health checks (was 99)
- Marketplace synced to v2.15.1 (committed + pushed to claude-code-skills)
- Deleted 5 stale local branches
- Added specs/housekeeping/ for T364-T366

## Verification
- All 84 modules pass contract validation (WHY comment + module.exports)
- All 8 runners match repo ↔ live (md5 checksum)
- 4 UPS modules confirmed non-blocking
- `node setup.js --health`: 101 OK, 0 warnings, 0 failures