### PR TITLE
T367: Version bump to 2.23.2 + CHANGELOG for T366 security hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.23.2] — 2026-04-11
+
+### Security
+- **execSync→execFileSync** (T366, T366b) — Converted all shell-interpolated `execSync` calls to `execFileSync` with args arrays across 7 modules (push-unpushed, pr-first-gate, drift-review, config-sync, hook-autocommit, _is-pid-running). Eliminates shell interpretation as defense-in-depth. Only `claude -p` calls remain (need shell for stdin piping, no interpolation).
+
 ## [2.23.1] — 2026-04-11
 
 ### Fixed

--- a/TODO.md
+++ b/TODO.md
@@ -976,7 +976,9 @@ Remaining:
 
 - [x] T365: Version bump to 2.23.1 + CHANGELOG for T363-T364 (PR #301)
 
-- [ ] T366: Replace execSync with execFileSync in 5 modules — eliminates shell interpretation for git/gh commands. Defense-in-depth: push-unpushed, pr-first-gate, drift-review, config-sync, hook-autocommit. (PR #302)
+- [x] T366: Replace execSync with execFileSync in 7 modules — eliminates shell interpretation for git/gh commands. Defense-in-depth: push-unpushed, pr-first-gate, drift-review, config-sync, hook-autocommit, _is-pid-running. (PR #302, #303)
+
+- [ ] T367: Version bump to 2.23.2 + CHANGELOG for T366 security hardening + marketplace sync (PR #304)
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.23.1",
+  "version": "2.23.2",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
Patch release for execSync→execFileSync security hardening across 7 modules.