### PR TITLE
T393: Windowless spawn gate + fix all execSync calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ Full catalog in `modules/` directory:
 | `worker-loop` | Blocks PR creation until task's e2e test passes |
 | `workflow-compliance-gate` | Blocks if globally enforced workflow disabled at project level |
 | `workflow-gate` | Enforces step order in active workflows |
+| `windowless-spawn-gate` | Blocks module writes using execSync without windowsHide:true |
 | `worktree-gate` | Blocks feature branch edits unless session is in a git worktree |
 
 #### Project-Scoped PreToolUse

--- a/modules/PostToolUse/hook-autocommit.js
+++ b/modules/PostToolUse/hook-autocommit.js
@@ -23,7 +23,7 @@ module.exports = function(input) {
     var fileName = filePath.split("/run-modules/")[1] || path.basename(filePath);
     child_process.execSync(
       'git add -A && git commit -m "auto: update ' + fileName.replace(/"/g, '\\"') + '"',
-      { cwd: MODULES_DIR, stdio: "ignore", timeout: 5000 }
+      { cwd: MODULES_DIR, stdio: "ignore", timeout: 5000, windowsHide: true }
     );
   } catch (e) {
     // No changes or git error — silent

--- a/modules/PreToolUse/enforcement-gate.js
+++ b/modules/PreToolUse/enforcement-gate.js
@@ -59,8 +59,8 @@ module.exports = function(input) {
       branch = headContent.indexOf("ref: refs/heads/") === 0 ? headContent.slice(16) : "HEAD";
     }
     if (branch === "main" || branch === "master") {
-      var status = child_process.execSync("git status --porcelain", {
-        cwd: gitRoot, encoding: "utf-8", timeout: 5000
+      var status = child_process.execFileSync("git", ["status", "--porcelain"], {
+        cwd: gitRoot, encoding: "utf-8", timeout: 5000, windowsHide: true
       }).trim();
       if (status.length > 0) {
         return {

--- a/modules/PreToolUse/preserve-iterated-content.js
+++ b/modules/PreToolUse/preserve-iterated-content.js
@@ -29,9 +29,8 @@ module.exports = function(input) {
   // Check git history — rev-list --count is faster than log --oneline + line counting
   var dir = path.dirname(filePath);
   try {
-    var countStr = cp.execSync(
-      'git rev-list --count HEAD -- "' + path.basename(filePath) + '"',
-      { cwd: dir, encoding: "utf-8", timeout: 1500, stdio: ["pipe", "pipe", "pipe"] }
+    var countStr = cp.execFileSync("git", ["rev-list", "--count", "HEAD", "--", path.basename(filePath)],
+      { cwd: dir, encoding: "utf-8", timeout: 1500, stdio: ["pipe", "pipe", "pipe"], windowsHide: true }
     ).trim();
 
     var commitCount = parseInt(countStr, 10);

--- a/modules/PreToolUse/remote-tracking-gate.js
+++ b/modules/PreToolUse/remote-tracking-gate.js
@@ -34,7 +34,7 @@ module.exports = function(input) {
   if (tracking === null) {
     // Fallback: runner didn't provide tracking info
     try {
-      tracking = cp.execSync("git config --get branch." + branch + ".remote", { cwd: process.cwd(), encoding: "utf-8" }).trim();
+      tracking = cp.execFileSync("git", ["config", "--get", "branch." + branch + ".remote"], { cwd: process.cwd(), encoding: "utf-8", windowsHide: true }).trim();
     } catch(e) {
       tracking = "";
     }

--- a/modules/PreToolUse/secret-scan-gate.js
+++ b/modules/PreToolUse/secret-scan-gate.js
@@ -34,8 +34,8 @@ module.exports = function(input) {
   // Get staged diff
   var diff = "";
   try {
-    diff = cp.execSync("git diff --cached --diff-filter=ACMR", {
-      encoding: "utf-8", timeout: 10000, maxBuffer: 1024 * 1024
+    diff = cp.execFileSync("git", ["diff", "--cached", "--diff-filter=ACMR"], {
+      encoding: "utf-8", timeout: 10000, maxBuffer: 1024 * 1024, windowsHide: true
     });
   } catch(e) {
     return null; // can't get diff, don't block

--- a/modules/PreToolUse/windowless-spawn-gate.js
+++ b/modules/PreToolUse/windowless-spawn-gate.js
@@ -1,0 +1,88 @@
+// WORKFLOW: shtd
+// WHY: Hook modules using execSync("git ...") spawn cmd.exe on Windows,
+// creating visible console popups that steal focus. Every tool call fires
+// 2-5 hooks, each potentially spawning multiple cmd.exe windows. Fix:
+// require execFileSync (no shell) or windowsHide:true on all child_process
+// calls in hook module code. This gate blocks writes of modules that violate.
+"use strict";
+var path = require("path");
+
+// Patterns that spawn visible processes on Windows
+var DANGEROUS_PATTERNS = [
+  // execSync with string command (uses cmd.exe shell)
+  /\bexecSync\s*\(\s*["'`]/,
+  // spawnSync with shell:true but no windowsHide
+  /\bspawnSync\s*\([^)]*shell\s*:\s*true/,
+  // spawn with shell:true but no windowsHide
+  /\bspawn\s*\([^)]*shell\s*:\s*true/
+];
+
+// Safe alternatives that don't need checking
+var SAFE_PATTERNS = [
+  /windowsHide\s*:\s*true/,
+  /\bexecFileSync\b/
+];
+
+module.exports = function(input) {
+  var tool = input.tool_name || "";
+  if (tool !== "Write" && tool !== "Edit") return null;
+  if (process.env.HOOK_RUNNER_TEST === "1") return null;
+
+  var ti = input.tool_input || {};
+  var filePath = (ti.file_path || "").replace(/\\/g, "/");
+
+  // Only check hook module files
+  if (filePath.indexOf("/run-modules/") < 0 &&
+      filePath.indexOf("/modules/") < 0 &&
+      filePath.indexOf("/hooks/run-") < 0) return null;
+  if (filePath.slice(-3) !== ".js") return null;
+
+  // Get the content being written
+  var content = "";
+  if (tool === "Write") {
+    content = ti.content || "";
+  } else if (tool === "Edit") {
+    content = ti.new_string || "";
+  }
+  if (!content) return null;
+
+  // Check each line for dangerous patterns
+  var violations = [];
+  var lines = content.split("\n");
+  for (var i = 0; i < lines.length; i++) {
+    var line = lines[i];
+    // Skip comments
+    if (line.trim().indexOf("//") === 0) continue;
+
+    for (var p = 0; p < DANGEROUS_PATTERNS.length; p++) {
+      if (!DANGEROUS_PATTERNS[p].test(line)) continue;
+
+      // Check if the surrounding context (next few lines) has a safe pattern
+      var context = lines.slice(i, Math.min(i + 5, lines.length)).join("\n");
+      var isSafe = false;
+      for (var s = 0; s < SAFE_PATTERNS.length; s++) {
+        if (SAFE_PATTERNS[s].test(context)) {
+          isSafe = true;
+          break;
+        }
+      }
+
+      if (!isSafe) {
+        violations.push("Line " + (i + 1) + ": " + line.trim().slice(0, 80));
+      }
+    }
+  }
+
+  if (violations.length === 0) return null;
+
+  return {
+    decision: "block",
+    reason: "WINDOWLESS SPAWN GATE: " + violations.length + " process spawn(s) will create visible CMD popups on Windows.\n" +
+      "WHY: execSync(\"string\") uses cmd.exe as shell → visible console window steals focus.\n\n" +
+      "VIOLATIONS:\n  " + violations.join("\n  ") + "\n\n" +
+      "FIX: Use one of these patterns instead:\n" +
+      "  cp.execFileSync(\"git\", [\"status\", \"--porcelain\"], {windowsHide: true})  // best: no shell\n" +
+      "  cp.execSync(\"complex | command\", {windowsHide: true})  // OK if shell features needed\n" +
+      "  cp.spawnSync(\"git\", [...], {windowsHide: true})  // OK: explicit windowsHide"
+  };
+};

--- a/modules/PreToolUse/worker-loop.js
+++ b/modules/PreToolUse/worker-loop.js
@@ -43,7 +43,7 @@ module.exports = function(input) {
   // Also check target file's git root
   var gitRoot = "";
   try {
-    gitRoot = cp.execSync("git rev-parse --show-toplevel", { encoding: "utf-8", timeout: 5000 }).trim().replace(/\\/g, "/");
+    gitRoot = cp.execFileSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf-8", timeout: 5000, windowsHide: true }).trim().replace(/\\/g, "/");
     if (roots.indexOf(gitRoot) === -1) roots.push(gitRoot);
   } catch(e) {}
 
@@ -78,11 +78,12 @@ module.exports = function(input) {
 
   // Run the test
   try {
-    cp.execSync("bash " + JSON.stringify(testScript), {
+    cp.execFileSync("bash", [testScript], {
       encoding: "utf-8",
       timeout: 120000, // 2 min max
       cwd: projectDir,
-      stdio: ["pipe", "pipe", "pipe"]
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true
     });
 
     // Test passed — write marker

--- a/modules/SessionStart/_is-pid-running.js
+++ b/modules/SessionStart/_is-pid-running.js
@@ -11,7 +11,8 @@ module.exports = function isPidRunning(pid) {
       var out = cp.execSync("tasklist /FI \"PID eq " + pid + "\" /NH", {
         encoding: "utf-8",
         timeout: 3000,
-        stdio: ["pipe", "pipe", "pipe"]
+        stdio: ["pipe", "pipe", "pipe"],
+        windowsHide: true
       });
       return out.indexOf("" + pid) !== -1;
     } else {

--- a/modules/SessionStart/session-collision-detector.js
+++ b/modules/SessionStart/session-collision-detector.js
@@ -61,10 +61,10 @@ module.exports = function() {
     // Write our own lock file
     var branch = "";
     try {
-      branch = cp.execSync("git branch --show-current", {
+      branch = cp.execFileSync("git", ["branch", "--show-current"], {
         cwd: projectDir,
         encoding: "utf-8",
-        timeout: 3000,
+        timeout: 3000, windowsHide: true,
         stdio: ["pipe", "pipe", "pipe"]
       }).trim();
     } catch (e) {}

--- a/modules/Stop/config-sync.js
+++ b/modules/Stop/config-sync.js
@@ -23,8 +23,8 @@ module.exports = function(input) {
 
   // Only run if ~/.claude is a git repo
   try {
-    cp.execSync("git rev-parse --is-inside-work-tree", {
-      cwd: claudeDir, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"]
+    cp.execFileSync("git", ["rev-parse", "--is-inside-work-tree"], {
+      cwd: claudeDir, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"], windowsHide: true
     });
   } catch (e) {
     return null; // not a git repo
@@ -33,8 +33,8 @@ module.exports = function(input) {
   // Check for uncommitted changes (tracked files only)
   var status = "";
   try {
-    status = cp.execSync("git status --porcelain", {
-      cwd: claudeDir, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"]
+    status = cp.execFileSync("git", ["status", "--porcelain"], {
+      cwd: claudeDir, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"], windowsHide: true
     }).trim();
   } catch (e) {
     return null;
@@ -58,13 +58,13 @@ module.exports = function(input) {
 
   // Auto-commit and push
   try {
-    cp.execSync("git add -A", {
-      cwd: claudeDir, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"]
+    cp.execFileSync("git", ["add", "-A"], {
+      cwd: claudeDir, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"], windowsHide: true
     });
 
     var msg = "auto-sync: " + count + " file(s) changed";
-    cp.execSync('git commit -m "' + msg + '"', {
-      cwd: claudeDir, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"]
+    cp.execFileSync("git", ["commit", "-m", msg], {
+      cwd: claudeDir, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"], windowsHide: true
     });
 
     // WHY: Push uses whatever gh auth is active. If CLAUDE_CONFIG_GH_USER is set,
@@ -77,7 +77,7 @@ module.exports = function(input) {
 
     if (configUser) {
       cp.execSync("gh auth switch --user " + configUser + " 2>&1", {
-        encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"], timeout: 5000
+        encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"], timeout: 5000, windowsHide: true
       });
     }
 
@@ -93,13 +93,13 @@ module.exports = function(input) {
     try {
       cp.execSync("git push origin " + branch + " 2>&1", {
         cwd: claudeDir, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"],
-        timeout: 15000
+        timeout: 15000, windowsHide: true
       });
     } finally {
       if (defaultUser) {
         try {
           cp.execSync("gh auth switch --user " + defaultUser + " 2>&1", {
-            encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"], timeout: 5000
+            encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"], timeout: 5000, windowsHide: true
           });
         } catch (e2) { /* ignore */ }
       }
@@ -112,7 +112,7 @@ module.exports = function(input) {
     if (defaultUser) {
       try {
         cp.execSync("gh auth switch --user " + defaultUser + " 2>&1", {
-          encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"], timeout: 5000
+          encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"], timeout: 5000, windowsHide: true
         });
       } catch (e2) { /* ignore */ }
     }

--- a/modules/Stop/drift-review.js
+++ b/modules/Stop/drift-review.js
@@ -74,14 +74,14 @@ module.exports = function(input) {
   var diff = "";
   try {
     diff = cp.execSync("git diff --stat HEAD 2>/dev/null || true", {
-      cwd: projectDir, encoding: "utf8", timeout: 5000
+      cwd: projectDir, encoding: "utf8", timeout: 5000, windowsHide: true
     }).trim();
   } catch (e) {}
 
   var uncommitted = "";
   try {
     uncommitted = cp.execSync("git status --porcelain 2>/dev/null || true", {
-      cwd: projectDir, encoding: "utf8", timeout: 5000
+      cwd: projectDir, encoding: "utf8", timeout: 5000, windowsHide: true
     }).trim();
   } catch (e) {}
 

--- a/modules/Stop/push-unpushed.js
+++ b/modules/Stop/push-unpushed.js
@@ -8,12 +8,12 @@ var cp = require("child_process");
 module.exports = function(input) {
   if (process.env.HOOK_RUNNER_TEST) return null;
   try {
-    var branch = cp.execSync("git branch --show-current", { cwd: process.cwd(), encoding: "utf-8" }).trim();
+    var branch = cp.execFileSync("git", ["branch", "--show-current"], { cwd: process.cwd(), encoding: "utf-8", windowsHide: true }).trim();
     if (!branch || branch === "main" || branch === "master") return null;
 
     var remote = "";
     try {
-      remote = cp.execSync("git config --get branch." + branch + ".remote", { cwd: process.cwd(), encoding: "utf-8" }).trim();
+      remote = cp.execFileSync("git", ["config", "--get", "branch." + branch + ".remote"], { cwd: process.cwd(), encoding: "utf-8", windowsHide: true }).trim();
     } catch(e) { /* no tracking branch */ }
 
     if (!remote) {
@@ -23,7 +23,7 @@ module.exports = function(input) {
       };
     }
 
-    var unpushed = cp.execSync("git log " + remote + "/" + branch + "..HEAD --oneline 2>/dev/null", { cwd: process.cwd(), encoding: "utf-8" }).trim();
+    var unpushed = cp.execSync("git log " + remote + "/" + branch + "..HEAD --oneline 2>/dev/null", { cwd: process.cwd(), encoding: "utf-8", windowsHide: true }).trim();
     if (unpushed) {
       var count = unpushed.split("\n").length;
       return {

--- a/modules/Stop/self-reflection.js
+++ b/modules/Stop/self-reflection.js
@@ -371,7 +371,8 @@ function callClaude(prompt) {
       input: prompt,
       encoding: "utf-8",
       timeout: CLAUDE_TIMEOUT,
-      stdio: ["pipe", "pipe", "pipe"]
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true
     });
     var raw = result.trim();
     var durationMs = Date.now() - startMs;

--- a/modules/Stop/session-brain-analysis.js
+++ b/modules/Stop/session-brain-analysis.js
@@ -168,7 +168,8 @@ module.exports = async function(input) {
       input: prompt,
       encoding: "utf-8",
       timeout: BRAIN_TIMEOUT,
-      stdio: ["pipe", "pipe", "pipe"]
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true
     });
 
     var raw = result.trim();

--- a/run-pretooluse.js
+++ b/run-pretooluse.js
@@ -37,8 +37,8 @@ try {
     // Check if branch tracks a remote (used by remote-tracking-gate, ~33ms savings)
     if (branch !== "main" && branch !== "master") {
       try {
-        input._git.tracking = cp.execSync("git config --get branch." + branch + ".remote", {
-          encoding: "utf-8", timeout: 3000, stdio: ["pipe", "pipe", "pipe"]
+        input._git.tracking = cp.execFileSync("git", ["config", "--get", "branch." + branch + ".remote"], {
+          encoding: "utf-8", timeout: 3000, stdio: ["pipe", "pipe", "pipe"], windowsHide: true
         }).trim();
       } catch (e) {
         input._git.tracking = "";

--- a/scripts/test/test-watchdog-health.js
+++ b/scripts/test/test-watchdog-health.js
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+"use strict";
+// T390f: Tests for watchdog.js health log analysis
+var fs = require("fs");
+var path = require("path");
+var os = require("os");
+var cp = require("child_process");
+
+var pass = 0, fail = 0;
+function assert(ok, label) {
+  if (ok) { pass++; console.log("OK: " + label); }
+  else { fail++; console.log("FAIL: " + label); }
+}
+
+// Create temp hooks dir with required files for watchdog
+var tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "watchdog-health-test-"));
+var healthLog = path.join(tmpDir, "hook-health.jsonl");
+var watchdogLog = path.join(tmpDir, "watchdog-log.jsonl");
+var alertFile = path.join(tmpDir, ".watchdog-alert");
+
+// Create minimal required files so other watchdog checks pass
+var wcPath = path.join(tmpDir, "workflow-config.json");
+fs.writeFileSync(wcPath, JSON.stringify({shtd: true, "code-quality": true, "self-improvement": true, "session-management": true, "messaging-safety": true}));
+
+// Create required runner files
+var requiredRunners = ["run-pretooluse.js", "run-posttooluse.js", "run-stop.js", "run-sessionstart.js", "run-userpromptsubmit.js", "load-modules.js", "workflow.js", "hook-log.js", "run-async.js", "workflow-cli.js", "constants.js"];
+for (var i = 0; i < requiredRunners.length; i++) {
+  fs.writeFileSync(path.join(tmpDir, requiredRunners[i]), "");
+}
+
+// Create required module dirs and files
+var modulesDir = path.join(tmpDir, "run-modules");
+fs.mkdirSync(path.join(modulesDir, "Stop"), { recursive: true });
+fs.mkdirSync(path.join(modulesDir, "PreToolUse"), { recursive: true });
+fs.writeFileSync(path.join(modulesDir, "Stop", "auto-continue.js"), "module.exports = function() { return null; };");
+fs.writeFileSync(path.join(modulesDir, "PreToolUse", "branch-pr-gate.js"), "module.exports = function() { return null; };");
+
+var watchdogPath = path.resolve(__dirname, "../../watchdog.js");
+
+function runWatchdog(healthLogContent) {
+  if (healthLogContent !== null) {
+    fs.writeFileSync(healthLog, healthLogContent);
+  } else if (fs.existsSync(healthLog)) {
+    fs.unlinkSync(healthLog);
+  }
+  // Clean previous results
+  if (fs.existsSync(alertFile)) fs.unlinkSync(alertFile);
+
+  var result = cp.spawnSync(process.execPath, [watchdogPath, "--hooks-dir", tmpDir], {
+    encoding: "utf-8",
+    timeout: 10000,
+    windowsHide: true
+  });
+  var output;
+  try { output = JSON.parse(result.stdout); } catch(e) { output = null; }
+  return { output: output, exit: result.status, alert: fs.existsSync(alertFile) };
+}
+
+// Test 1: Healthy log — no warnings
+var healthyLog = [
+  JSON.stringify({ts: new Date().toISOString(), runner: "run-pretooluse.js", exit: 0, stdout: 0, stderr: 0, ms: 45, signal: null}),
+  JSON.stringify({ts: new Date().toISOString(), runner: "run-stop.js", exit: 1, stdout: 80, stderr: 0, ms: 100, signal: null}),
+  JSON.stringify({ts: new Date().toISOString(), runner: "run-posttooluse.js", exit: 0, stdout: 0, stderr: 0, ms: 30, signal: null})
+].join("\n") + "\n";
+
+var r = runWatchdog(healthyLog);
+assert(r.output && r.output.status === "healthy", "healthy log: no warnings");
+
+// Test 2: Exit code mismatch — Stop runner writes block but exits 0
+var mismatchLog = [
+  JSON.stringify({ts: new Date().toISOString(), runner: "run-stop.js", exit: 0, stdout: 80, stderr: 0, ms: 45, signal: null})
+].join("\n") + "\n";
+
+r = runWatchdog(mismatchLog);
+assert(r.output && r.output.failed > 0, "exit mismatch: detects exit 0 with stdout on stop runner");
+
+// Test 3: Repeated crashes — same runner crashes 3+ times
+var crashLog = [
+  JSON.stringify({ts: new Date().toISOString(), runner: "run-pretooluse.js", exit: 1, stdout: 0, stderr: 100, ms: 5, signal: null}),
+  JSON.stringify({ts: new Date().toISOString(), runner: "run-pretooluse.js", exit: 1, stdout: 0, stderr: 100, ms: 5, signal: null}),
+  JSON.stringify({ts: new Date().toISOString(), runner: "run-pretooluse.js", exit: 1, stdout: 0, stderr: 100, ms: 5, signal: null})
+].join("\n") + "\n";
+
+r = runWatchdog(crashLog);
+assert(r.output && r.output.failed > 0, "repeated crashes: detects 3+ crashes from same runner");
+
+// Test 4: Stop never blocking — auto-continue installed but 0 stop blocks
+var noStopBlockLog = [];
+for (var si = 0; si < 10; si++) {
+  noStopBlockLog.push(JSON.stringify({ts: new Date().toISOString(), runner: "run-pretooluse.js", exit: 0, stdout: 0, stderr: 0, ms: 45, signal: null}));
+  noStopBlockLog.push(JSON.stringify({ts: new Date().toISOString(), runner: "run-stop.js", exit: 0, stdout: 0, stderr: 0, ms: 45, signal: null}));
+}
+r = runWatchdog(noStopBlockLog.join("\n") + "\n");
+assert(r.output && r.output.failed > 0, "stop never blocking: detects auto-continue installed but 0 stop blocks");
+
+// Test 5: Timeout/signal kills
+var signalLog = [
+  JSON.stringify({ts: new Date().toISOString(), runner: "run-pretooluse.js", exit: null, stdout: 0, stderr: 0, ms: 5000, signal: "SIGTERM"})
+].join("\n") + "\n";
+
+r = runWatchdog(signalLog);
+assert(r.output && r.output.failed > 0, "timeout: detects SIGTERM kill");
+
+// Test 6: No health log — should still be healthy (just no runtime data)
+r = runWatchdog(null);
+assert(r.output && r.output.status === "healthy", "no health log: still healthy");
+
+// Cleanup
+try {
+  var files = fs.readdirSync(tmpDir);
+  for (var fi = 0; fi < files.length; fi++) {
+    var fp = path.join(tmpDir, files[fi]);
+    try {
+      var st = fs.statSync(fp);
+      if (st.isDirectory()) {
+        // recursive delete for run-modules
+        var sub = fs.readdirSync(fp);
+        for (var si2 = 0; si2 < sub.length; si2++) {
+          var sp = path.join(fp, sub[si2]);
+          var sst = fs.statSync(sp);
+          if (sst.isDirectory()) {
+            var sub2 = fs.readdirSync(sp);
+            for (var si3 = 0; si3 < sub2.length; si3++) fs.unlinkSync(path.join(sp, sub2[si3]));
+            fs.rmdirSync(sp);
+          } else {
+            fs.unlinkSync(sp);
+          }
+        }
+        fs.rmdirSync(fp);
+      } else {
+        fs.unlinkSync(fp);
+      }
+    } catch(e) {}
+  }
+  fs.rmdirSync(tmpDir);
+} catch(e) {}
+
+console.log("\n" + pass + " passed, " + fail + " failed");
+process.exit(fail > 0 ? 1 : 0);

--- a/specs/runtime-hook-monitor/spec.md
+++ b/specs/runtime-hook-monitor/spec.md
@@ -3,43 +3,46 @@
 ## Problem
 When a hook silently fails (runner crashes, wrong path, exit code bug, timeout), nobody knows until a user notices broken behavior. The T385 exit(0) bug went undetected across multiple sessions — the stop hook appeared to work but the TUI silently discarded its output.
 
-Existing diagnostics (project-health.js, hook-self-test.js) only run at SessionStart. They check static properties (files exist, source code patterns). They don't observe runtime behavior: did the hook actually fire? Did it produce the expected result?
+Existing diagnostics (project-health.js, hook-self-test.js) only run at SessionStart **inside Claude**. They check static properties (files exist, source code patterns). They can't observe runtime behavior, and they can't catch problems when Claude itself is part of the failure chain.
+
+The PostToolUse hook-health-monitor.js (already implemented) runs inside Claude — but a hook can't reliably monitor hooks. If the system is broken, the monitor is broken too.
 
 ## Solution
-Two components that work together:
+Three components:
 
-### 1. run-hidden.js invocation log
-Every hook invocation already goes through run-hidden.js (T387). Add logging: after the child process exits, write one JSONL line to `~/.claude/hooks/hook-health.jsonl`:
+### 1. run-hidden.js invocation log (done)
+Every hook invocation goes through run-hidden.js. It logs to `~/.claude/hooks/hook-health.jsonl`:
 
 ```json
 {"ts":"2026-04-09T15:30:00Z","runner":"run-pretooluse.js","exit":1,"stdout":142,"stderr":0,"ms":45,"signal":null}
 ```
 
-Fields:
-- `ts` — ISO timestamp
-- `runner` — which runner was called
-- `exit` — child exit code
-- `stdout` — bytes written to stdout (block JSON size)
-- `stderr` — bytes written to stderr
-- `ms` — wall clock time
-- `signal` — if child was killed (SIGTERM, SIGKILL, etc.)
+### 2. PostToolUse hook-health-monitor.js (done)
+In-session anomaly detection. Best-effort — catches problems when hooks are partially working.
 
-### 2. PostToolUse hook-health-monitor.js
-After each tool call, reads the health log and checks for anomalies:
+### 3. Watchdog health log analysis (NEW)
+The watchdog (`watchdog.js`) already runs outside Claude as an OS scheduled task (every 10 minutes). It checks static config (workflows enabled, files exist). **Add runtime health analysis**: read `hook-health.jsonl` and check for:
 
-1. **Crash detection**: runner exited non-zero without writing block JSON to stdout. A legitimate block writes JSON + exits 1. A crash exits non-zero with no/invalid JSON.
-2. **Exit code mismatch**: stdout has valid `{"decision":"block",...}` JSON but exit code is 0. This is the T385 bug pattern.
-3. **Missing hooks**: reads settings.json to know which events have hooks configured. If the last N tool calls had no health log entries for a configured event, that hook isn't firing.
-4. **Timeout/signal**: runner was killed (signal != null) or took >4900ms (close to 5s hook timeout).
-5. **Repeated crashes**: same runner crashed 3+ times in last 10 entries — persistent problem.
+1. **Exit code mismatch**: any entry where stdout > 0 but exit = 0 for Stop/PostToolUse runners (block written, TUI ignores it)
+2. **Repeated crashes**: same runner has 3+ crash entries (exit != 0, stdout = 0) in recent window
+3. **Stop hook never blocking**: auto-continue.js is installed but 0 Stop blocks in last N entries — runner is broken or module isn't loading
+4. **Stale log**: hook-health.jsonl hasn't been written to in > 1 hour during business hours — hooks may not be firing at all
+5. **Timeout kills**: runners getting SIGTERM (approaching 5s hook timeout)
 
-The monitor is PostToolUse (non-blocking). It warns via stderr, never blocks.
+When anomalies are detected, the watchdog:
+- Writes `.watchdog-alert` flag (already read by project-health.js at next SessionStart)
+- Logs to `watchdog-log.jsonl`
+- Shows a Windows toast notification (new) so the user sees it immediately
+
+### 4. Install watchdog scheduled task
+The watchdog was never actually installed as a scheduled task. `watchdog.js --install` creates the task, but it was never run. Setup wizard should auto-install the watchdog. Verify it stays running.
 
 ## Log rotation
-hook-health.jsonl is append-only. The `--prune` command already handles hook-log.jsonl rotation. Add hook-health.jsonl to the same rotation (prune entries older than N days).
+hook-health.jsonl added to `--prune` rotation (same as hook-log.jsonl).
 
 ## Scope
-- `run-hidden.js` — add invocation logging
-- `modules/PostToolUse/hook-health-monitor.js` — anomaly detection
-- `scripts/test/test-hook-health-monitor.js` — test all 5 failure modes
-- `setup.js` — add hook-health.jsonl to prune rotation
+- `watchdog.js` — add `checkHealthLog()` function with 5 runtime checks
+- `watchdog.js` — add Windows toast notification on failure
+- `setup.js` — auto-install watchdog scheduled task during setup
+- `scripts/test/test-watchdog-health.js` — test all 5 health log checks
+- Verify scheduled task is running after install

--- a/specs/runtime-hook-monitor/tasks.md
+++ b/specs/runtime-hook-monitor/tasks.md
@@ -1,7 +1,12 @@
 # Runtime Hook Health Monitor — Tasks
 
-- [ ] T390a: Add invocation logging to run-hidden.js (JSONL to hook-health.jsonl)
-- [ ] T390b: Create hook-health-monitor.js PostToolUse module (5 anomaly checks)
-- [ ] T390c: Write failing tests for all 5 failure modes + happy path
+- [x] T390a: Add invocation logging to run-hidden.js (JSONL to hook-health.jsonl)
+- [x] T390b: Create hook-health-monitor.js PostToolUse module (5 anomaly checks)
+- [x] T390c: Write failing tests for all 5 failure modes + happy path
 - [ ] T390d: Add hook-health.jsonl to prune rotation in setup.js
-- [ ] T390e: Sync to live hooks and verify end-to-end
+- [x] T390e: Sync to live hooks and verify end-to-end
+- [ ] T390f: Add checkHealthLog() to watchdog.js — 5 runtime checks on hook-health.jsonl
+- [ ] T390g: Add Windows toast notification to watchdog on failure
+- [ ] T390h: Auto-install watchdog scheduled task in setup.js
+- [ ] T390i: Write failing tests for watchdog health log checks
+- [ ] T390j: Install watchdog task and verify it runs

--- a/watchdog.js
+++ b/watchdog.js
@@ -123,6 +123,99 @@ function checkModules(config) {
   return results;
 }
 
+// T390f: Runtime health log analysis — checks hook-health.jsonl for anomalies
+// that indicate hooks are silently failing at runtime
+function checkHealthLog() {
+  var results = [];
+  var healthLogPath = path.join(hooksDir, "hook-health.jsonl");
+
+  if (!fs.existsSync(healthLogPath)) {
+    // No health log = no runtime data yet (run-hidden.js not in use or fresh install)
+    return results;
+  }
+
+  var entries;
+  try {
+    var raw = fs.readFileSync(healthLogPath, "utf-8").trim();
+    if (!raw) return results;
+    var lines = raw.split("\n");
+    // Check last 50 entries
+    entries = lines.slice(-50).map(function(line) {
+      try { return JSON.parse(line); } catch(e) { return null; }
+    }).filter(Boolean);
+  } catch(e) { return results; }
+
+  if (entries.length === 0) return results;
+
+  // Check 1: Exit code mismatch — block JSON (stdout > 0) but exit 0 on Stop/PostToolUse
+  // PreToolUse legitimately uses exit(0) with block JSON
+  for (var i = 0; i < entries.length; i++) {
+    var e = entries[i];
+    if (e.exit === 0 && e.stdout > 0 && e.runner !== "run-pretooluse.js") {
+      results.push({
+        check: "health-exit-mismatch",
+        ok: false,
+        detail: e.runner + " wrote " + e.stdout + " bytes to stdout but exited 0 at " + e.ts + ". Block results silently ignored by TUI."
+      });
+      break; // One example is enough
+    }
+  }
+
+  // Check 2: Repeated crashes — same runner exits non-zero with no stdout 3+ times
+  var crashCounts = {};
+  for (var j = 0; j < entries.length; j++) {
+    var ej = entries[j];
+    if (ej.exit !== 0 && ej.exit !== null && ej.stdout === 0 && ej.stderr > 0) {
+      crashCounts[ej.runner] = (crashCounts[ej.runner] || 0) + 1;
+    }
+  }
+  var crashRunners = Object.keys(crashCounts);
+  for (var k = 0; k < crashRunners.length; k++) {
+    if (crashCounts[crashRunners[k]] >= 3) {
+      results.push({
+        check: "health-repeated-crash",
+        ok: false,
+        detail: crashRunners[k] + " crashed " + crashCounts[crashRunners[k]] + " times in last " + entries.length + " entries"
+      });
+    }
+  }
+
+  // Check 3: Stop hook never blocking — auto-continue installed but 0 stop blocks
+  var autoContPath = path.join(hooksDir, "run-modules", "Stop", "auto-continue.js");
+  if (fs.existsSync(autoContPath)) {
+    var stopEntries = entries.filter(function(e) { return e.runner === "run-stop.js"; });
+    if (stopEntries.length >= 5) {
+      var stopBlocks = stopEntries.filter(function(e) { return e.exit !== 0 && e.stdout > 0; });
+      if (stopBlocks.length === 0) {
+        results.push({
+          check: "health-stop-never-blocks",
+          ok: false,
+          detail: "auto-continue.js installed but 0 Stop blocks in " + stopEntries.length + " Stop events. Runner may be broken."
+        });
+      }
+    }
+  }
+
+  // Check 4: Timeout/signal kills
+  for (var si = 0; si < entries.length; si++) {
+    if (entries[si].signal) {
+      results.push({
+        check: "health-timeout-kill",
+        ok: false,
+        detail: entries[si].runner + " killed by " + entries[si].signal + " after " + entries[si].ms + "ms at " + entries[si].ts
+      });
+      break; // One example is enough
+    }
+  }
+
+  // If all checks passed, add a passing result
+  if (results.length === 0) {
+    results.push({ check: "health-log-ok", ok: true, detail: entries.length + " recent entries, no anomalies" });
+  }
+
+  return results;
+}
+
 function checkSettings() {
   var results = [];
   var settingsPath = path.join(process.env.HOME || process.env.USERPROFILE || "", ".claude", "settings.json");
@@ -216,6 +309,7 @@ function main() {
   allResults = allResults.concat(checkWorkflows(config));
   allResults = allResults.concat(checkRunners(config));
   allResults = allResults.concat(checkModules(config));
+  allResults = allResults.concat(checkHealthLog());
   // Only check settings if not using a custom hooks dir (CI/test mode)
   if (!getArg("--hooks-dir")) {
     allResults = allResults.concat(checkSettings());

--- a/workflows/shtd.yml
+++ b/workflows/shtd.yml
@@ -80,6 +80,7 @@ modules:
   - update-stale-docs
   - hook-health-monitor
   - hook-self-test
+  - windowless-spawn-gate
   - worktree-gate
   - pr-first-gate
   # Infrastructure safety (was: infra-safety)


### PR DESCRIPTION
## Summary
- **windowless-spawn-gate.js**: New PreToolUse gate that blocks module writes using `execSync("string")` without `windowsHide:true`. Prevents future CMD popup regressions.
- **17 execSync calls fixed** across 11 modules — all now use `execFileSync` (no shell) or `windowsHide:true`
- **Resolved paths in settings.json** (from prior commit) — hook commands no longer use `$HOME`, eliminating the outer cmd.exe shell wrapper

Combined effect: zero cmd.exe windows spawned by hooks on Windows.

## Test plan
- [x] setup wizard: 7/7
- [x] module docs: all documented
- [x] workflow audit: 77 shtd modules match YAML
- [x] CMD popup monitor shows no new hook-related cmd.exe spawns