### PR TITLE
T349/T351/T352/T353: Lessons system fixes + --lessons CLI

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -760,10 +760,10 @@ Perf notes: preserve-iterated-content (46ms) and secret-scan-gate (45ms) average
 - [x] T421: Version bump to 2.21.2 + CHANGELOG for T420 (PR #290)
 
 ## Cache Correctness Fix
-- [ ] T422: Fix cachedSpecScan stale hasUnchecked — editing tasks.md doesn't change parent specs/ dir mtime, so cached entries return stale hasUnchecked. Fix: re-check task content via cachedReadFile on cache hit.
+- [x] T422: Fix cachedSpecScan stale hasUnchecked — re-check task content via cachedReadFile on cache hit (~3.8ms avg, still 25x faster) (PR #291)
 
 ## Status
-- 358 tasks completed, 1 pending
+- 359 tasks completed, 0 pending
 - Version: 2.21.2
 - Marketplace: synced to v2.21.2
 - CI: ALL GREEN (Linux + Windows)
@@ -911,6 +911,22 @@ Remaining from this session's discussion:
 - [x] T347: Self-reflection buildPrompt handles no-edit sessions — shows "NO FILES EDITED" warning so claude -p analysis flags unproductive sessions.
 - [x] T348: Version bump to 2.12.0 + CHANGELOG + marketplace sync (T341-T347: UPS ban, frustration detection in runner, self-reflection improvements)
 - Duplicate T refs removed — see Bugs & Security section above for T337-T340
+
+## Self-Analysis Lessons System — Fixes Needed
+
+Context: The self-reflection → load-lessons pipeline has gaps found during ddei-e2e session (2026-04-11).
+
+- [x] T349: Fix dual lessons file — injected prompt told Claude to write to `self-analysis-lessons.jsonl` without full path. Fixed to specify `~/.claude/hooks/self-analysis-lessons.jsonl` (PR #292)
+
+- [ ] T350: Self-reflection only writes lessons for high-severity corrective feedback (user corrections). It should ALSO extract general operational lessons — patterns like "PowerShell Compress-Archive fails on file locks" or "MSYS_NO_PATHCONV blocks winpath conversion". These are discovered during normal work, not just user corrections. Add a "general lessons" extraction path in `extractCorrectiveFeedback()` or a new function.
+
+- [x] T351: Lessons rotation — when file exceeds 200 lines, archive oldest and keep recent 100. Added to load-lessons.js SessionStart module (PR #292)
+
+- [x] T352: Increased MAX_LESSONS from 10 to 20 so more lessons are injected at session start (PR #292)
+
+- [x] T353: Added `--lessons` CLI command — shows all lessons, supports `--project <name>`, `--date YYYY-MM-DD`, `--archive` filters (PR #292)
+
+- [ ] T354: Modify Stop hook text — when Claude creates TODOs in another project, the stop hook should tell it: "If you created tasks in another project, run: `touch ~/.claude/.preserve-tab` then `python C:/Users/joelg/Documents/ProjectsCL1/context-reset/context_reset.py --project-dir $CLAUDE_PROJECT_DIR` — this preserves the current tab so user can review, while a new Claude tab opens to work on the cross-project TODOs." Currently the stop hook says "Do NOT preserve the old tab unless something unusual happened" which prevents this workflow.
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog

--- a/modules/SessionStart/load-lessons.js
+++ b/modules/SessionStart/load-lessons.js
@@ -12,7 +12,9 @@ var CLAUDE_DIR = path.join(os.homedir(), ".claude");
 var LESSONS_FILE = path.join(CLAUDE_DIR, "hooks", "self-analysis-lessons.jsonl");
 var ERROR_LOG = path.join(CLAUDE_DIR, "self-analysis-errors.log");
 var ANALYSIS_LOG = path.join(CLAUDE_DIR, "self-analysis.log");
-var MAX_LESSONS = 10; // inject the 10 most recent
+var MAX_LESSONS = 20; // inject the 20 most recent (T352: increased from 10)
+var MAX_LINES = 200; // rotate when file exceeds this (T351)
+var ARCHIVE_FILE = path.join(CLAUDE_DIR, "hooks", "self-analysis-lessons-archive.jsonl");
 
 function checkBgErrors() {
   // Surface background script errors that the user can't see
@@ -50,7 +52,7 @@ module.exports = function(input) {
       "(3) This module (load-lessons) injects those lessons at SessionStart so you learn from past sessions.\n" +
       "(4) reflection-score.js tracks your score (clean reflections +points, corrections -points).\n" +
       "YOUR ROLE: When you learn something this session (a mistake, a better pattern, a user correction),\n" +
-      "write it to self-analysis-lessons.jsonl as a JSONL line: {\"lesson\": \"...\", \"ts\": \"ISO\", \"session\": \"id\"}.\n" +
+      "write it to ~/.claude/hooks/self-analysis-lessons.jsonl as a JSONL line: {\"lesson\": \"...\", \"ts\": \"ISO\", \"session\": \"id\"}.\n" +
       "Future sessions will see it. Do NOT reinvent the system — it already exists and runs automatically."
     );
 
@@ -60,6 +62,21 @@ module.exports = function(input) {
       parts.push("BACKGROUND SCRIPT ERRORS (auto-detected):\n" + errors +
         "\nInvestigate and fix these before they recur.");
     }
+
+    // T351: Rotate lessons file if it exceeds MAX_LINES
+    try {
+      if (fs.existsSync(LESSONS_FILE)) {
+        var allLines = fs.readFileSync(LESSONS_FILE, "utf-8").trim().split("\n");
+        if (allLines.length > MAX_LINES) {
+          var archive = allLines.slice(0, allLines.length - 100);
+          var keep = allLines.slice(-100);
+          // Append old lines to archive
+          fs.appendFileSync(ARCHIVE_FILE, archive.join("\n") + "\n");
+          // Overwrite lessons with recent 100
+          fs.writeFileSync(LESSONS_FILE, keep.join("\n") + "\n");
+        }
+      }
+    } catch(e) {}
 
     // Load lessons
     if (fs.existsSync(LESSONS_FILE)) {

--- a/run-modules/SessionStart/load-lessons.js
+++ b/run-modules/SessionStart/load-lessons.js
@@ -1,3 +1,4 @@
+// WORKFLOW: shtd
 // WHY: Self-analysis generates lessons from interrupts, but those lessons
 // are only useful if Claude reads them at the start of each session.
 // This module reads self-analysis-lessons.jsonl and injects recent
@@ -7,33 +8,99 @@ var fs = require("fs");
 var path = require("path");
 var os = require("os");
 
-var LESSONS_FILE = path.join(os.homedir(), ".claude", "hooks", "self-analysis-lessons.jsonl");
-var MAX_LESSONS = 10; // inject the 10 most recent
+var CLAUDE_DIR = path.join(os.homedir(), ".claude");
+var LESSONS_FILE = path.join(CLAUDE_DIR, "hooks", "self-analysis-lessons.jsonl");
+var ERROR_LOG = path.join(CLAUDE_DIR, "self-analysis-errors.log");
+var ANALYSIS_LOG = path.join(CLAUDE_DIR, "self-analysis.log");
+var MAX_LESSONS = 20; // inject the 20 most recent (T352: increased from 10)
+var MAX_LINES = 200; // rotate when file exceeds this (T351)
+var ARCHIVE_FILE = path.join(CLAUDE_DIR, "hooks", "self-analysis-lessons-archive.jsonl");
+
+function checkBgErrors() {
+  // Surface background script errors that the user can't see
+  var msgs = [];
+  var logFiles = [ERROR_LOG, ANALYSIS_LOG];
+  for (var i = 0; i < logFiles.length; i++) {
+    var logFile = logFiles[i];
+    try {
+      if (!fs.existsSync(logFile)) continue;
+      var stat = fs.statSync(logFile);
+      // Only report if modified in last 24 hours
+      if (Date.now() - stat.mtimeMs > 86400000) continue;
+      var lines = fs.readFileSync(logFile, "utf-8").trim().split("\n");
+      var errors = lines.filter(function(l) {
+        return /error|fail|stderr/i.test(l);
+      }).slice(-3);
+      if (errors.length > 0) {
+        msgs.push("Background script issues in " + path.basename(logFile) + ":\n" +
+          errors.join("\n"));
+      }
+    } catch(e) {}
+  }
+  return msgs.length > 0 ? msgs.join("\n\n") : "";
+}
 
 module.exports = function(input) {
+  var parts = [];
   try {
-    if (!fs.existsSync(LESSONS_FILE)) return null;
-    var content = fs.readFileSync(LESSONS_FILE, "utf-8").trim();
-    if (!content) return null;
+    // T379: Inject self-reflection system description so Claude understands
+    // how the feedback loop works and can participate in it.
+    parts.push(
+      "SELF-REFLECTION SYSTEM: You have a self-reflection system that runs at every Stop event.\n" +
+      "How it works: (1) self-reflection.js analyzes your session — gate decisions, edits, user corrections.\n" +
+      "(2) Lessons are extracted and stored in self-analysis-lessons.jsonl.\n" +
+      "(3) This module (load-lessons) injects those lessons at SessionStart so you learn from past sessions.\n" +
+      "(4) reflection-score.js tracks your score (clean reflections +points, corrections -points).\n" +
+      "YOUR ROLE: When you learn something this session (a mistake, a better pattern, a user correction),\n" +
+      "write it to ~/.claude/hooks/self-analysis-lessons.jsonl as a JSONL line: {\"lesson\": \"...\", \"ts\": \"ISO\", \"session\": \"id\"}.\n" +
+      "Future sessions will see it. Do NOT reinvent the system — it already exists and runs automatically."
+    );
 
-    var lines = content.split("\n").filter(function(l) { return l.trim(); });
-    var recent = lines.slice(-MAX_LESSONS);
+    // Check for background script errors
+    var errors = checkBgErrors();
+    if (errors) {
+      parts.push("BACKGROUND SCRIPT ERRORS (auto-detected):\n" + errors +
+        "\nInvestigate and fix these before they recur.");
+    }
 
-    var lessons = recent.map(function(line) {
-      try {
-        var obj = JSON.parse(line);
-        return obj.lesson || "";
-      } catch(e) {
-        return "";
+    // T351: Rotate lessons file if it exceeds MAX_LINES
+    try {
+      if (fs.existsSync(LESSONS_FILE)) {
+        var allLines = fs.readFileSync(LESSONS_FILE, "utf-8").trim().split("\n");
+        if (allLines.length > MAX_LINES) {
+          var archive = allLines.slice(0, allLines.length - 100);
+          var keep = allLines.slice(-100);
+          // Append old lines to archive
+          fs.appendFileSync(ARCHIVE_FILE, archive.join("\n") + "\n");
+          // Overwrite lessons with recent 100
+          fs.writeFileSync(LESSONS_FILE, keep.join("\n") + "\n");
+        }
       }
-    }).filter(function(l) { return l; });
+    } catch(e) {}
 
-    if (lessons.length === 0) return null;
+    // Load lessons
+    if (fs.existsSync(LESSONS_FILE)) {
+      var content = fs.readFileSync(LESSONS_FILE, "utf-8").trim();
+      if (content) {
+        var lines = content.split("\n").filter(function(l) { return l.trim(); });
+        var recent = lines.slice(-MAX_LESSONS);
+        var lessons = recent.map(function(line) {
+          try {
+            var obj = JSON.parse(line);
+            return obj.lesson || "";
+          } catch(e) {
+            return "";
+          }
+        }).filter(function(l) { return l; });
 
-    return "SELF-ANALYSIS LESSONS (from past interrupt reflections):\n" +
-      lessons.join("\n") +
-      "\nApply these lessons. If you catch yourself repeating a pattern, stop and correct.";
-  } catch(e) {
-    return null;
-  }
+        if (lessons.length > 0) {
+          parts.push("SELF-ANALYSIS LESSONS (from past interrupt reflections):\n" +
+            lessons.join("\n") +
+            "\nApply these lessons. If you catch yourself repeating a pattern, stop and correct.");
+        }
+      }
+    }
+  } catch(e) {}
+
+  return parts.length > 0 ? { text: parts.join("\n\n") } : null;
 };

--- a/setup.js
+++ b/setup.js
@@ -747,6 +747,7 @@ function cmdHelp() {
   console.log("  --sync          Sync modules from GitHub per ~/.claude/hooks/modules.yaml");
   console.log("  --list          Show catalog vs installed modules with status");
   console.log("  --stats         Quick text summary of hook log activity");
+  console.log("  --lessons       Show self-analysis lessons (--project <name>, --date YYYY-MM-DD)");
   console.log("  --workflow      Manage enforceable step pipelines (list|start|status|complete|reset)");
   console.log("  --export [file] Export installed modules as shareable YAML (default: modules-export.yaml)");
   console.log("  --perf          Analyze module timing data and identify bottlenecks");
@@ -1024,6 +1025,54 @@ function cmdStats() {
     }
     console.log("");
   }
+}
+
+function cmdLessons(args) {
+  console.log("[hook-runner] Self-Analysis Lessons");
+  console.log("========================");
+  var lessonsFile = path.join(HOOKS_DIR, "self-analysis-lessons.jsonl");
+  var archiveFile = path.join(HOOKS_DIR, "self-analysis-lessons-archive.jsonl");
+
+  // Parse filters
+  var filterProject = null;
+  var filterDate = null;
+  var pidx = args.indexOf("--project");
+  if (pidx !== -1 && args[pidx + 1]) filterProject = args[pidx + 1].toLowerCase();
+  var didx = args.indexOf("--date");
+  if (didx !== -1 && args[didx + 1]) filterDate = args[didx + 1];
+  var showArchive = args.indexOf("--archive") !== -1;
+
+  var targetFile = showArchive ? archiveFile : lessonsFile;
+  if (!fs.existsSync(targetFile)) {
+    console.log("  No lessons file found at " + targetFile);
+    return;
+  }
+  var content = fs.readFileSync(targetFile, "utf-8").trim();
+  if (!content) {
+    console.log("  Lessons file is empty.");
+    return;
+  }
+  var lines = content.split("\n").filter(function(l) { return l.trim(); });
+  var lessons = [];
+  for (var i = 0; i < lines.length; i++) {
+    try {
+      var obj = JSON.parse(lines[i]);
+      if (filterProject && obj.lesson && obj.lesson.toLowerCase().indexOf(filterProject) === -1 &&
+          (!obj.session || obj.session.toLowerCase().indexOf(filterProject) === -1)) continue;
+      if (filterDate && obj.ts && obj.ts.indexOf(filterDate) !== 0) continue;
+      lessons.push(obj);
+    } catch(e) {}
+  }
+  console.log("  Total: " + lessons.length + " lesson(s)" + (showArchive ? " (archive)" : ""));
+  if (filterProject) console.log("  Filter: project contains '" + filterProject + "'");
+  if (filterDate) console.log("  Filter: date starts with '" + filterDate + "'");
+  console.log("");
+  for (var j = 0; j < lessons.length; j++) {
+    var l = lessons[j];
+    var prefix = l.ts ? "[" + l.ts.slice(0, 10) + "] " : "";
+    console.log("  " + prefix + (l.lesson || "(no lesson text)"));
+  }
+  if (lessons.length === 0) console.log("  No lessons match the given filters.");
 }
 
 function cmdList() {
@@ -1646,6 +1695,7 @@ function main() {
   if (args.indexOf("--upgrade") !== -1) return cmdUpgrade(args, dryRun);
   if (args.indexOf("--uninstall") !== -1) return cmdUninstall(args, dryRun);
   if (args.indexOf("--prune") !== -1) return cmdPrune(args, dryRun);
+  if (args.indexOf("--lessons") !== -1) return cmdLessons(args);
   if (args.indexOf("--stats") !== -1) return cmdStats();
   if (args.indexOf("--export") !== -1) return cmdExport(args);
   if (args.indexOf("--perf") !== -1) return cmdPerf();


### PR DESCRIPTION
## Summary
- **T349**: Fix injected prompt path — told Claude to write to `self-analysis-lessons.jsonl` without full path, now specifies `~/.claude/hooks/self-analysis-lessons.jsonl`
- **T351**: Add lessons file rotation — when >200 lines, archive oldest, keep recent 100
- **T352**: Increase MAX_LESSONS from 10 to 20 for richer session context
- **T353**: Add `--lessons` CLI command with `--project`, `--date`, `--archive` filters

## Test plan
- [x] setup wizard tests: 7/7 pass
- [x] `--lessons` shows all 86 lessons
- [x] `--lessons --date 2026-04-11` filters correctly (3 results)
- [x] Module loads without error