### PR TITLE
T407: Fix workflow YAML/tag mismatches

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -680,8 +680,11 @@ Remaining:
 - [x] T405: Version bump to 2.20.0 + CHANGELOG (PR #274)
 - [x] T406: Marketplace sync — copy T397-T405 changes to claude-code-skills (pushed to grobomo/claude-code-skills)
 
+## YAML Sync
+- [ ] T407: Fix workflow YAML/tag mismatches — add 3 missing modules to shtd.yml, remove stale entry from cpr workflow yml
+
 ## Status
-- 343 tasks completed, 0 pending
+- 343 tasks completed, 1 pending
 - Version: 2.20.0
 - Marketplace: claude-code-skills synced to v2.20.0
 - CI: ALL GREEN (Linux + Windows)

--- a/workflows/cross-project-reset.yml
+++ b/workflows/cross-project-reset.yml
@@ -27,5 +27,4 @@ steps:
     completion:
       require_files: []
 
-modules:
-  - cwd-drift-detector
+modules: []

--- a/workflows/shtd.yml
+++ b/workflows/shtd.yml
@@ -103,6 +103,10 @@ modules:
   # Messaging safety (was: messaging-safety)
   - messaging-safety-gate
   - share-is-generic
+  # Project-scoped (ddei-email-security)
+  - rdp-testbox-gate
+  # System reminders
+  - hook-system-reminder
   # Self-improvement (was: self-improvement)
   - instruction-to-hook-gate
   - instruction-detector


### PR DESCRIPTION
## Summary
- Add `rdp-testbox-gate` and `hook-system-reminder` to shtd.yml (were tagged but not listed)
- Remove stale `cwd-drift-detector` from cross-project-reset.yml (moved to shtd in T400)
- Audit now shows all 5 workflows matching their YAML definitions

## Test plan
- [x] `node setup.js --workflow audit` shows "OK (matches YAML)" for all workflows
- [x] Live workflows synced