### PR TITLE
T369: Add 5 missing modules to README catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ node setup.js --workflow query Edit        # which workflows affect Edit?
 
 | Workflow | Modules | What it enforces |
 |----------|---------|-----------------|
-| `shtd` | 69 | Spec-Hook-Test-Driven — the full development pipeline. Enforces spec → branch → test → implement → PR, plus code quality, infrastructure safety, messaging guards, session lifecycle, and self-improvement. |
+| `shtd` | 83 | Spec-Hook-Test-Driven — the full development pipeline. Enforces spec → branch → test → implement → PR, plus code quality, infrastructure safety, messaging guards, session lifecycle, and self-improvement. |
 | `customer-data-guard` | 3 | Read-only incident response — blocks env changes, data exfil, and V1 modifications. |
 | `dispatcher-worker` | 3 | Role-aware fleet workflow. Dispatcher specs/distributes, workers implement/test/PR. |
 | `no-local-docker` | 1 | Blocks local Docker commands, forces remote infrastructure. |
@@ -307,9 +307,13 @@ Full catalog in `modules/` directory:
 | `block-local-docker` | Blocks docker/docker-compose commands |
 | `branch-pr-gate` | Enforces feature branch → task branch → PR workflow |
 | `claude-p-pattern` | Enforces correct `claude -p` invocation pattern |
+| `commit-counter-gate` | Forces commit after every 5 edits — prevents losing work on context reset |
+| `commit-quality-gate` | Blocks generic commit messages (< 5 words, "fix"/"update" without detail) |
 | `continuous-claude-gate` | Blocks code without tracked task workflow |
 | `crlf-ssh-key-check` | Blocks SSH key copy without CRLF stripping |
 | `cwd-drift-detector` | Blocks cross-project file access |
+| `deploy-gate` | Blocks deploy commands when git tree is dirty |
+| `deploy-history-reminder` | Shows last 5 commits before deploy — prevents repeating failed approaches |
 | `disk-space-guard` | Blocks destructive commands after disk space errors |
 | `enforcement-gate` | Requires git repo + TODO.md before edits |
 | `env-var-check` | Blocks edits if required env vars missing |
@@ -336,6 +340,7 @@ Full catalog in `modules/` directory:
 | `secret-scan-gate` | Blocks commits with API keys or tokens |
 | `settings-change-gate` | Requires rationale when modifying config |
 | `settings-hooks-gate` | Blocks adding hooks directly to settings.json |
+| `spec-before-code-gate` | Forces spec/TODO entry before first file modification after commit |
 | `spec-gate` | Blocks code without specs/tasks.md |
 | `task-completion-gate` | Blocks marking tasks complete without PR evidence |
 | `test-checkpoint-gate` | Blocks code without e2e test (auto-detects `scripts/test/test-TXXX*.sh`) |

--- a/TODO.md
+++ b/TODO.md
@@ -1003,7 +1003,11 @@ Status:
 
 ## Cleanup
 
-- [ ] T368: Untrack run-modules/ from git — directory was in .gitignore but still tracked, causing 46+ phantom dirty files on every session. `git rm --cached -r run-modules/` removes from tracking without deleting live files.
+- [x] T368: Untrack run-modules/ from git (PR #305) — directory was in .gitignore but still tracked, causing 46+ phantom dirty files on every session. `git rm --cached -r run-modules/` removes from tracking without deleting live files.
+
+## Docs
+
+- [ ] T369: Add 5 missing modules to README catalog — commit-counter-gate, commit-quality-gate, deploy-gate, deploy-history-reminder, spec-before-code-gate. Update shtd module count from 69 to 83.
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog


### PR DESCRIPTION
## Summary
- Added commit-counter-gate, commit-quality-gate, deploy-gate, deploy-history-reminder, spec-before-code-gate to README module catalog
- Updated shtd workflow module count from 69 to 83

## Test plan
- [x] Verified module names match files in modules/PreToolUse/
- [x] Verified shtd count matches `grep -l "WORKFLOW: shtd" modules/*/*.js | wc -l`