### PR TITLE
T365: Version bump to 2.23.1 + CHANGELOG for T363-T364

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.23.1] — 2026-04-11
+
+### Fixed
+- **deploy-history-reminder silent discard** (T363) — Module returned `{text: "..."}` but PreToolUse runner only checks `result.decision`. Advisory was never shown. Writes to stderr now. DEPLOY_PATTERNS aligned with deploy-gate (5→10).
+- **Runner {text} advisory handling** (T363) — Added `{text}` output to run-stop-bg.js and run-posttooluse.js so advisory modules (config-sync, drift-review, hook-health-monitor) are visible.
+- **commit-quality-gate heredoc parsing** (T364) — Simple `-m "msg"` regex matched before heredoc pattern, extracting `$(cat <<` as the message. Fixed by checking heredoc first.
+
 ## [2.23.0] — 2026-04-11
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -972,7 +972,9 @@ Remaining:
 
 - [x] T363: Fix deploy-history-reminder silent discard — module returned `{text: "..."}` which PreToolUse runner ignores (only checks `result.decision`). Advisory was never shown. Fix: write to stderr + return null. Also aligned DEPLOY_PATTERNS with deploy-gate (5→10 patterns). Added {text} handling to run-stop-bg.js and run-posttooluse.js. (PR #299)
 
-- [ ] T364: Fix commit-quality-gate heredoc parsing — simple `-m "msg"` regex matched before heredoc, extracting `$(cat <<` as the message. Fix: try heredoc pattern first. (PR #300)
+- [x] T364: Fix commit-quality-gate heredoc parsing — simple `-m "msg"` regex matched before heredoc, extracting `$(cat <<` as the message. Fix: try heredoc pattern first. (PR #300)
+
+- [x] T365: Version bump to 2.23.1 + CHANGELOG for T363-T364 (PR #301)
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.23.0",
+  "version": "2.23.1",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
Patch release for code review fixes: advisory text silent discard + heredoc parsing.