### PR TITLE
T394: Fix batch module test for helper files

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -632,6 +632,9 @@ See `specs/fix-run-hidden/investigation.md` for full analysis with ProcMon evide
 - [x] T390-wh: Watchdog health log analysis — checkHealthLog() in watchdog.js reads hook-health.jsonl, detects exit code mismatches, repeated crashes, stop-never-blocking, timeout kills. Watchdog scheduled task installed (HookRunnerWatchdog, every 10min).
 - [x] T390-whi: Added windowsHide:true to 3 remaining spawn calls (chat-export, interrupt-detector)
 
+## Test Fixes
+- [ ] T394: Fix batch module test — validate helper files (_is-pid-running.js) with correct contract instead of gate module contract
+
 ## Pending
 - [ ] PR for branch 262-T393-execfile-fix needs to be created/merged (contains T390 auto-continue fix + watchdog health + windowsHide + T393 resolved paths)
 - [ ] Marketplace sync needed (v2.19.0)

--- a/scripts/test/_batch-module-test.js
+++ b/scripts/test/_batch-module-test.js
@@ -9,6 +9,22 @@ var events = fs.readdirSync(modsDir).filter(function(d) {
 });
 var failures = [], total = 0;
 
+// Helper files (underscore prefix) are utility modules, not gates.
+// They export functions but don't follow the gate contract (return null or {decision:"block"}).
+// Validate that they export a function and don't throw on basic input.
+function testHelper(event, name, filePath) {
+  total++;
+  try {
+    delete require.cache[require.resolve(filePath)];
+    var m = require(filePath);
+    if (typeof m !== "function") { failures.push(event + "/" + name + ": helper not a function"); return; }
+    // Call with a safe default arg — helpers typically take a single value (pid, path, etc.)
+    m(0);
+  } catch(e) {
+    failures.push(event + "/" + name + ": helper threw: " + e.message.split("\n")[0]);
+  }
+}
+
 function testModule(event, name, filePath) {
   total++;
   try {
@@ -45,7 +61,11 @@ for (var ei = 0; ei < events.length; ei++) {
         testModule(events[ei], files[fi] + "/" + subfiles[si], path.join(fp, subfiles[si]));
       }
     } else if (files[fi].slice(-3) === ".js") {
-      testModule(events[ei], files[fi], fp);
+      if (files[fi].charAt(0) === "_") {
+        testHelper(events[ei], files[fi], fp);
+      } else {
+        testModule(events[ei], files[fi], fp);
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- `_is-pid-running.js` (underscore-prefix helper) was tested with the gate module contract and failed because it returns a boolean, not `null`/`{decision:"block"}`.
- Added `testHelper()` path: validates helpers export a function and don't throw on basic input.
- All 87 modules pass (86 gates + 1 helper).

## Test plan
- [x] `node scripts/test/_batch-module-test.js` — 87/87 ALL OK