### PR TITLE
T371: Version bump to 2.23.3 + CHANGELOG for T368-T370

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.23.3] — 2026-04-11
+
+### Fixed
+- **Untracked run-modules/ from git** (T368) — Directory was in `.gitignore` but still tracked, causing 46+ phantom dirty files every session. Removed from tracking without deleting live files.
+- **README module catalog** (T369) — Added 5 missing modules (commit-counter-gate, commit-quality-gate, deploy-gate, deploy-history-reminder, spec-before-code-gate). Updated shtd workflow count from 69 to 83.
+- **package.json files array** (T370) — Added preflight.js, generate-manifest.js, run-stop-bg.js to `files` array so they're included in npx installs.
+
 ## [2.23.2] — 2026-04-11
 
 ### Security

--- a/TODO.md
+++ b/TODO.md
@@ -1011,7 +1011,9 @@ Status:
 
 ## Packaging
 
-- [ ] T370: Add missing files to package.json — preflight.js, generate-manifest.js, run-stop-bg.js missing from `files` array, won't be included in npx installs.
+- [x] T370: Add missing files to package.json (PR #307) — preflight.js, generate-manifest.js, run-stop-bg.js missing from `files` array, won't be included in npx installs.
+
+- [ ] T371: Version bump to 2.23.3 + CHANGELOG for T368-T370 cleanup + marketplace sync
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.23.2",
+  "version": "2.23.3",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Version bump 2.23.2 → 2.23.3
- CHANGELOG for T368 (untrack run-modules), T369 (README catalog), T370 (package.json files)

## Test plan
- [x] version field updated in package.json
- [x] CHANGELOG entry added