### PR TITLE
T401: Gitignore run-modules/ (local hook copies)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ SESSION_STATE.md
 .workflow-state.json
 workflow-config.json
 scripts/test/archive/
+run-modules/


### PR DESCRIPTION
## Summary
- `run-modules/` contains local copies of live hooks written by cross-project drift (before T400 fix)
- Added to `.gitignore` since canonical source is `modules/` (catalog)

## Test plan
- [x] `git status` shows clean tree after change