### PR TITLE
T414: Version bump to 2.21.0 + docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.21.0] — 2026-04-10
+
+### Changed
+- **hook-editing-gate** (T413) — Removed self-edit protection. hook-runner is the gatekeeper and can now edit all hooks including its own gate. Other projects remain blocked. Weakening detector + quality checks still apply. Hardcoded paths replaced with generic guidance. 16 tests (was 14).
+
 ## [2.20.2] — 2026-04-10
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Modular hook runner for Claude Code. Workflows group modules into enforceable pi
 - `modules/` — distributable module catalog organized by event type
 - `workflows/` — built-in workflow definitions (YAML)
 - `specs/` — feature specs with tasks and checkpoints
-- `scripts/test/` — test scripts (49 suites)
+- `scripts/test/` — test scripts (51 suites)
 - `package.json` — npm package (enables `npx grobomo/hook-runner`)
 
 ## Testing

--- a/TODO.md
+++ b/TODO.md
@@ -716,8 +716,11 @@ Remaining:
 ## Hook Editing Gate
 - [x] T413: Remove self-edit protection from hook-editing-gate + fix hardcoded paths. Hook-runner is the gatekeeper — it can edit all hooks. Other projects blocked. 16 tests. (PR #282)
 
+## Docs + Release
+- [ ] T414: Update CLAUDE.md test count (49→51), version bump to 2.21.0 for T413, marketplace sync
+
 ## Status
-- 350 tasks completed, 0 pending
+- 350 tasks completed, 1 pending
 - Version: 2.20.2
 - Marketplace: claude-code-skills synced to v2.20.2
 - CI: ALL GREEN (Linux + Windows)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.20.2",
+  "version": "2.21.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Version bump to 2.21.0 for T413 (hook-editing-gate fix)
- CLAUDE.md test count fixed (49→51)
- Marketplace synced

## Test plan
- [x] 16/16 hook-editing-gate tests pass
- [x] Marketplace pushed