### PR TITLE
T416: Fix false coverage gaps in report analysis

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -730,8 +730,11 @@ What was done this session:
 ## Test & Sync Fixes
 - [x] T415: Fix T339 test — T413 removed self-edit protection, test still expected BLOCK. Updated to expect PASS. Synced setup.js to live. (PR #284)
 
+## Report Analysis Fix
+- [ ] T416: Fix false coverage gaps in --report --analyze — analyzeHooks reports "No modules for X event" for all 5 events despite modules existing. Debug and fix.
+
 ## Status
-- 352 tasks completed, 0 pending
+- 352 tasks completed, 1 pending
 - Version: 2.21.0
 - Marketplace: claude-code-skills synced to v2.21.0
 - CI: ALL GREEN (Linux + Windows)

--- a/setup.js
+++ b/setup.js
@@ -205,7 +205,10 @@ function scanHooks() {
         var cmd = h.command || "";
         var scriptPath = resolveScriptPath(cmd);
         var exists = scriptPath ? fs.existsSync(scriptPath) : false;
-        var isRunner = scriptPath ? /run-(pretooluse|posttooluse|stop|sessionstart|userpromptsubmit)\.js$/i.test(scriptPath) : false;
+        // T416: run-hidden.js wrapper means scriptPath resolves to run-hidden.js, not the actual runner.
+        // Check both the resolved path and the full command string for the runner pattern.
+        var runnerPattern = /run-(pretooluse|posttooluse|stop|sessionstart|userpromptsubmit)\.js/i;
+        var isRunner = scriptPath ? runnerPattern.test(scriptPath) || runnerPattern.test(cmd) : false;
 
         var info = {
           event: event,
@@ -243,15 +246,23 @@ function scanHooks() {
 
 function resolveScriptPath(cmd) {
   // Extract script path from command like: node "$HOME/.claude/hooks/run-stop.js"
-  var match = cmd.match(/["']([^"']+\.(js|sh|py))["']/);
-  if (match) {
-    return match[1].replace(/\$HOME/g, HOME).replace(/~/g, HOME);
-  }
-  // Try bare path after "node "
+  // T416: For run-hidden.js wrapper commands like: node "...run-hidden.js" run-stop.js
+  // collect all .js paths and prefer the actual runner over the wrapper.
+  var allPaths = [];
+  var re = /["']([^"']+\.(js|sh|py))["']/g;
+  var m;
+  while ((m = re.exec(cmd)) !== null) allPaths.push(m[1]);
   var parts = cmd.split(/\s+/);
-  for (var i = 0; i < parts.length; i++) {
-    if (/\.(js|sh|py)$/.test(parts[i])) {
-      return parts[i].replace(/\$HOME/g, HOME).replace(/~/g, HOME);
+  for (var pi = 0; pi < parts.length; pi++) {
+    var p = parts[pi].replace(/^["']|["']$/g, "");
+    if (/\.(js|sh|py)$/.test(p) && allPaths.indexOf(p) === -1) allPaths.push(p);
+  }
+  if (allPaths.length === 0) return null;
+  // Prefer the actual runner over run-hidden.js wrapper
+  var runnerRe = /run-(pretooluse|posttooluse|stop|sessionstart|userpromptsubmit)\.js$/i;
+  for (var ri = 0; ri < allPaths.length; ri++) {
+    if (runnerRe.test(allPaths[ri])) {
+      return allPaths[ri].replace(/\$HOME/g, HOME).replace(/~/g, HOME);
     }
   }
   return null;


### PR DESCRIPTION
## Summary
- T393 changed hook commands to use `run-hidden.js` wrapper on Windows
- `resolveScriptPath` extracted `run-hidden.js` instead of actual runner → `isRunner` never matched → 0 modules detected → all 5 events reported as "No modules" coverage gaps
- Fix: collect all .js paths, prefer actual runner name over wrapper

## Test plan
- [x] Setup wizard tests pass (7/7)
- [x] Report `--analyze` now shows real module counts (85 modules across 5 events)
- [x] Health check: 110 OK