### PR TITLE
T363: Fix silent advisory discard in deploy-history-reminder and runners

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -966,10 +966,11 @@ What was done this session:
 
 Remaining:
 - shtd.yml update not yet committed (minor — just module count)
-- 0 pending tasks
 - 94 modules across 5 workflows, health 110/0/0
-- Step 3 (code review/optimize) partially done — ES5 clean, workflow audit clean
-- Step 4 (zoom out) not started — project is mature, consider: npm publish, team demo, documentation refresh
+
+## Code Review Fix
+
+- [ ] T363: Fix deploy-history-reminder silent discard — module returned `{text: "..."}` which PreToolUse runner ignores (only checks `result.decision`). Advisory was never shown. Fix: write to stderr + return null. Also aligned DEPLOY_PATTERNS with deploy-gate (5→10 patterns). (PR #299)
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog

--- a/modules/PreToolUse/deploy-history-reminder.js
+++ b/modules/PreToolUse/deploy-history-reminder.js
@@ -10,7 +10,12 @@ var DEPLOY_PATTERNS = [
   /quick-sync/,
   /create-zip/,
   /terraform\s+apply/,
-  /az\s+vm\s+run-command\s+create/
+  /az\s+vm\s+run-command\s+create/,
+  /aws\s+(?:s3\s+cp|lambda\s+update|ecs\s+update|deploy)/,
+  /kubectl\s+apply/,
+  /docker\s+push/,
+  /scp\s+.*:/,
+  /rsync\s+.*:/
 ];
 
 module.exports = function(input) {
@@ -39,9 +44,8 @@ module.exports = function(input) {
 
   if (!history) return null;
 
-  // Return as text advisory (non-blocking)
-  return {
-    text: "DEPLOY REMINDER: Recent commits before this run:\n" + history +
-      "\nVerify you're not repeating a failed approach."
-  };
+  // Advisory — write to stderr (visible in hook log) and return null (non-blocking)
+  process.stderr.write("DEPLOY REMINDER: Recent commits before this run:\n" + history +
+    "\nVerify you're not repeating a failed approach.\n");
+  return null;
 };

--- a/run-posttooluse.js
+++ b/run-posttooluse.js
@@ -46,6 +46,9 @@ runAsync.runModules(modules, input,
       if (!firstResult) firstResult = result;
       return false; // T378: continue running remaining modules
     }
+    if (result && result.text) {
+      process.stderr.write(result.text + "\n");
+    }
     hookLog.logHook("PostToolUse", modName, "pass", Object.assign({}, ctx, { ms: ms }));
     return false;
   },

--- a/run-stop-bg.js
+++ b/run-stop-bg.js
@@ -48,6 +48,9 @@ runAsync.runModules(modules, input,
     if (result && result.decision === "block") {
       hookLog.logHook("Stop", modName, "block", Object.assign({}, ctx, { reason: result.reason, ms: ms }));
     } else {
+      if (result && result.text) {
+        process.stderr.write(result.text + "\n");
+      }
       hookLog.logHook("Stop", modName, "pass", Object.assign({}, ctx, { ms: ms }));
     }
     return false;


### PR DESCRIPTION
## Summary
- deploy-history-reminder returned {text: '...'} but PreToolUse runner only checks result.decision — advisory was silently discarded. Fixed to write to stderr + return null.
- Aligned DEPLOY_PATTERNS with deploy-gate (5 to 10 patterns).
- Added {text} advisory handling to run-stop-bg.js and run-posttooluse.js so advisory modules (config-sync, drift-review, hook-health-monitor) are visible in logs.

## Test plan
- [x] Batch module test: 94/94 pass
- [x] Manual test: terraform apply triggers stderr advisory
- [x] Health check: 110/0/0