### PR TITLE
T404: Fix test-modules.sh hang on sync modules

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -656,8 +656,14 @@ no test caught because tests only validated modules in isolation, not the full p
 - [x] T403b: E2E pipeline tests — pipe real input through run-hidden.js → runner → modules, verify block/pass output. Tests the full pipeline including timeouts. Cover every rule in the manifest. (PR #265)
 - [x] T403c: Preflight check — runs at session start or on demand. Reports: X rules active, Y tested in last 24h, Z never fired. Flags dead rules. (PR #265)
 
+## Test & Release (T404+)
+
+- [ ] T404: Fix test-modules.sh hang on Stop/auto-continue.js — module spawns detached process, test runner waits forever. Add timeout per-module or skip async Stop modules in batch test.
+- [ ] T405: Version bump to 2.20.0 + CHANGELOG (T397-T402 formalization, T400 cwd-drift fix, portable paths)
+- [ ] T406: Marketplace sync — copy T397-T402 changes to claude-code-skills (also covers T002/T003 from claude-code-skills TODO)
+
 ## Status
-- 339 tasks completed, 0 pending
+- 339 tasks completed, 3 pending
 - Version: 2.19.0
 - Marketplace: claude-code-skills synced to v2.19.0
 - CI: ALL GREEN (Linux + Windows)

--- a/scripts/test/test-modules.sh
+++ b/scripts/test/test-modules.sh
@@ -89,6 +89,7 @@ for event_dir in "$REPO_DIR"/modules/*/; do
           setTimeout(function() { console.log('timeout'); process.exit(0); }, 5000);
         } else {
           console.log(r === null ? 'null' : typeof r);
+          process.exit(0);
         }
       } catch(e) {
         console.log('error: ' + e.message);


### PR DESCRIPTION
## Summary
- Modules returning sync results but spawning detached child processes kept node alive
- Added `process.exit(0)` after sync `console.log` to ensure clean exit

## Test plan
- [x] Individual module tests (auto-continue, lesson-effectiveness) return cleanly
- [x] No regressions in other test suites