### PR TITLE
T372: Fix test-runners.sh broken by run-modules/ untracking

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1015,6 +1015,10 @@ Status:
 
 - [x] T371: Version bump to 2.23.3 + CHANGELOG for T368-T370 cleanup + marketplace sync (PR #308)
 
+## Test Fixes
+
+- [ ] T372: Fix test-runners.sh — Tests 2 and 6 reference `run-modules/` which was untracked in T368. Point at `modules/` instead.
+
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog
 - `modules/` has all available modules organized by event type

--- a/scripts/test/test-runners.sh
+++ b/scripts/test/test-runners.sh
@@ -16,13 +16,13 @@ echo "[1] load-modules.js exports a function"
 node -e "var lm = require('$REPO_DIR/load-modules.js'); if (typeof lm !== 'function') throw new Error('not a function');" 2>/dev/null && pass "load-modules exports function" || fail "load-modules not a function"
 
 # Test 2: load-modules returns array for existing dir
-echo "[2] load-modules returns array for run-modules/PreToolUse"
-COUNT=$(node -e "var lm = require('$REPO_DIR/load-modules.js'); var r = lm('$REPO_DIR/run-modules/PreToolUse'); console.log(r.length);" 2>/dev/null)
+echo "[2] load-modules returns array for modules/PreToolUse"
+COUNT=$(node -e "var lm = require('$REPO_DIR/load-modules.js'); var r = lm('$REPO_DIR/modules/PreToolUse'); console.log(r.length);" 2>/dev/null)
 if [ "$COUNT" -gt 0 ]; then pass "found $COUNT PreToolUse modules"; else fail "no modules found"; fi
 
 # Test 3: load-modules returns empty for nonexistent dir
 echo "[3] load-modules returns empty for nonexistent dir"
-COUNT=$(node -e "var lm = require('$REPO_DIR/load-modules.js'); var r = lm('$REPO_DIR/run-modules/FakeEvent'); console.log(r.length);" 2>/dev/null)
+COUNT=$(node -e "var lm = require('$REPO_DIR/load-modules.js'); var r = lm('$REPO_DIR/modules/FakeEvent'); console.log(r.length);" 2>/dev/null)
 if [ "$COUNT" -eq 0 ]; then pass "empty for fake dir"; else fail "returned $COUNT for fake dir"; fi
 
 # Test 4: Each runner script exists and has shebang
@@ -48,7 +48,7 @@ done
 
 # Test 6: Example modules export functions
 echo "[6] Example modules export functions"
-for mod in run-modules/PreToolUse/enforcement-gate.js run-modules/Stop/auto-continue.js run-modules/PostToolUse/rule-hygiene.js; do
+for mod in modules/PreToolUse/enforcement-gate.js modules/Stop/auto-continue.js modules/PostToolUse/rule-hygiene.js; do
   if [ -f "$BASH_DIR/$mod" ]; then
     node -e "var m = require('$REPO_DIR/$mod'); if (typeof m !== 'function') throw new Error('not a function');" 2>/dev/null && pass "$mod exports function" || fail "$mod not a function"
   else


### PR DESCRIPTION
## Summary
- T368 untracked `run-modules/` from git, breaking 3 tests in test-runners.sh
- Updated Tests 2, 3, 6 to use `modules/` (the repo catalog) instead

## Test plan
- [x] `bash scripts/test/test-runners.sh` → 15/15 pass