### PR TITLE
T412: Version bump to 2.20.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.20.2] — 2026-04-10
+
+### Fixed
+- **Workflow gate resilience** (T411) — `checkGate` now handles missing YAML files gracefully instead of throwing ENOENT (was causing 87 errors from stale `.workflow-state.json` paths). Test added.
+
 ## [2.20.1] — 2026-04-10
 
 ### Fixed

--- a/TODO.md
+++ b/TODO.md
@@ -710,8 +710,11 @@ Remaining:
 ## Workflow Resilience
 - [x] T411: Fix workflow-gate 87 errors — checkGate resilient to missing YAML + fixed stale workflow_path (PR #279)
 
+## Release
+- [ ] T412: Version bump to 2.20.2 + CHANGELOG for T411 + marketplace sync
+
 ## Status
-- 348 tasks completed, 0 pending
+- 348 tasks completed, 1 pending
 - Version: 2.20.1
 - Marketplace: claude-code-skills synced to v2.20.1
 - CI: ALL GREEN (Linux + Windows)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.20.1",
+  "version": "2.20.2",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Version bump to 2.20.2 for T411 (workflow gate resilience fix)
- CHANGELOG updated

## Test plan
- [x] 17/17 workflow tests pass
- [x] Health: 110 OK, 0 failures