### PR TITLE
T397: Formalize hook-system-reminder module

### DIFF
--- a/modules/PreToolUse/hook-system-reminder.js
+++ b/modules/PreToolUse/hook-system-reminder.js
@@ -1,0 +1,43 @@
+// WORKFLOW: shtd
+// WHY: Claude repeatedly tries to create .claude/rules/ files despite being
+// told dozens of times across dozens of sessions. This hook fires when Claude
+// tries to WRITE or EDIT anything in ~/.claude/ to remind it how the system works.
+// It's a soft block — Claude can proceed after reading the reminder.
+"use strict";
+var os = require("os");
+
+var HOOKS_DIR = os.homedir().replace(/\\/g, "/") + "/.claude";
+
+module.exports = function(input) {
+  var tool = input.tool_name;
+  // Only care about writes/edits, not reads
+  if (tool !== "Write" && tool !== "Edit") return null;
+
+  var filePath = (input.tool_input || {}).file_path || "";
+  var normalized = filePath.replace(/\\/g, "/");
+
+  // Only fire when touching ~/.claude/ directory
+  if (normalized.indexOf(HOOKS_DIR) === -1) return null;
+
+  // Allow edits to hook-runner source (that's where modules live)
+  if (normalized.indexOf("hook-runner/") !== -1) return null;
+
+  // Allow settings files (settings.json, settings.local.json)
+  if (/settings(\.local)?\.json$/.test(normalized)) return null;
+
+  return {
+    decision: "block",
+    reason: "HOOK-RUNNER SYSTEM REMINDER — Read before proceeding.\n\n" +
+      "The ONLY enforcement mechanism is hook-runner modules:\n" +
+      "  Modules:  ~/.claude/hooks/run-modules/<Event>/<name>.js\n" +
+      "  Per-project: run-modules/PreToolUse/<project-name>/<name>.js\n" +
+      "  Config:   ~/.claude/hooks/modules.yaml\n" +
+      "  Source:   ~/Documents/ProjectsCL1/_grobomo/hook-runner/\n\n" +
+      "NEVER CREATE:\n" +
+      "  ~/.claude/rules/     — not a thing, not enforced, not read\n" +
+      "  .claude/rules/       — same, doesn't work, stop trying\n\n" +
+      "To add enforcement → create .js in hook-runner/run-modules/PreToolUse/\n" +
+      "To edit hooks → open a session in the hook-runner project\n\n" +
+      "Blocked: " + filePath.substring(0, 120)
+  };
+};

