### PR TITLE
T400: Fix cross-project write protection

### DIFF
--- a/modules/PreToolUse/cwd-drift-detector.js
+++ b/modules/PreToolUse/cwd-drift-detector.js
@@ -1,4 +1,4 @@
-// WORKFLOW: cross-project-reset
+// WORKFLOW: shtd
 // WHY: When working in project A, Claude drifts into project B's files (cd, edit, read).
 // Instead of working in-place, spawn a new tab via context-reset so both projects
 // get proper tracking, hooks, and TODO.md context.

--- a/specs/cross-project-write-gate/spec.md
+++ b/specs/cross-project-write-gate/spec.md
@@ -1,0 +1,15 @@
+# T400: Fix cross-project write protection
+
+## Problem
+Claude wrote .js files to hook-runner source from a ddei-email-security session, bypassing cross-project protection. Root cause: `cwd-drift-detector` is tagged `// WORKFLOW: cross-project-reset` but that workflow is disabled. Only `shtd` and `customer-data-guard` are active.
+
+## Solution
+Change cwd-drift-detector's workflow tag from `cross-project-reset` to `shtd` so it runs with the active workflow. Cross-project write protection is core development discipline, not an optional workflow.
+
+## Changes
+- `modules/PreToolUse/cwd-drift-detector.js` — change workflow tag to `shtd`
+- Sync to live copy in `~/.claude/hooks/run-modules/`
+
+## Test Cases
+1. Verify module loads with shtd workflow tag
+2. Existing cwd-drift tests still pass (test-T321 suite covers drift scenarios)

--- a/workflows/shtd.yml
+++ b/workflows/shtd.yml
@@ -95,6 +95,7 @@ modules:
   - hook-autocommit
   - no-adhoc-commands
   - cross-project-todo-gate
+  - cwd-drift-detector
   - no-focus-steal
   - settings-audit-log
   - settings-change-gate


### PR DESCRIPTION
## Summary
- Root cause: `cwd-drift-detector` was tagged `cross-project-reset` workflow (disabled)
- Fix: changed tag to `shtd` (always active) so cross-project writes are blocked
- Added `cwd-drift-detector` to `shtd.yml` module list

## Test plan
- [x] 12/12 cwd-drift-detector tests pass
- [x] Synced to live hooks