### PR TITLE
T366b: Convert remaining execSync to execFileSync

### DIFF
--- a/modules/SessionStart/_is-pid-running.js
+++ b/modules/SessionStart/_is-pid-running.js
@@ -8,7 +8,7 @@ module.exports = function isPidRunning(pid) {
   if (isNaN(pid) || pid <= 0 || pid !== Math.floor(pid)) return false;
   try {
     if (process.platform === "win32") {
-      var out = cp.execSync("tasklist /FI \"PID eq " + pid + "\" /NH", {
+      var out = cp.execFileSync("tasklist", ["/FI", "PID eq " + pid, "/NH"], {
         encoding: "utf-8",
         timeout: 3000,
         stdio: ["pipe", "pipe", "pipe"],

--- a/modules/Stop/config-sync.js
+++ b/modules/Stop/config-sync.js
@@ -111,7 +111,7 @@ module.exports = function(input) {
   } catch (e) {
     if (defaultUser) {
       try {
-        cp.execSync("gh auth switch --user " + defaultUser + " 2>&1", {
+        cp.execFileSync("gh", ["auth", "switch", "--user", defaultUser], {
           encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"], timeout: 5000, windowsHide: true
         });
       } catch (e2) { /* ignore */ }


### PR DESCRIPTION
Follow-up to T366. Converts 2 remaining execSync calls: config-sync catch block (gh auth switch) and _is-pid-running (tasklist). Only claude -p calls remain (need shell for stdin piping, no interpolation).