### PR TITLE
T411: Workflow gate resilience for missing YAML

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -707,8 +707,11 @@ Remaining:
 ## Marketplace Sync
 - [x] T410: Sync marketplace to v2.20.1 (T407-T409 fixes: YAML alignment, cpt-gate false positive fix, version bump) (PR #278)
 
+## Workflow Resilience
+- [ ] T411: Fix workflow-gate 87 errors — stale workflow_path in .workflow-state.json + checkGate not resilient to missing YAML
+
 ## Status
-- 347 tasks completed, 0 pending
+- 347 tasks completed, 1 pending
 - Version: 2.20.1
 - Marketplace: claude-code-skills synced to v2.20.1
 - CI: ALL GREEN (Linux + Windows)

--- a/scripts/test/test-T081-T082-T083-T084-T085-T086-workflow.sh
+++ b/scripts/test/test-T081-T082-T083-T084-T085-T086-workflow.sh
@@ -195,6 +195,18 @@ RESULT=$(node -e "
 # Clean up workflow state
 node -e "var wf = require('$REPO_DIR/workflow.js'); wf.resetState('$WFTMP_WIN');" 2>/dev/null
 
+echo "[17] checkGate: resilient to missing YAML (stale workflow_path)"
+# Write a state file pointing to a non-existent YAML path
+cat > "$WFTMP/.workflow-state.json" << 'STATEEOF'
+{"workflow":"fake","workflow_path":"/tmp/does-not-exist.yml","started_at":"2026-01-01T00:00:00Z","steps":{"step1":{"status":"pending"}}}
+STATEEOF
+RESULT=$(node -e "
+  var wf = require('$REPO_DIR/workflow.js');
+  var check = wf.checkGate('step1', '$WFTMP_WIN');
+  console.log(check.allowed ? 'allowed' : 'blocked');
+" 2>/dev/null)
+[ "$RESULT" = "allowed" ] && pass "missing YAML returns allowed" || fail "got: $RESULT"
+
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ] || exit 1

--- a/workflow.js
+++ b/workflow.js
@@ -254,7 +254,10 @@ function checkGate(stepId, projectDir) {
   var state = readState(projectDir);
   if (!state) return { allowed: true, reason: "no active workflow" };
 
-  var def = loadWorkflow(state.workflow_path);
+  var def;
+  try { def = loadWorkflow(state.workflow_path); } catch(e) {
+    return { allowed: true, reason: "workflow YAML not found: " + state.workflow_path };
+  }
   var stepDef = null;
   for (var i = 0; i < def.steps.length; i++) {
     if (def.steps[i].id === stepId) { stepDef = def.steps[i]; break; }


### PR DESCRIPTION
## Summary
- `checkGate` now catches ENOENT when `workflow_path` in `.workflow-state.json` points to a moved/deleted YAML file
- Was causing 87 errors in hook-log from stale state files (old pre-`_grobomo` path)
- Added test [17] for missing YAML resilience

## Test plan
- [x] All 17 workflow tests pass
- [x] Live workflow.js synced