### PR TITLE
T355-T360: Commit discipline gate modules

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -936,17 +936,17 @@ Context: Claude spins wheels making undocumented changes, no git trail, can't de
 
 Design principle: gate on ALL tools via PreToolUse (not just Edit/Write). Claude bypasses Edit gates by using Bash with sed/awk/echo/python. Use `git diff --stat` as ground truth. Persist state in files, not memory (survives context resets).
 
-- [ ] T355: **Commit counter gate (PreToolUse, ALL tools)** — Track file modifications since last commit. Count increments on: Edit, Write, Bash containing file-modifying patterns (sed -i, awk, echo >, cat >, python -c.*open.*write, tee). After 5 modifications without a `git commit`, block ALL tool calls with: "You have N uncommitted file changes. Commit now with a descriptive message before continuing." Reset counter on successful `git commit`. Store in `~/.claude/hooks/.uncommitted-edit-count`. Cross-check with `git diff --stat` (counter can drift if files are reverted).
+- [x] T355: **Commit counter gate** — commit-counter-gate.js tracks Edit/Write/file-modifying Bash. After 5 without commit, blocks. Cross-checks git diff. State in .uncommitted-edit-count (PR #296)
 
-- [ ] T356: **Deploy gate (PreToolUse, Bash)** — Before commands matching `upload-and-run|quick-sync|create-zip|terraform apply|az vm run-command create`, check `git status --porcelain`. If dirty tree, block: "Uncommitted changes detected. Commit before deploying so results are tied to a known git state." Every E2E run must be traceable to a commit SHA.
+- [x] T356: **Deploy gate** — deploy-gate.js blocks deploy commands (upload-and-run, terraform apply, kubectl apply, docker push, etc.) when git tree is dirty. Shows changed files (PR #296)
 
-- [ ] T357: **Spec-before-code gate (PreToolUse, Edit/Write/Bash file-modify)** — On FIRST file modification after a commit, check for a spec. Look for: recent TODO.md entry with "SPEC:" or "FIX:" prefix, or a git commit within 5 min with message >20 chars. If no spec: "Write a spec first. What's broken? What's the fix? Why? Add to TODO.md or a commit message."
+- [x] T357: **Spec-before-code gate** — spec-before-code-gate.js blocks first file modification after commit unless TODO.md has unchecked tasks or recent commit has descriptive message (PR #296)
 
-- [ ] T358: **Commit message quality gate (PreToolUse, Bash matching git commit)** — Block if message: (a) <10 words, (b) starts with generic "fix/update/change" without specifics, (c) doesn't say what changed and why. Example good message: "Fix F5 marketplace import — winpath() needed when MSYS_NO_PATHCONV=1 blocks Git Bash path conversion"
+- [x] T358: **Commit message quality gate** — commit-quality-gate.js blocks git commit with <5 word messages or generic starts (fix/update/change without detail) (PR #296)
 
-- [ ] T359: **Git history check reminder (PreToolUse, Bash matching upload-and-run|quick-sync)** — Non-blocking advisory before E2E re-runs: "Before re-running: `git log --oneline -10` to see what you tried. Don't repeat failed approaches."
+- [x] T359: **Git history check reminder** — deploy-history-reminder.js shows last 5 commits as advisory before deploy commands. Non-blocking (PR #296)
 
-- [ ] T360: **Anti-circumvention patterns** — File-modifying Bash detection must cover: `sed -i, awk -i, echo.*>, cat.*>, tee, python.*open.*write, printf.*>, cp .*, mv .*`. Cannot be bypassed by wrapping in a script — gate checks the actual command content. Counter file persists across context resets.
+- [x] T360: **Anti-circumvention patterns** — Both commit-counter-gate and spec-before-code-gate detect file-modifying Bash patterns: sed -i, awk -i, echo >, cat >, tee, python open write, printf >, cp, mv (PR #296)
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog

--- a/modules/PreToolUse/commit-counter-gate.js
+++ b/modules/PreToolUse/commit-counter-gate.js
@@ -1,0 +1,103 @@
+// WORKFLOW: shtd
+// WHY: Claude makes 20+ file changes without committing, then context resets
+// and all work is lost or untraceable. User tracks progress via GitHub Mobile.
+// Every 5 edits, force a commit so there's a git trail.
+"use strict";
+var fs = require("fs");
+var path = require("path");
+var cp = require("child_process");
+var os = require("os");
+
+var COUNTER_FILE = path.join(os.homedir(), ".claude", "hooks", ".uncommitted-edit-count");
+var MAX_EDITS = 5;
+
+// Patterns indicating file-modifying Bash commands (T360)
+var FILE_MODIFY_PATTERNS = [
+  /\bsed\s+-i/,
+  /\bawk\s+-i/,
+  /\becho\s+.*>/,
+  /\bcat\s+.*>/,
+  /\btee\s/,
+  /\bpython[23]?\s+.*open\s*\(.*['"]\s*w/,
+  /\bprintf\s+.*>/,
+  /\bcp\s+/,
+  /\bmv\s+/
+];
+
+function readCounter() {
+  try {
+    var data = JSON.parse(fs.readFileSync(COUNTER_FILE, "utf-8"));
+    return data.count || 0;
+  } catch(e) { return 0; }
+}
+
+function writeCounter(count) {
+  try {
+    fs.writeFileSync(COUNTER_FILE, JSON.stringify({ count: count, ts: new Date().toISOString() }));
+  } catch(e) {}
+}
+
+function getGitDiffCount() {
+  try {
+    var out = cp.execFileSync("git", ["diff", "--stat"], {
+      encoding: "utf-8", timeout: 5000, windowsHide: true
+    }).trim();
+    if (!out) return 0;
+    var lines = out.split("\n");
+    // Last line is summary like "3 files changed, ..."
+    var summary = lines[lines.length - 1];
+    var match = summary.match(/(\d+)\s+file/);
+    return match ? parseInt(match[1], 10) : 0;
+  } catch(e) { return 0; }
+}
+
+module.exports = function(input) {
+  var cmd = "";
+  if (input.tool_name === "Bash") {
+    try {
+      cmd = (typeof input.tool_input === "string" ? JSON.parse(input.tool_input) : input.tool_input || {}).command || "";
+    } catch(e) { cmd = (input.tool_input || {}).command || ""; }
+  }
+
+  // Reset counter on git commit
+  if (input.tool_name === "Bash" && /git\s+commit/.test(cmd)) {
+    writeCounter(0);
+    return null;
+  }
+
+  // Increment counter on file modifications
+  var isFileModify = false;
+  if (input.tool_name === "Edit" || input.tool_name === "Write") {
+    isFileModify = true;
+  } else if (input.tool_name === "Bash") {
+    for (var i = 0; i < FILE_MODIFY_PATTERNS.length; i++) {
+      if (FILE_MODIFY_PATTERNS[i].test(cmd)) {
+        isFileModify = true;
+        break;
+      }
+    }
+  }
+
+  if (!isFileModify) return null;
+
+  var count = readCounter() + 1;
+  writeCounter(count);
+
+  if (count >= MAX_EDITS) {
+    // Cross-check with actual git diff
+    var gitCount = getGitDiffCount();
+    if (gitCount === 0) {
+      // Counter drifted (files were reverted) — reset
+      writeCounter(0);
+      return null;
+    }
+    return {
+      decision: "block",
+      reason: "COMMIT COUNTER: " + count + " file modifications since last commit (" + gitCount + " files changed in git).\n" +
+        "Commit now with a descriptive message before continuing.\n" +
+        "Run: git add <files> && git commit -m 'describe what changed and why'"
+    };
+  }
+
+  return null;
+};

--- a/modules/PreToolUse/commit-quality-gate.js
+++ b/modules/PreToolUse/commit-quality-gate.js
@@ -1,0 +1,61 @@
+// WORKFLOW: shtd
+// WHY: Generic commit messages like "fix" or "update" make git history useless.
+// When debugging E2E failures across 10+ deploy cycles, you need to know what
+// each commit actually changed and why. Bad messages waste 10+ minutes per cycle.
+"use strict";
+
+var GENERIC_STARTS = /^\s*(fix|update|change|modify|edit|tweak|adjust|minor|wip|tmp|temp|stuff|misc|cleanup)\b/i;
+var MIN_WORDS = 5;
+
+module.exports = function(input) {
+  if (input.tool_name !== "Bash") return null;
+
+  var cmd = "";
+  try {
+    cmd = (typeof input.tool_input === "string" ? JSON.parse(input.tool_input) : input.tool_input || {}).command || "";
+  } catch(e) { cmd = (input.tool_input || {}).command || ""; }
+
+  // Only gate git commit commands
+  if (!/git\s+commit/.test(cmd)) return null;
+
+  // Skip amend (message already exists)
+  if (/--amend/.test(cmd)) return null;
+
+  // Extract commit message from -m flag
+  var msg = "";
+  // Match -m "msg", -m 'msg', or heredoc patterns
+  var mMatch = cmd.match(/\-m\s+["']([^"']+)["']/);
+  if (!mMatch) {
+    // Try heredoc: -m "$(cat <<'EOF'\nmsg\nEOF\n)"
+    var heredocMatch = cmd.match(/\-m\s+"\$\(cat\s+<<'?EOF'?\s*\n([\s\S]*?)\nEOF/);
+    if (heredocMatch) msg = heredocMatch[1].trim();
+  } else {
+    msg = mMatch[1].trim();
+  }
+
+  if (!msg) return null; // Can't parse message — don't block (might be interactive)
+
+  // Check word count
+  var words = msg.split(/\s+/).filter(function(w) { return w.length > 0; });
+  if (words.length < MIN_WORDS) {
+    return {
+      decision: "block",
+      reason: "COMMIT MESSAGE TOO SHORT: " + words.length + " words (min " + MIN_WORDS + ").\n" +
+        "Your message: \"" + msg + "\"\n" +
+        "Good format: \"Fix <what> — <why>\" or \"Add <feature> for <purpose>\"\n" +
+        "Example: \"Fix F5 marketplace import — winpath() needed when MSYS_NO_PATHCONV=1\""
+    };
+  }
+
+  // Check for generic starts without specifics
+  if (GENERIC_STARTS.test(msg) && words.length < 8) {
+    return {
+      decision: "block",
+      reason: "COMMIT MESSAGE TOO GENERIC: starts with '" + words[0] + "' without enough detail.\n" +
+        "Your message: \"" + msg + "\"\n" +
+        "Say WHAT changed and WHY. Example: \"Fix spec-gate cache — stale hasUnchecked when tasks.md edited\""
+    };
+  }
+
+  return null;
+};

--- a/modules/PreToolUse/deploy-gate.js
+++ b/modules/PreToolUse/deploy-gate.js
@@ -1,0 +1,63 @@
+// WORKFLOW: shtd
+// WHY: E2E deploy cycles take 10+ minutes. When deployed from a dirty tree,
+// results can't be traced to a specific commit SHA. Wasted debugging time
+// when you can't reproduce what was actually deployed.
+"use strict";
+var cp = require("child_process");
+
+// Commands that deploy or run code on remote infrastructure
+var DEPLOY_PATTERNS = [
+  /upload-and-run/,
+  /quick-sync/,
+  /create-zip/,
+  /terraform\s+apply/,
+  /az\s+vm\s+run-command\s+create/,
+  /aws\s+(?:s3\s+cp|lambda\s+update|ecs\s+update|deploy)/,
+  /kubectl\s+apply/,
+  /docker\s+push/,
+  /scp\s+.*:/,
+  /rsync\s+.*:/
+];
+
+module.exports = function(input) {
+  if (input.tool_name !== "Bash") return null;
+
+  var cmd = "";
+  try {
+    cmd = (typeof input.tool_input === "string" ? JSON.parse(input.tool_input) : input.tool_input || {}).command || "";
+  } catch(e) { cmd = (input.tool_input || {}).command || ""; }
+
+  // Check if command matches any deploy pattern
+  var matched = false;
+  for (var i = 0; i < DEPLOY_PATTERNS.length; i++) {
+    if (DEPLOY_PATTERNS[i].test(cmd)) {
+      matched = true;
+      break;
+    }
+  }
+  if (!matched) return null;
+
+  // Check git status for uncommitted changes
+  var status = "";
+  try {
+    status = cp.execFileSync("git", ["status", "--porcelain"], {
+      encoding: "utf-8", timeout: 5000, windowsHide: true
+    }).trim();
+  } catch(e) {
+    // Not a git repo or git not available — allow
+    return null;
+  }
+
+  if (!status) return null; // Clean tree — allow deploy
+
+  // Count changed files
+  var changedFiles = status.split("\n").length;
+  return {
+    decision: "block",
+    reason: "DEPLOY GATE: " + changedFiles + " uncommitted change(s) detected. " +
+      "Commit before deploying so results are tied to a known git SHA.\n" +
+      "Run: git add <files> && git commit -m 'describe what changed and why'\n" +
+      "Changed files:\n" + status.split("\n").slice(0, 10).join("\n") +
+      (changedFiles > 10 ? "\n... and " + (changedFiles - 10) + " more" : "")
+  };
+};

--- a/modules/PreToolUse/deploy-history-reminder.js
+++ b/modules/PreToolUse/deploy-history-reminder.js
@@ -1,0 +1,47 @@
+// WORKFLOW: shtd
+// WHY: Claude repeats failed deploy approaches because it doesn't check git
+// history first. Each E2E cycle is 10+ minutes. Checking recent commits takes
+// 2 seconds and prevents wasting 30+ minutes on already-tried approaches.
+"use strict";
+var cp = require("child_process");
+
+var DEPLOY_PATTERNS = [
+  /upload-and-run/,
+  /quick-sync/,
+  /create-zip/,
+  /terraform\s+apply/,
+  /az\s+vm\s+run-command\s+create/
+];
+
+module.exports = function(input) {
+  if (input.tool_name !== "Bash") return null;
+
+  var cmd = "";
+  try {
+    cmd = (typeof input.tool_input === "string" ? JSON.parse(input.tool_input) : input.tool_input || {}).command || "";
+  } catch(e) { cmd = (input.tool_input || {}).command || ""; }
+
+  var matched = false;
+  for (var i = 0; i < DEPLOY_PATTERNS.length; i++) {
+    if (DEPLOY_PATTERNS[i].test(cmd)) { matched = true; break; }
+  }
+  if (!matched) return null;
+
+  // Non-blocking — just log recent history as advisory
+  var history = "";
+  try {
+    history = cp.execFileSync("git", ["log", "--oneline", "-5"], {
+      encoding: "utf-8", timeout: 5000, windowsHide: true
+    }).trim();
+  } catch(e) {
+    return null;
+  }
+
+  if (!history) return null;
+
+  // Return as text advisory (non-blocking)
+  return {
+    text: "DEPLOY REMINDER: Recent commits before this run:\n" + history +
+      "\nVerify you're not repeating a failed approach."
+  };
+};

--- a/modules/PreToolUse/spec-before-code-gate.js
+++ b/modules/PreToolUse/spec-before-code-gate.js
@@ -1,0 +1,110 @@
+// WORKFLOW: shtd
+// WHY: Claude dives into coding without documenting what it's fixing or why.
+// After context resets, there's no trail of intent. Forces a spec (TODO entry
+// or recent commit message) before the first file modification.
+"use strict";
+var fs = require("fs");
+var path = require("path");
+var cp = require("child_process");
+var os = require("os");
+
+var STATE_FILE = path.join(os.homedir(), ".claude", "hooks", ".spec-before-code-state");
+
+// File-modifying Bash patterns (shared with commit-counter-gate)
+var FILE_MODIFY_PATTERNS = [
+  /\bsed\s+-i/,
+  /\bawk\s+-i/,
+  /\becho\s+.*>/,
+  /\bcat\s+.*>/,
+  /\btee\s/,
+  /\bpython[23]?\s+.*open\s*\(.*['"]\s*w/,
+  /\bprintf\s+.*>/
+];
+
+function readState() {
+  try {
+    return JSON.parse(fs.readFileSync(STATE_FILE, "utf-8"));
+  } catch(e) { return { lastCommitTs: 0, specChecked: false }; }
+}
+
+function writeState(state) {
+  try {
+    fs.writeFileSync(STATE_FILE, JSON.stringify(state));
+  } catch(e) {}
+}
+
+function hasRecentSpec() {
+  var projectDir = process.env.CLAUDE_PROJECT_DIR || "";
+  if (!projectDir) return true; // Can't check — don't block
+
+  // Check TODO.md for recent entries with task markers
+  var todoPath = path.join(projectDir, "TODO.md");
+  try {
+    if (fs.existsSync(todoPath)) {
+      var content = fs.readFileSync(todoPath, "utf-8");
+      // Has unchecked tasks = spec exists
+      if (/^- \[ \] T\d+:/m.test(content)) return true;
+    }
+  } catch(e) {}
+
+  // Check recent commit message (within 5 min) with sufficient detail
+  try {
+    var log = cp.execFileSync("git", ["log", "--oneline", "-1", "--format=%s", "--since=5.minutes.ago"], {
+      encoding: "utf-8", timeout: 5000, windowsHide: true
+    }).trim();
+    if (log && log.split(/\s+/).length > 4) return true;
+  } catch(e) {}
+
+  return false;
+}
+
+module.exports = function(input) {
+  var cmd = "";
+  if (input.tool_name === "Bash") {
+    try {
+      cmd = (typeof input.tool_input === "string" ? JSON.parse(input.tool_input) : input.tool_input || {}).command || "";
+    } catch(e) { cmd = (input.tool_input || {}).command || ""; }
+  }
+
+  // Reset state on git commit
+  if (input.tool_name === "Bash" && /git\s+commit/.test(cmd)) {
+    writeState({ lastCommitTs: Date.now(), specChecked: false });
+    return null;
+  }
+
+  // Only check on file modifications
+  var isFileModify = false;
+  if (input.tool_name === "Edit" || input.tool_name === "Write") {
+    isFileModify = true;
+  } else if (input.tool_name === "Bash") {
+    for (var i = 0; i < FILE_MODIFY_PATTERNS.length; i++) {
+      if (FILE_MODIFY_PATTERNS[i].test(cmd)) {
+        isFileModify = true;
+        break;
+      }
+    }
+  }
+  if (!isFileModify) return null;
+
+  var state = readState();
+
+  // Already checked spec this commit cycle — don't nag
+  if (state.specChecked) return null;
+
+  // First file modification since last commit — check for spec
+  if (hasRecentSpec()) {
+    state.specChecked = true;
+    writeState(state);
+    return null;
+  }
+
+  // No spec found — block
+  return {
+    decision: "block",
+    reason: "SPEC-BEFORE-CODE: No spec found for this change.\n" +
+      "Before coding, document what you're doing:\n" +
+      "  Option A: Add a task to TODO.md: '- [ ] T###: Fix <what> — <why>'\n" +
+      "  Option B: The previous commit message (within 5 min) describes the work\n" +
+      "Write the spec first, then make your changes."
+  };
+};


### PR DESCRIPTION
## Summary
5 new PreToolUse modules enforcing commit discipline:
- **deploy-gate**: Blocks deploy commands on dirty git tree
- **commit-quality-gate**: Blocks short/generic commit messages (<5 words or starts with fix/update)
- **deploy-history-reminder**: Advisory showing last 5 commits before deploy (non-blocking)
- **commit-counter-gate**: Blocks after 5 file modifications without commit, cross-checks git diff
- **spec-before-code-gate**: Blocks first edit without TODO task or recent descriptive commit

All include anti-circumvention patterns for file-modifying Bash (T360).

## Test plan
- [x] All 5 modules load and return null for non-matching input
- [x] deploy-gate blocks on dirty tree
- [x] commit-quality-gate blocks short messages, allows good ones
- [x] Batch module test: 94/94 pass (was 89)