### PR TITLE
T364: Fix commit-quality-gate heredoc parsing order

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -970,7 +970,9 @@ Remaining:
 
 ## Code Review Fix
 
-- [ ] T363: Fix deploy-history-reminder silent discard — module returned `{text: "..."}` which PreToolUse runner ignores (only checks `result.decision`). Advisory was never shown. Fix: write to stderr + return null. Also aligned DEPLOY_PATTERNS with deploy-gate (5→10 patterns). (PR #299)
+- [x] T363: Fix deploy-history-reminder silent discard — module returned `{text: "..."}` which PreToolUse runner ignores (only checks `result.decision`). Advisory was never shown. Fix: write to stderr + return null. Also aligned DEPLOY_PATTERNS with deploy-gate (5→10 patterns). Added {text} handling to run-stop-bg.js and run-posttooluse.js. (PR #299)
+
+- [ ] T364: Fix commit-quality-gate heredoc parsing — simple `-m "msg"` regex matched before heredoc, extracting `$(cat <<` as the message. Fix: try heredoc pattern first. (PR #300)
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog

--- a/modules/PreToolUse/commit-quality-gate.js
+++ b/modules/PreToolUse/commit-quality-gate.js
@@ -23,14 +23,15 @@ module.exports = function(input) {
 
   // Extract commit message from -m flag
   var msg = "";
-  // Match -m "msg", -m 'msg', or heredoc patterns
-  var mMatch = cmd.match(/\-m\s+["']([^"']+)["']/);
-  if (!mMatch) {
-    // Try heredoc: -m "$(cat <<'EOF'\nmsg\nEOF\n)"
-    var heredocMatch = cmd.match(/\-m\s+"\$\(cat\s+<<'?EOF'?\s*\n([\s\S]*?)\nEOF/);
-    if (heredocMatch) msg = heredocMatch[1].trim();
+  // Try heredoc first: -m "$(cat <<'EOF'\nmsg\nEOF\n)"
+  // Must check before simple -m "msg" because the outer quotes confuse the simple regex
+  var heredocMatch = cmd.match(/\-m\s+"\$\(cat\s+<<'?EOF'?\s*\n([\s\S]*?)\nEOF/);
+  if (heredocMatch) {
+    msg = heredocMatch[1].trim();
   } else {
-    msg = mMatch[1].trim();
+    // Simple -m "msg" or -m 'msg'
+    var mMatch = cmd.match(/\-m\s+["']([^"']+)["']/);
+    if (mMatch) msg = mMatch[1].trim();
   }
 
   if (!msg) return null; // Can't parse message — don't block (might be interactive)


### PR DESCRIPTION
## Summary
- Simple `-m "msg"` regex matched before heredoc pattern, extracting `$(cat <<` as the commit message and blocking with 'TOO SHORT: 2 words'
- Fix: try heredoc pattern first, fall back to simple pattern

## Test plan
- [x] Heredoc commit message: passes (null)
- [x] Short message: blocks correctly
- [x] Good simple message: passes (null)