### PR TITLE
T398: Add spec and tests for rdp-testbox-gate

### DIFF
--- a/scripts/test/test-rdp-testbox-gate.js
+++ b/scripts/test/test-rdp-testbox-gate.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+"use strict";
+// Test suite for rdp-testbox-gate module (T398)
+
+var path = require("path");
+var MOD = path.join(__dirname, "../../modules/PreToolUse/ddei-email-security/rdp-testbox-gate.js");
+
+var pass = 0, fail = 0;
+function assert(name, ok) {
+  if (ok) { console.log("  PASS: " + name); pass++; }
+  else { console.log("  FAIL: " + name); fail++; }
+}
+
+var gate = require(MOD);
+
+console.log("=== hook-runner: rdp-testbox-gate (T398) ===");
+
+// 1. Non-Bash tool passes
+var r1 = gate({ tool_name: "Write", tool_input: { file_path: "/tmp/rdp.js" } });
+assert("non-Bash tool passes", r1 === null);
+
+// 2. git status with rdp filename passes (T396 fix)
+var r2 = gate({ tool_name: "Bash", tool_input: { command: "git status rdp-testbox-gate.js" } });
+assert("git status rdp-testbox-gate.js passes", r2 === null);
+
+// 3. git add with rdp filename passes
+var r3 = gate({ tool_name: "Bash", tool_input: { command: "git add rdp-testbox-gate.js" } });
+assert("git add rdp-testbox-gate.js passes", r3 === null);
+
+// 4. git diff with rdp filename passes
+var r4 = gate({ tool_name: "Bash", tool_input: { command: "git diff rdp-testbox-gate.js" } });
+assert("git diff rdp-testbox-gate.js passes", r4 === null);
+
+// 5. cat with rdp filename passes
+var r5 = gate({ tool_name: "Bash", tool_input: { command: "cat rdp-testbox-gate.js" } });
+assert("cat rdp-testbox-gate.js passes", r5 === null);
+
+// 6. mstsc command blocked
+var r6 = gate({ tool_name: "Bash", tool_input: { command: "mstsc /v:10.0.0.1" } });
+assert("mstsc blocked", r6 && r6.decision === "block");
+
+// 7. cmdkey command blocked
+var r7 = gate({ tool_name: "Bash", tool_input: { command: "cmdkey /generic:TERMSRV/10.0.0.1" } });
+assert("cmdkey blocked", r7 && r7.decision === "block");
+
+// 8. powershell with mstsc blocked
+var r8 = gate({ tool_name: "Bash", tool_input: { command: 'powershell -Command "Start-Process mstsc /v:10.0.0.1"' } });
+assert("powershell mstsc blocked", r8 && r8.decision === "block");
+
+// 9. joel-scripts allowed
+var r9 = gate({ tool_name: "Bash", tool_input: { command: "joel-scripts/testbox-rdp.sh start" } });
+assert("joel-scripts allowed", r9 === null);
+
+// 10. testbox-create blocked
+var r10 = gate({ tool_name: "Bash", tool_input: { command: "testbox-create --name test" } });
+assert("testbox-create blocked", r10 && r10.decision === "block");
+
+// 11. testbox-destroy blocked
+var r11 = gate({ tool_name: "Bash", tool_input: { command: "testbox-destroy --name test" } });
+assert("testbox-destroy blocked", r11 && r11.decision === "block");
+
+// 12. Block message mentions proven pattern
+assert("block mentions proven pattern", r6.reason.indexOf("PROVEN RDP PATTERN") !== -1);
+
+// 13. Block message mentions two servers
+assert("block mentions ddei-testbox", r6.reason.indexOf("ddei-testbox") !== -1);
+assert("block mentions ddei-tester", r6.reason.indexOf("ddei-tester") !== -1);
+
+// 14. Normal bash command passes
+var r14 = gate({ tool_name: "Bash", tool_input: { command: "echo hello world" } });
+assert("normal bash passes", r14 === null);
+
+console.log("\n" + pass + "/" + (pass + fail) + " passed");
+process.exit(fail > 0 ? 1 : 0);

--- a/specs/rdp-testbox-gate/spec.md
+++ b/specs/rdp-testbox-gate/spec.md
@@ -1,0 +1,29 @@
+# T398: rdp-testbox-gate module (ddei-email-security PreToolUse)
+
+## Problem
+Claude wasted a full session reinventing RDP connection logic that already worked in `start-e2e-test.sh` (commit 21e5b3d). Module was deployed to live but without specs or tests.
+
+## Solution
+Add spec and test suite for the existing `modules/PreToolUse/ddei-email-security/rdp-testbox-gate.js`.
+
+## Behavior
+- **Triggers on**: `Bash` tool with RDP-related commands (mstsc, cmdkey, testbox-rdp, testbox-create, testbox-destroy, or bare "rdp" in command context)
+- **Allows**: read-only git/cat/grep commands referencing files with "rdp" in name (T396 fix)
+- **Allows**: joel-scripts/ commands (user's own scripts)
+- **Blocks with reminder**: RDP connection/creation commands with the proven pattern from start-e2e-test.sh
+
+## Test Cases
+1. Non-Bash tool → pass
+2. `git status rdp-testbox-gate.js` → pass (read-only git)
+3. `git add rdp-testbox-gate.js` → pass (read-only git)
+4. `cat rdp-testbox-gate.js` → pass (read-only command)
+5. `mstsc /v:10.0.0.1` → block
+6. `cmdkey /generic:TERMSRV/10.0.0.1` → block
+7. `powershell -Command "Start-Process mstsc"` → pass (no rdp keyword directly, but mstsc is there) → block
+8. `joel-scripts/testbox-rdp.sh` → pass (joel-scripts allowed)
+9. Block message mentions proven pattern
+10. Block message mentions two servers (ddei-testbox vs ddei-tester)
+
+## Files
+- `modules/PreToolUse/ddei-email-security/rdp-testbox-gate.js` — already in catalog (T396)
+- `scripts/test/test-rdp-testbox-gate.js` — new test suite


### PR DESCRIPTION
## Summary
- Adds spec for `ddei-email-security/rdp-testbox-gate.js`
- Adds 15-test suite covering T396 false-positive fix, block/pass paths, reminder content

## Test plan
- [x] 15/15 tests pass (`node scripts/test/test-rdp-testbox-gate.js`)