### PR TITLE
T367: Rewrite README — individual-first framing (fixes #194)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,19 @@ Modular hook system for Claude Code. Enforce workflows, block mistakes, inject c
 
 Claude Code [hooks](https://docs.anthropic.com/en/docs/claude-code/hooks) let you run scripts at key moments: before a tool runs, after it runs, when a session starts, when it stops. hook-runner turns this into a **module system** — drop a `.js` file in a folder and it runs automatically.
 
-On top of modules, **workflows** group related modules into enforceable pipelines. Enable a workflow and its modules activate together. Disable it and they all go silent. This is how you scale from one person's preferences to a team's engineering standards.
+On top of modules, **workflows** group related modules into enforceable pipelines. Enable a workflow and its modules activate together. Disable it and they all go silent. This gives you a single place to organize all your hook behavior — no more hunting through `settings.json` entries.
 
 ## Why hook-runner?
 
-Claude Code hooks are powerful but raw: you write shell commands in `settings.json`, they run on every invocation, and there's no structure. This works for one person with three hooks. It doesn't work when you have 30+ enforcement rules, some that only apply in certain contexts, and teammates who need the same guardrails.
+Claude Code hooks are powerful but raw: you write shell commands in `settings.json`, they run on every invocation, and there's no structure. This works with three hooks. It doesn't work when you have 30+ enforcement rules, some that only apply in certain contexts, and you need to turn groups on and off.
 
-hook-runner solves three problems:
+hook-runner replaces direct `settings.json` editing. After install, you never touch `settings.json` for hooks again — hook-runner owns all five events and routes to your modules automatically.
 
-**1. Modules over shell commands.** Each rule is a `.js` file that receives structured input (tool name, file path, command) and returns a decision. No string parsing, no fragile regexes against `settings.json` entries. Modules are testable, documented, and version-controlled.
+**1. Modules over shell commands.** Each rule is a `.js` file that receives structured input (tool name, file path, command) and returns a decision. Modules are testable, documented, and version-controlled. Drop a file in a folder and it runs — remove it and it stops.
 
-**2. Workflows over individual modules.** You don't think "I need to enable spec-gate, branch-gate, test-checkpoint-gate, and worker-loop." You think "I want the SHTD development pipeline." Workflows group related modules so you enable one name and get a complete enforcement regime.
+**2. Workflows over individual modules.** You don't think "I need to enable spec-gate, branch-gate, test-checkpoint-gate, and worker-loop." You think "I want the SHTD development pipeline." Workflows group related modules so you enable one name and get a complete enforcement regime. Disable it and they all go silent. This is how you manage 80+ modules without losing track.
 
-**3. When to use which.** Use a **raw hook** (in `settings.json`) for one-off scripts that don't need to coordinate with anything — a notification sound on completion, a logging call. Use a **module** when the rule should be testable, has a `// WHY:` story behind it, and belongs to a category of enforcement. Use a **workflow** when multiple modules work together to enforce a process — a development pipeline, a safety regime, a deployment checklist.
-
-The progression is: raw hooks for experiments, modules for durable rules, workflows for team-wide standards.
+**3. Portability.** Export your module config as YAML (`--export`), sync it to another machine (`--sync`), or share a workflow definition. Workflows also make it easy to switch contexts — enable `customer-data-guard` during incident response, disable it after.
 
 ## Integrating with other Claude Code tools
 

--- a/TODO.md
+++ b/TODO.md
@@ -532,8 +532,12 @@ What was done:
 - [x] T365: Clean up 5 stale local branches (PR #234)
 - [x] T366: Code review pass — fixed stale counts, verified 84 modules pass contract, 8 runners match live (PR #234)
 
+## Docs Rewrite (Issue #194)
+- [ ] T367: Rewrite README — fix framing: workflows are for individuals (not teams), hook-runner replaces settings.json (never suggest direct edits), workflows = enable/disable groups + portability
+- [ ] T368: Sync updated README to marketplace (claude-code-skills)
+
 ## Status
-- 290 tasks completed, 0 pending
+- 290 tasks completed, 2 pending
 - Version: 2.15.1
 - Marketplace: claude-code-skills synced to v2.15.1
 - CI: ALL GREEN (Linux + Windows)

--- a/specs/docs-rewrite/spec.md
+++ b/specs/docs-rewrite/spec.md
@@ -1,0 +1,21 @@
+# Docs Rewrite (Issue #194)
+
+## Problem
+README has stale framing from early versions:
+- Presents workflows as a "team" feature — they're for individuals first
+- Suggests adding hooks to settings.json — hook-runner's whole point is you never touch settings.json after install
+- "Why hook-runner" section frames workflows as team standards scaling — should frame as personal organization + portability
+- Some counts and examples reflect older module catalog
+
+## Changes
+1. Reframe "Why hook-runner" — individual productivity, not team scaling
+2. Remove all "add to settings.json" suggestions — hook-runner IS the replacement
+3. Workflows = enable/disable groups of modules + portable configs, not team management
+4. Update any stale counts or examples
+5. Keep technical accuracy (module contract, CLI reference, architecture)
+
+## Verification
+- README renders correctly on GitHub
+- No references to editing settings.json for hooks
+- No "team" framing for workflows (mention teams only as secondary benefit)
+- Close issue #194

--- a/specs/docs-rewrite/tasks.md
+++ b/specs/docs-rewrite/tasks.md
@@ -1,0 +1,7 @@
+# T367-T368: Docs Rewrite — Tasks
+
+- [ ] T367a: Rewrite "Why hook-runner" section — individual productivity, not team scaling
+- [ ] T367b: Rewrite "Workflows" intro — enable/disable groups + portability, not team standards
+- [ ] T367c: Remove settings.json references — hook-runner replaces direct settings.json editing
+- [ ] T367d: Review and fix any stale counts, examples, or outdated integration notes
+- [ ] T368: Sync updated README to marketplace (claude-code-skills)


### PR DESCRIPTION
## Summary
- Reframed workflows as personal organization + portability, not team scaling
- hook-runner replaces settings.json editing — never suggest adding hooks to settings.json directly
- Replaced "raw hooks for experiments" advice with portability as third value prop
- No technical changes, docs only

Closes #194

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm no stale team-centric framing remains
- [ ] Confirm no "add to settings.json" suggestions