### PR TITLE
T421: Version bump to 2.21.2 + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.21.2] — 2026-04-10
+
+### Performance
+- **spec-gate caching** (T420) — Added mtime-based caching for specs/ directory scan, TODO.md reads, and autoActivateShtd. Cold call ~108ms, warm calls ~1.7ms avg (was ~98ms). 57x speedup on cached calls. Cache invalidates when file mtimes change.
+
 ## [2.21.1] — 2026-04-10
 
 ### Fixed

--- a/TODO.md
+++ b/TODO.md
@@ -757,13 +757,13 @@ What was done this session:
 Remaining perf targets (from --perf): preserve-iterated-content (47ms avg), secret-scan-gate (44ms avg), spec-gate (40ms avg)
 
 ## Performance Optimization
-- [ ] T420: Optimize spec-gate — cache specs/ directory scan with mtime invalidation (~62ms→<1ms for cached), cache autoActivateShtd result per session (~7ms→0ms)
-- [ ] T421: Version bump + CHANGELOG
+- [x] T420: Optimize spec-gate — mtime-based caching for specs/ scan + TODO.md reads + autoActivateShtd (~98ms→2ms per call, 57x speedup) (PR #289)
+- [x] T421: Version bump to 2.21.2 + CHANGELOG for T420 (PR #290)
 
 ## Status
-- 356 tasks completed, 2 pending
-- Version: 2.21.1
-- Marketplace: needs sync to v2.21.1
+- 358 tasks completed, 0 pending
+- Version: 2.21.2
+- Marketplace: synced to v2.21.1
 - CI: ALL GREEN (Linux + Windows)
 - 88 modules across 5 workflows (2 active: shtd + customer-data-guard), 51 test suites
 - Self-reflection system live: self-reflection (brain bridge) + reflection-gate + reflection-score + score-inject

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.21.1",
+  "version": "2.21.2",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Version bump to 2.21.2
- CHANGELOG entry for T420 spec-gate performance optimization

## Test plan
- [x] No code changes — version/docs only