### PR TITLE
T409: Version bump to 2.20.1 + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.20.1] — 2026-04-10
+
+### Fixed
+- **Workflow YAML/tag mismatches** (T407) — added `rdp-testbox-gate` and `hook-system-reminder` to `shtd.yml`, removed stale `cwd-drift-detector` from `cross-project-reset.yml`.
+- **cpt-gate false positive** (T408) — gate matched "cross-project" as substring, blocking edits referencing workflow names like `cross-project-reset`. Fixed with regex negative lookahead. 8 tests added.
+
 ## [2.20.0] — 2026-04-10
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -684,10 +684,13 @@ Remaining:
 - [x] T407: Fix workflow YAML/tag mismatches — add 2 missing modules to shtd.yml, remove stale entry from cpr workflow yml (PR #275)
 
 ## Gate Fix
-- [ ] T408: Fix false positive in cpt-gate — workflow name triggers the standalone marker check
+- [x] T408: Fix false positive in cpt-gate — workflow name triggers the standalone marker check (PR #276)
+
+## Release
+- [ ] T409: Version bump to 2.20.1 + CHANGELOG for T407-T408
 
 ## Status
-- 344 tasks completed, 1 pending
+- 345 tasks completed, 1 pending
 - Version: 2.20.0
 - Marketplace: claude-code-skills synced to v2.20.0
 - CI: ALL GREEN (Linux + Windows)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.20.0",
+  "version": "2.20.1",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Version bump 2.20.0 → 2.20.1
- CHANGELOG entry for T407 (YAML sync) and T408 (cpt-gate false positive fix)

## Test plan
- [x] Key test suites pass (T408, T094, T204)