### PR TITLE
T378: PostToolUse runner runs all modules before exiting

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -574,8 +574,11 @@ What was done:
 ## Release
 - [x] T377: Version bump to 2.16.0 + CHANGELOG for T376 + marketplace sync (PR #246)
 
+## PostToolUse Runner Fix
+- [ ] T378: PostToolUse runner runs all modules before exiting — same pattern as T376 Stop fix. Consistent behavior for monitoring/reporting events.
+
 ## Status
-- 301 tasks completed, 0 pending
+- 301 tasks completed, 1 pending
 - Version: 2.16.0
 - Marketplace: claude-code-skills synced to v2.16.0
 - CI: ALL GREEN (Linux + Windows)

--- a/run-posttooluse.js
+++ b/run-posttooluse.js
@@ -26,6 +26,10 @@ if (input && input.tool_input && typeof input.tool_input.path === "string") {
 var ctx = hookLog.extractContext("PostToolUse", input);
 var modules = loadModules(path.join(__dirname, "run-modules", "PostToolUse"));
 
+// T378: Run all modules before exiting (consistent with T376 Stop runner fix).
+// PostToolUse is monitoring/reporting — all modules should run even if one blocks.
+var firstResult = null;
+
 runAsync.runModules(modules, input,
   function handleResult(modName, result, err, ms) {
     if (err) {
@@ -36,13 +40,17 @@ runAsync.runModules(modules, input,
     if (result && result.decision) {
       hookLog.logHook("PostToolUse", modName, result.decision, Object.assign({}, ctx, { reason: result.reason, ms: ms }));
       process.stderr.write(result.reason + "\n");
-      process.stdout.write(JSON.stringify(result));
-      process.exit(1);
+      if (!firstResult) firstResult = result;
+      return false; // T378: continue running remaining modules
     }
     hookLog.logHook("PostToolUse", modName, "pass", Object.assign({}, ctx, { ms: ms }));
     return false;
   },
   function handleDone() {
+    if (firstResult) {
+      process.stdout.write(JSON.stringify(firstResult));
+      process.exit(1);
+    }
     // No output = allow
   }
 );


### PR DESCRIPTION
## Summary
- Same pattern as T376 Stop fix — collect first block, continue running remaining modules
- PostToolUse is monitoring/reporting, all modules should execute
- Synced to live hooks

## Test plan
- [x] 6/6 PostToolUse runner tests pass
- [x] Synced to live