### PR TITLE
T419: Optimize pr-first-gate — file cache with 5min TTL

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -739,8 +739,11 @@ What was done this session:
 ## Release
 - [x] T418: Version bump to 2.21.1 + CHANGELOG for T415-T417 (PR #287)
 
+## Performance
+- [ ] T419: Optimize pr-first-gate — file-based cache with 5min TTL instead of per-process gh call (~67ms→<1ms for cached lookups)
+
 ## Status
-- 355 tasks completed, 0 pending
+- 355 tasks completed, 1 pending
 - Version: 2.21.1
 - Marketplace: needs sync to v2.21.1
 - CI: ALL GREEN (Linux + Windows)

--- a/modules/PreToolUse/pr-first-gate.js
+++ b/modules/PreToolUse/pr-first-gate.js
@@ -6,10 +6,31 @@
 // This gate blocks spec/code edits on feature branches that don't have an open PR.
 "use strict";
 var cp = require("child_process");
+var fs = require("fs");
+var path = require("path");
 
-// Cache PR check per branch per process lifetime (hooks are short-lived, but
-// multiple modules run in one invocation — avoids redundant gh calls)
-var prCache = {};
+// File-based cache with TTL — gh pr list is ~67ms per call, runs on every
+// Edit/Write on feature branches. Once a PR exists it won't disappear,
+// so cache the result for 5 minutes to avoid repeated network calls.
+var CACHE_TTL_MS = 300000; // 5 minutes
+var CACHE_DIR = path.join(process.env.HOME || process.env.USERPROFILE || "", ".claude", ".pr-cache");
+
+function readCache(branch) {
+  try {
+    var fp = path.join(CACHE_DIR, encodeURIComponent(branch) + ".json");
+    var data = JSON.parse(fs.readFileSync(fp, "utf-8"));
+    if (Date.now() - (data.ts || 0) < CACHE_TTL_MS) return data.hasPR;
+  } catch (e) { /* miss */ }
+  return undefined;
+}
+
+function writeCache(branch, hasPR) {
+  try {
+    if (!fs.existsSync(CACHE_DIR)) fs.mkdirSync(CACHE_DIR, { recursive: true });
+    var fp = path.join(CACHE_DIR, encodeURIComponent(branch) + ".json");
+    fs.writeFileSync(fp, JSON.stringify({ ts: Date.now(), hasPR: hasPR }));
+  } catch (e) { /* best effort */ }
+}
 
 module.exports = function(input) {
   var tool = (input.tool_name || "").toLowerCase();
@@ -43,21 +64,25 @@ module.exports = function(input) {
   var branch = (input._git && input._git.branch) || "";
   if (!branch || branch === "main" || branch === "master") return null;
 
-  // Check if an open PR exists for this branch
-  if (prCache[branch] !== undefined) {
-    if (prCache[branch]) return null; // PR exists
-  } else {
+  // Check if an open PR exists for this branch (file-based cache, 5min TTL)
+  var cached = readCache(branch);
+  if (cached !== undefined) {
+    if (cached) return null; // PR exists (cached)
+    // cached false = no PR last time, but re-check if TTL allows
+  }
+  if (cached === undefined) {
     try {
       var result = cp.execSync(
         "gh_auto pr list --head " + branch + " --state open --json number --limit 1",
         { cwd: process.cwd(), encoding: "utf-8", timeout: 5000, windowsHide: true }
       ).trim();
       var prs = JSON.parse(result || "[]");
-      prCache[branch] = prs.length > 0;
-      if (prCache[branch]) return null;
+      var hasPR = prs.length > 0;
+      writeCache(branch, hasPR);
+      if (hasPR) return null;
     } catch(e) {
       // gh not available or failed — don't block if we can't check
-      prCache[branch] = true;
+      writeCache(branch, true);
       return null;
     }
   }


### PR DESCRIPTION
## Summary
- pr-first-gate called `gh_auto pr list` on every Edit/Write on feature branches (~67ms avg)
- Added file-based cache in `~/.claude/.pr-cache/` with 5-minute TTL
- Once a PR exists it won't disappear, so cache hit eliminates the network call
- Expected: ~67ms → <1ms for 99%+ of invocations

## Test plan
- [x] pr-first-gate tests pass (7/7)
- [x] Cache file written on first call, read on subsequent calls
- [x] Module still blocks when no PR exists