### PR TITLE
T415: Fix T339 test for T413 self-edit change

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -727,12 +727,15 @@ What was done this session:
 ## Docs + Release
 - [x] T414: Update CLAUDE.md test count (49→51), version bump to 2.21.0 for T413, marketplace sync (PR #283)
 
+## Test & Sync Fixes
+- [ ] T415: Fix T339 test — T413 removed self-edit protection, test still expected BLOCK. Updated to expect PASS. Synced setup.js to live.
+
 ## Status
-- 351 tasks completed, 0 pending
+- 352 tasks completed, 0 pending
 - Version: 2.21.0
 - Marketplace: claude-code-skills synced to v2.21.0
 - CI: ALL GREEN (Linux + Windows)
-- 86 modules across 5 workflows (2 active: shtd + customer-data-guard), 51 test suites
+- 88 modules across 5 workflows (2 active: shtd + customer-data-guard), 51 test suites
 - Self-reflection system live: self-reflection (brain bridge) + reflection-gate + reflection-score + score-inject
 - Scoring: Novice→Master levels, intervention tracking, full audit logging
 - Health: 110 OK, 0 warnings, 0 failures

--- a/scripts/test/test-T339-hook-lock.sh
+++ b/scripts/test/test-T339-hook-lock.sh
@@ -88,12 +88,12 @@ else
   fail "other project should be blocked from settings: $OUTPUT"
 fi
 
-# 4. Self-edit of hook-editing-gate.js always blocked (even from hook-runner)
+# 4. Self-edit of hook-editing-gate.js allowed from hook-runner (T413 removed self-edit protection)
 OUTPUT=$(run_gate "Edit" "$HOOKS_DIR/run-modules/PreToolUse/hook-editing-gate.js" "var x = 1;")
-if echo "$OUTPUT" | grep -q "BLOCKED.*SELF-EDIT"; then
-  pass "self-edit of hook-editing-gate.js always blocked"
+if echo "$OUTPUT" | grep -q "PASSED"; then
+  pass "self-edit of hook-editing-gate.js allowed from hook-runner"
 else
-  fail "self-edit should be blocked: $OUTPUT"
+  fail "self-edit should pass from hook-runner: $OUTPUT"
 fi
 
 # 5. Safe small edits to modules pass from hook-runner project


### PR DESCRIPTION
## Summary
- T413 removed self-edit protection from hook-editing-gate.js but T339 test still expected BLOCK
- Updated test to expect PASS when editing hook-editing-gate.js from hook-runner project
- 9/9 tests pass

## Test plan
- [x] T339 test suite passes (9/9)
- [x] Full test suite run (400+ pass, modules suite passes individually)