### PR TITLE
T417: Fix analysis false positives — score C(8) → A(0)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -733,8 +733,11 @@ What was done this session:
 ## Report Analysis Fix
 - [x] T416: Fix false coverage gaps in --report --analyze — resolveScriptPath returned run-hidden.js wrapper instead of actual runner, isRunner never matched. Fix: prefer runner paths over wrapper. (PR #285)
 
+## Analysis Quality
+- [ ] T417: Fix analysis false positives — exclude _prefix helpers from WHY/WORKFLOW checks, exclude archived modules from DRY detection, improve score accuracy.
+
 ## Status
-- 353 tasks completed, 0 pending
+- 353 tasks completed, 1 pending
 - Version: 2.21.0
 - Marketplace: claude-code-skills synced to v2.21.0
 - CI: ALL GREEN (Linux + Windows)

--- a/report.js
+++ b/report.js
@@ -1379,6 +1379,9 @@ function generateReport(scan, outputPath, hookStats, options) {
       var aModList = [];
       for (var ami = 0; ami < aMods.length; ami++) {
         if (aMods[ami].archived) continue;
+        // Skip _prefix helper files (shared utilities, not modules)
+        var aBaseName = aMods[ami].name.replace(/^.*\//, "");
+        if (aBaseName.charAt(0) === "_") continue;
         var aModName = aMods[ami].name.replace(/\.js$/, "");
         var aStatsKey = aEvt + "/" + aModName;
         aModList.push({

--- a/setup.js
+++ b/setup.js
@@ -260,9 +260,23 @@ function resolveScriptPath(cmd) {
   if (allPaths.length === 0) return null;
   // Prefer the actual runner over run-hidden.js wrapper
   var runnerRe = /run-(pretooluse|posttooluse|stop|sessionstart|userpromptsubmit)\.js$/i;
+  // Find the wrapper's directory (first quoted full path) to resolve bare runner names
+  var wrapperDir = "";
+  for (var wi = 0; wi < allPaths.length; wi++) {
+    var resolved = allPaths[wi].replace(/\$HOME/g, HOME).replace(/~/g, HOME);
+    if (resolved.indexOf("/") !== -1 || resolved.indexOf("\\") !== -1) {
+      wrapperDir = path.dirname(resolved);
+      break;
+    }
+  }
   for (var ri = 0; ri < allPaths.length; ri++) {
     if (runnerRe.test(allPaths[ri])) {
-      return allPaths[ri].replace(/\$HOME/g, HOME).replace(/~/g, HOME);
+      var rp = allPaths[ri].replace(/\$HOME/g, HOME).replace(/~/g, HOME);
+      // If bare name (no directory), resolve relative to wrapper dir
+      if (wrapperDir && rp.indexOf("/") === -1 && rp.indexOf("\\") === -1) {
+        rp = path.join(wrapperDir, rp);
+      }
+      return rp;
     }
   }
   return null;


### PR DESCRIPTION
## Summary
- `resolveScriptPath` returned bare runner name for `run-hidden.js` wrapper → `path.dirname` gave `.` → wrong `modulesDir` → archived modules mixed into analysis
- Archived `gsd-gate` appeared in DRY WHY check as false duplicate
- `_is-pid-running` helper flagged for missing WHY/WORKFLOW (it's a helper, not a module)
- Analysis score improved from C(8 demerits) to A(0 demerits)

## Test plan
- [x] Setup wizard tests pass (7/7)
- [x] Analysis shows 0 demerits, score A
- [x] No false coverage gaps, no false DRY issues
- [x] Health check: 110 OK