### PR TITLE
T354: Cross-project workflow in stop-message.txt

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -926,7 +926,7 @@ Context: The self-reflection → load-lessons pipeline has gaps found during dde
 
 - [x] T353: Added `--lessons` CLI command — shows all lessons, supports `--project <name>`, `--date YYYY-MM-DD`, `--archive` filters (PR #292)
 
-- [ ] T354: Modify Stop hook text — when Claude creates TODOs in another project, the stop hook should tell it: "If you created tasks in another project, run: `touch ~/.claude/.preserve-tab` then `python C:/Users/joelg/Documents/ProjectsCL1/context-reset/context_reset.py --project-dir $CLAUDE_PROJECT_DIR` — this preserves the current tab so user can review, while a new Claude tab opens to work on the cross-project TODOs." Currently the stop hook says "Do NOT preserve the old tab unless something unusual happened" which prevents this workflow.
+- [x] T354: Added cross-project workflow instructions to stop-message.txt — tells Claude to preserve tab + context-reset to other project when cross-project TODOs are created. Also added stop-message.txt to module catalog (PR #294)
 
 ## Commit Discipline & Spec Enforcement
 

--- a/modules/Stop/stop-message.txt
+++ b/modules/Stop/stop-message.txt
@@ -1,0 +1,14 @@
+DO NOT STOP. DO NOT SUMMARIZE. DO NOT LIST OPTIONS. Follow this order:
+
+1) Check TODO.md in $CLAUDE_PROJECT_DIR — if tasks remain, do the next one NOW.
+2) Read the jsonl logs in ~/.claude/projects/ (folder matching current project path, most recent .jsonl). Scan for incomplete tangents, abandoned fixes, things discussed but never done — do them.
+3) Organize, modularize, optimize, secure the project. Code review, DRY, clean up, harden.
+4) Zoom out: why does this project exist, how does it integrate, what real-world value comes next? How can we share it with the team — publish, document, demo, package? Write new tasks to TODO.md then EXECUTE. No breaks. No asking. Plan then do.
+
+If context is getting long, save state to $CLAUDE_PROJECT_DIR/TODO.md (always the launch directory, not cwd), then run: python C:/Users/joelg/Documents/ProjectsCL1/context-reset/context_reset.py --project-dir $CLAUDE_PROJECT_DIR
+To keep the old tab open for review: touch ~/.claude/.preserve-tab before running context_reset.py (one-shot, auto-deleted)
+
+CROSS-PROJECT WORK: If you created TODOs in another project's TODO.md, preserve this tab and open a new session for that project:
+  touch ~/.claude/.preserve-tab
+  python C:/Users/joelg/Documents/ProjectsCL1/context-reset/context_reset.py --project-dir <OTHER_PROJECT_DIR>
+This keeps the current tab for user review while a new Claude tab picks up the cross-project work.


### PR DESCRIPTION
## Summary
- Add cross-project TODO instructions to stop-message.txt
- When Claude creates TODOs in another project, tells it to preserve tab + context-reset
- Also adds stop-message.txt to module catalog (was only in live run-modules)

## Test plan
- [x] stop-message.txt content verified
- [x] auto-continue.js reads from __dirname/stop-message.txt — works with catalog copy