### PR TITLE
T418: Version bump to 2.21.1 + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.21.1] — 2026-04-10
+
+### Fixed
+- **T339 test** (T415) — Updated test for T413 self-edit protection removal. Was expecting BLOCK, now expects PASS.
+- **Report analysis false coverage gaps** (T416) — `resolveScriptPath` returned `run-hidden.js` wrapper path instead of actual runner on Windows. `isRunner` never matched → 0 modules → all 5 events reported as empty.
+- **Report analysis false positives** (T417) — Bare runner name resolved to project dir instead of hooks dir, mixing archived modules into analysis. `_prefix` helper files flagged for missing headers. Score C(8 demerits) → A(0).
+
 ## [2.21.0] — 2026-04-10
 
 ### Changed

--- a/TODO.md
+++ b/TODO.md
@@ -734,10 +734,13 @@ What was done this session:
 - [x] T416: Fix false coverage gaps in --report --analyze — resolveScriptPath returned run-hidden.js wrapper instead of actual runner, isRunner never matched. Fix: prefer runner paths over wrapper. (PR #285)
 
 ## Analysis Quality
-- [ ] T417: Fix analysis false positives — exclude _prefix helpers from WHY/WORKFLOW checks, exclude archived modules from DRY detection, improve score accuracy.
+- [x] T417: Fix analysis false positives — resolveScriptPath bare name resolution, _prefix helper exclusion, archived module DRY fix. Score C(8)→A(0). (PR #286)
 
 ## Status
-- 353 tasks completed, 1 pending
+- [ ] T418: Version bump to 2.21.1 + CHANGELOG for T415-T417
+
+## Status
+- 354 tasks completed, 1 pending
 - Version: 2.21.0
 - Marketplace: claude-code-skills synced to v2.21.0
 - CI: ALL GREEN (Linux + Windows)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.21.0",
+  "version": "2.21.1",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Version bump 2.21.0 → 2.21.1
- CHANGELOG entries for T415-T417 (test fix, report analysis fixes)

## Test plan
- [x] Setup wizard tests 7/7
- [x] Health check 110 OK
- [x] Analysis score A (0 demerits)