--- a/scripts/test/test-hook-system-reminder.js
+++ b/scripts/test/test-hook-system-reminder.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+"use strict";
+// Test suite for hook-system-reminder module (T397)
+
+var path = require("path");
+var os = require("os");
+var MOD = path.join(__dirname, "../../modules/PreToolUse/hook-system-reminder.js");
+
+var pass = 0, fail = 0;
+function assert(name, ok) {
+  if (ok) { console.log("  PASS: " + name); pass++; }
+  else { console.log("  FAIL: " + name); fail++; }
+}
+
+var gate = require(MOD);
+var home = os.homedir().replace(/\\/g, "/");
+
+console.log("=== hook-runner: hook-system-reminder (T397) ===");
+
+// 1. Non-hook file passes
+var r1 = gate({ tool_name: "Write", tool_input: { file_path: "/tmp/foo.js" } });
+assert("non-claude file passes", r1 === null);
+
+// 2. Write to ~/.claude/rules/ blocked
+var r2 = gate({ tool_name: "Write", tool_input: { file_path: home + "/.claude/rules/never-do-x.md" } });
+assert("write to .claude/rules/ blocked", r2 && r2.decision === "block");
+
+// 3. Edit hook-runner source (in hooks dir) passes
+var r3 = gate({ tool_name: "Edit", tool_input: { file_path: home + "/.claude/hooks/run-modules/PreToolUse/hook-runner/some-gate.js" } });
+assert("hook-runner source edit passes", r3 === null);
+
+// 4. Write to settings.json passes
+var r4 = gate({ tool_name: "Write", tool_input: { file_path: home + "/.claude/settings.json" } });
+assert("settings.json passes", r4 === null);
+
+// 5. Write to settings.local.json passes
+var r5 = gate({ tool_name: "Write", tool_input: { file_path: home + "/.claude/settings.local.json" } });
+assert("settings.local.json passes", r5 === null);
+
+// 6. Edit CLAUDE.md in ~/.claude/ blocked
+var r6 = gate({ tool_name: "Edit", tool_input: { file_path: home + "/.claude/CLAUDE.md" } });
+assert("edit CLAUDE.md blocked", r6 && r6.decision === "block");
+
+// 7. Read tool passes (not Write/Edit)
+var r7 = gate({ tool_name: "Read", tool_input: { file_path: home + "/.claude/rules/foo.md" } });
+assert("Read tool passes", r7 === null);
+
+// 8. Bash tool passes
+var r8 = gate({ tool_name: "Bash", tool_input: { command: "cat " + home + "/.claude/rules/foo.md" } });
+assert("Bash tool passes", r8 === null);
+
+// 9. Windows backslash paths normalized
+var winPath = home.replace(/\//g, "\\") + "\\.claude\\rules\\test.md";
+var r9 = gate({ tool_name: "Write", tool_input: { file_path: winPath } });
+assert("Windows backslash paths blocked", r9 && r9.decision === "block");
+
+// 10. Block message contains reminder text
+assert("block message mentions hook-runner", r2.reason.indexOf("hook-runner") !== -1);
+assert("block message mentions NEVER CREATE", r2.reason.indexOf("NEVER CREATE") !== -1);
+
+console.log("\n" + pass + "/" + (pass + fail) + " passed");
+process.exit(fail > 0 ? 1 : 0);

--- a/specs/hook-system-reminder/spec.md
+++ b/specs/hook-system-reminder/spec.md
@@ -1,0 +1,27 @@
+# T397: hook-system-reminder module (global PreToolUse)
+
+## Problem
+Claude repeatedly tries to create `~/.claude/rules/` files despite being told across dozens of sessions that enforcement is ONLY via hook-runner modules. The module exists in live hooks (`run-modules/PreToolUse/hook-system-reminder.js`) but was deployed without specs or tests.
+
+## Solution
+Formalize `hook-system-reminder.js` as a catalog module (`modules/PreToolUse/`) with proper tests.
+
+## Behavior
+- **Triggers on**: `Write` or `Edit` tool targeting any file in `~/.claude/`
+- **Allows**: edits to `hook-runner/` source files (that's where modules live)
+- **Allows**: edits to `settings.json` / `settings.local.json`
+- **Blocks with reminder**: any other Write/Edit to `~/.claude/` — tells Claude about hook-runner module system, never create `.claude/rules/`
+
+## Test Cases
+1. Non-hook file (e.g. `/tmp/foo.js`) → pass
+2. Write to `~/.claude/rules/never-do-x.md` → block
+3. Edit to `~/.claude/hooks/run-modules/PreToolUse/some-gate.js` (hook-runner path) → pass (hook-runner edits allowed)
+4. Write to `~/.claude/settings.json` → pass
+5. Write to `~/.claude/settings.local.json` → pass
+6. Edit to `~/.claude/CLAUDE.md` → block (not hook-runner, not settings)
+7. Read tool on `~/.claude/` → pass (only Write/Edit gated)
+8. Bash tool → pass (not Write/Edit)
+
+## Files
+- `modules/PreToolUse/hook-system-reminder.js` — catalog copy
+- `scripts/test/test-hook-system-reminder.js` — test suite


### PR DESCRIPTION
## Summary
- Moves live `hook-system-reminder.js` to catalog (`modules/PreToolUse/`)
- Adds spec (`specs/hook-system-reminder/spec.md`)
- Adds 11-test suite covering all block/pass paths

## Test plan
- [x] 11/11 tests pass (`node scripts/test/test-hook-system-reminder.js`)