### PR TITLE
T366: Replace execSync with execFileSync in 5 modules

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -976,6 +976,8 @@ Remaining:
 
 - [x] T365: Version bump to 2.23.1 + CHANGELOG for T363-T364 (PR #301)
 
+- [ ] T366: Replace execSync with execFileSync in 5 modules — eliminates shell interpretation for git/gh commands. Defense-in-depth: push-unpushed, pr-first-gate, drift-review, config-sync, hook-autocommit. (PR #302)
+
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog
 - `modules/` has all available modules organized by event type

--- a/modules/PostToolUse/hook-autocommit.js
+++ b/modules/PostToolUse/hook-autocommit.js
@@ -21,10 +21,8 @@ module.exports = function(input) {
   // Auto-commit the change
   try {
     var fileName = filePath.split("/run-modules/")[1] || path.basename(filePath);
-    child_process.execSync(
-      'git add -A && git commit -m "auto: update ' + fileName.replace(/"/g, '\\"') + '"',
-      { cwd: MODULES_DIR, stdio: "ignore", timeout: 5000, windowsHide: true }
-    );
+    child_process.execFileSync("git", ["add", "-A"], { cwd: MODULES_DIR, stdio: "ignore", timeout: 5000, windowsHide: true });
+    child_process.execFileSync("git", ["commit", "-m", "auto: update " + fileName], { cwd: MODULES_DIR, stdio: "ignore", timeout: 5000, windowsHide: true });
   } catch (e) {
     // No changes or git error — silent
   }

--- a/modules/PreToolUse/pr-first-gate.js
+++ b/modules/PreToolUse/pr-first-gate.js
@@ -72,9 +72,8 @@ module.exports = function(input) {
   }
   if (cached === undefined) {
     try {
-      var result = cp.execSync(
-        "gh_auto pr list --head " + branch + " --state open --json number --limit 1",
-        { cwd: process.cwd(), encoding: "utf-8", timeout: 5000, windowsHide: true }
+      var result = cp.execFileSync("gh_auto", ["pr", "list", "--head", branch, "--state", "open", "--json", "number", "--limit", "1"],
+        { cwd: process.cwd(), encoding: "utf-8", timeout: 5000, windowsHide: true, stdio: ["pipe", "pipe", "pipe"] }
       ).trim();
       var prs = JSON.parse(result || "[]");
       var hasPR = prs.length > 0;

--- a/modules/Stop/config-sync.js
+++ b/modules/Stop/config-sync.js
@@ -76,7 +76,7 @@ module.exports = function(input) {
     if (defaultUser && !safeUser.test(defaultUser)) defaultUser = "";
 
     if (configUser) {
-      cp.execSync("gh auth switch --user " + configUser + " 2>&1", {
+      cp.execFileSync("gh", ["auth", "switch", "--user", configUser], {
         encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"], timeout: 5000, windowsHide: true
       });
     }
@@ -91,14 +91,14 @@ module.exports = function(input) {
     if (!/^[a-zA-Z0-9._\-\/]+$/.test(branch)) branch = "main";
 
     try {
-      cp.execSync("git push origin " + branch + " 2>&1", {
+      cp.execFileSync("git", ["push", "origin", branch], {
         cwd: claudeDir, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"],
         timeout: 15000, windowsHide: true
       });
     } finally {
       if (defaultUser) {
         try {
-          cp.execSync("gh auth switch --user " + defaultUser + " 2>&1", {
+          cp.execFileSync("gh", ["auth", "switch", "--user", defaultUser], {
             encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"], timeout: 5000, windowsHide: true
           });
         } catch (e2) { /* ignore */ }

--- a/modules/Stop/drift-review.js
+++ b/modules/Stop/drift-review.js
@@ -73,15 +73,15 @@ module.exports = function(input) {
   // Get recent uncommitted changes
   var diff = "";
   try {
-    diff = cp.execSync("git diff --stat HEAD 2>/dev/null || true", {
-      cwd: projectDir, encoding: "utf8", timeout: 5000, windowsHide: true
+    diff = cp.execFileSync("git", ["diff", "--stat", "HEAD"], {
+      cwd: projectDir, encoding: "utf8", timeout: 5000, windowsHide: true, stdio: ["pipe", "pipe", "pipe"]
     }).trim();
   } catch (e) {}
 
   var uncommitted = "";
   try {
-    uncommitted = cp.execSync("git status --porcelain 2>/dev/null || true", {
-      cwd: projectDir, encoding: "utf8", timeout: 5000, windowsHide: true
+    uncommitted = cp.execFileSync("git", ["status", "--porcelain"], {
+      cwd: projectDir, encoding: "utf8", timeout: 5000, windowsHide: true, stdio: ["pipe", "pipe", "pipe"]
     }).trim();
   } catch (e) {}
 

--- a/modules/Stop/push-unpushed.js
+++ b/modules/Stop/push-unpushed.js
@@ -23,7 +23,7 @@ module.exports = function(input) {
       };
     }
 
-    var unpushed = cp.execSync("git log " + remote + "/" + branch + "..HEAD --oneline 2>/dev/null", { cwd: process.cwd(), encoding: "utf-8", windowsHide: true }).trim();
+    var unpushed = cp.execFileSync("git", ["log", remote + "/" + branch + "..HEAD", "--oneline"], { cwd: process.cwd(), encoding: "utf-8", windowsHide: true, stdio: ["pipe", "pipe", "pipe"] }).trim();
     if (unpushed) {
       var count = unpushed.split("\n").length;
       return {


### PR DESCRIPTION
Defense-in-depth: convert string-interpolated execSync calls to execFileSync with args arrays. Eliminates shell interpretation. Modules: push-unpushed, pr-first-gate, drift-review, config-sync, hook-autocommit. 94/94 modules pass.