### PR TITLE
T423: Add 5 orphan modules to catalog + retag to shtd

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ node setup.js --workflow query Edit        # which workflows affect Edit?
 
 | Workflow | Modules | What it enforces |
 |----------|---------|-----------------|
-| `shtd` | 83 | Spec-Hook-Test-Driven — the full development pipeline. Enforces spec → branch → test → implement → PR, plus code quality, infrastructure safety, messaging guards, session lifecycle, and self-improvement. |
+| `shtd` | 90 | Spec-Hook-Test-Driven — the full development pipeline. Enforces spec → branch → test → implement → PR, plus code quality, infrastructure safety, messaging guards, session lifecycle, and self-improvement. |
 | `customer-data-guard` | 3 | Read-only incident response — blocks env changes, data exfil, and V1 modifications. |
 | `dispatcher-worker` | 3 | Role-aware fleet workflow. Dispatcher specs/distributes, workers implement/test/PR. |
 | `no-local-docker` | 1 | Blocks local Docker commands, forces remote infrastructure. |
@@ -305,6 +305,7 @@ Full catalog in `modules/` directory:
 | `archive-not-delete` | Blocks file deletion, suggests archiving instead |
 | `aws-tagging-gate` | Enforces required tags on AWS resource creation |
 | `block-local-docker` | Blocks docker/docker-compose commands |
+| `blueprint-no-sleep` | Blocks sleep between Blueprint MCP calls (pages load during prompt processing) |
 | `branch-pr-gate` | Enforces feature branch → task branch → PR workflow |
 | `claude-p-pattern` | Enforces correct `claude -p` invocation pattern |
 | `commit-counter-gate` | Forces commit after every 5 edits — prevents losing work on context reset |
@@ -318,6 +319,7 @@ Full catalog in `modules/` directory:
 | `enforcement-gate` | Requires git repo + TODO.md before edits |
 | `env-var-check` | Blocks edits if required env vars missing |
 | `force-push-gate` | Blocks git push --force to main/master |
+| `gh-auto-gate` | Forces gh_auto wrapper for all gh/git push commands (EMU account safety) |
 | `git-destructive-guard` | Blocks git reset --hard, checkout ., clean -f without diagnosis |
 | `git-rebase-safety` | Warns about reversed --ours/--theirs during rebase |
 | `hook-editing-gate` | Enforces WORKFLOW tag, WHY comment, exit(1) in hook files |
@@ -329,12 +331,15 @@ Full catalog in `modules/` directory:
 | `no-fragile-heuristics` | Blocks pixel-counting heuristics |
 | `reflection-gate` | Blocks edits if self-reflection found unresolved issues |
 | `no-hardcoded-paths` | Blocks hardcoded absolute paths in code |
+| `no-hook-bypass` | Blocks Bash cat/echo writes when Write/Edit is gated |
+| `no-nested-claude` | Blocks nested claude -p calls (use context-reset for cross-project) |
 | `no-passive-rules` | Blocks .md rules when a hook module is better |
 | `no-rules-gate` | Blocks creation of ~/.claude/rules/ files (use hook modules instead) |
 | `hook-system-reminder` | Reminds Claude that enforcement is ONLY via hook-runner modules |
 | `pr-first-gate` | Blocks spec/code edits on branches without an open PR |
 | `pr-per-task-gate` | Requires task ID in PR titles |
 | `preserve-iterated-content` | Warns on full-file rewrites of iterated files |
+| `publish-json-guard` | Blocks edits to .github/publish.json and git remote config |
 | `remote-tracking-gate` | Blocks edits if branch not pushed to remote |
 | `root-cause-gate` | Blocks retry without root cause diagnosis |
 | `secret-scan-gate` | Blocks commits with API keys or tokens |

--- a/TODO.md
+++ b/TODO.md
@@ -1017,7 +1017,27 @@ Status:
 
 ## Test Fixes
 
-- [ ] T372: Fix test-runners.sh — Tests 2 and 6 reference `run-modules/` which was untracked in T368. Point at `modules/` instead.
+- [x] T372: Fix test-runners.sh (PR #310) — Tests 2 and 6 reference `run-modules/` which was untracked in T368. Point at `modules/` instead.
+
+## Session Handoff (2026-04-11d)
+What was done this session:
+- T368 (PR #305): Untracked run-modules/ from git — eliminated 46+ phantom dirty files
+- T369 (PR #306): Added 5 missing modules to README catalog, updated shtd count to 83
+- T370 (PR #307): Added 3 missing files to package.json files array
+- T371 (PR #308): Version bump to 2.23.3 + marketplace sync
+- T372 (PR #310): Fixed test-runners.sh broken by T368 run-modules/ untracking
+- Code review: all JSON.parse wrapped in try/catch, all execSync safe, no path traversal
+- Module validation: 372/372 pass (all modules load and execute)
+- gh auth on grobomo (switch back to joel-ginsberg_tmemu before push)
+
+Remaining to investigate:
+- test-T351-session-collision.sh and test-module-sync.sh failures (may be transient/slow)
+- Full test suite: 395 pass, 6 fail → after T372 fix, runners suite should now pass (was 3 of the 6)
+
+Status:
+- 0 pending tasks
+- Version: 2.23.3
+- Clean git status on main
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog

--- a/TODO.md
+++ b/TODO.md
@@ -1039,6 +1039,9 @@ Status:
 - Version: 2.23.3
 - Clean git status on main
 
+## Catalog Sync
+- [ ] T423: Add 5 orphan modules to catalog — blueprint-no-sleep, gh-auto-gate, no-hook-bypass, no-nested-claude, publish-json-guard. Retag from stale workflow names to shtd. Update shtd.yml (85→90) + README module table.
+
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog
 - `modules/` has all available modules organized by event type

--- a/modules/PreToolUse/blueprint-no-sleep.js
+++ b/modules/PreToolUse/blueprint-no-sleep.js
@@ -1,0 +1,32 @@
+// WORKFLOW: shtd
+// WHY: Claude kept adding `sleep` between Blueprint MCP calls thinking pages
+// needed time to load. Each Claude prompt takes 3-10s to process — more than
+// enough for pages to load. Sleep wastes time twice: once for the sleep, once
+// for Claude processing the sleep result.
+"use strict";
+
+module.exports = function(input) {
+  if (input.tool_name !== "Bash") return null;
+  var cmd = (input.tool_input || {}).command || "";
+
+  // Block sleep commands that appear to be between browser automation steps
+  if (!/^\s*sleep\b/.test(cmd)) return null;
+
+  // Check conversation context for recent Blueprint tool usage
+  // Since we can't access conversation history, block all bare `sleep` commands
+  // and let the user override if they really need one
+  var seconds = cmd.match(/sleep\s+(\d+)/);
+  if (!seconds) return null;
+  var dur = parseInt(seconds[1], 10);
+
+  // Only block sleeps > 1s (short sleeps may be intentional for other reasons)
+  if (dur <= 1) return null;
+
+  return {
+    decision: "block",
+    reason: "PERFORMANCE: Do not use sleep between actions.\n" +
+      "Each Claude prompt takes 3-10s to process — pages will have loaded.\n" +
+      "Just call the next action directly. Sleep wastes time twice.\n" +
+      "If you truly need a delay, use sleep 1 (max 1 second)."
+  };
+};

--- a/modules/PreToolUse/gh-auto-gate.js
+++ b/modules/PreToolUse/gh-auto-gate.js
@@ -1,0 +1,44 @@
+// WORKFLOW: shtd
+// WHY: `gh auth switch` is broken with EMU accounts — the API still uses the EMU token
+// even after switching. Raw `gh` and `git push` commands silently use the wrong account,
+// causing 403s or pushing to the wrong org. gh_auto reads .github/publish.json and sets
+// GH_TOKEN correctly every time. Tagged security (never disable) instead of shtd.
+"use strict";
+
+module.exports = function(input) {
+  if (input.tool_name !== "Bash") return null;
+  var cmd = (input.tool_input && input.tool_input.command) || "";
+
+  // Only check commands that interact with GitHub
+  var isGhCmd = /^\s*gh\s/.test(cmd);
+  var isGitPush = /\bgit\s+push\b/.test(cmd);
+  var isGitFetch = /\bgit\s+fetch\b/.test(cmd);
+  var isGitPull = /\bgit\s+pull\b/.test(cmd);
+  var isGitLsRemote = /\bgit\s+ls-remote\b/.test(cmd);
+
+  if (!isGhCmd && !isGitPush && !isGitFetch && !isGitPull && !isGitLsRemote) return null;
+
+  // Allow if GH_TOKEN is explicitly set in the command
+  if (/GH_TOKEN=/.test(cmd)) return null;
+
+  // Allow if using gh_auto script
+  if (/gh_auto/.test(cmd)) return null;
+
+  // Allow gh auth commands (needed to get tokens)
+  if (/^\s*gh\s+auth\b/.test(cmd)) return null;
+
+  // Allow gh api user (diagnostic)
+  if (/^\s*gh\s+api\s+user\b/.test(cmd)) return null;
+
+  // Block everything else
+  var suggestion = isGhCmd
+    ? cmd.replace(/^\s*gh\s+/, "gh_auto ")
+    : cmd.replace(/\bgit\s+(push|pull|fetch|ls-remote)\b/, "gh_auto $1");
+
+  return {
+    decision: "block",
+    reason: "[gh-auto-gate] Raw gh/git remote commands use the wrong account with EMU.\n" +
+      "Use gh_auto (reads .github/publish.json) or set GH_TOKEN explicitly.\n\n" +
+      "Suggested fix:\n  " + suggestion
+  };
+};

--- a/modules/PreToolUse/no-hook-bypass.js
+++ b/modules/PreToolUse/no-hook-bypass.js
@@ -1,0 +1,131 @@
+// WORKFLOW: shtd
+// WHY: Claude circumvented a PreToolUse gate by using Bash (cat >, echo >) instead
+// of the blocked Write/Edit tool. This defeats the entire hook enforcement system.
+// If a gate blocks Write/Edit, Bash must not be used as a backdoor to write the same file.
+//
+// Detection: When a Bash command writes to a file (cat >, echo >, tee, printf >),
+// check if any PreToolUse gate would have blocked the equivalent Write/Edit.
+// Also detects Claude explicitly saying "bypass" or "work around" a hook in its reasoning.
+"use strict";
+var fs = require("fs");
+var path = require("path");
+var os = require("os");
+
+var FLAG_FILE = path.join(os.tmpdir(), ".claude-instruction-pending");
+
+// Patterns that indicate Bash is being used to write files
+var WRITE_PATTERNS = [
+  /\bcat\s*>\s*/,
+  /\bcat\s*>>\s*/,
+  /\becho\s.*>\s*/,
+  /\bprintf\s.*>\s*/,
+  /\btee\s+/,
+  /\bcat\s*<<.*>\s*/,       // heredoc redirect
+  /\bcat\s*<<'?\w+'?\s*>/,  // heredoc with quote
+];
+
+// Extract the target file path from a write command
+function extractTargetPath(cmd) {
+  // Match: cat > "path" or cat > path or echo "x" > path or tee path
+  var m = cmd.match(/>\s*"([^"]+)"/);
+  if (m) return m[1];
+  m = cmd.match(/>\s*'([^']+)'/);
+  if (m) return m[1];
+  m = cmd.match(/>\s*(\S+)/);
+  if (m) return m[1];
+  m = cmd.match(/\btee\s+"([^"]+)"/);
+  if (m) return m[1];
+  m = cmd.match(/\btee\s+(\S+)/);
+  if (m) return m[1];
+  return null;
+}
+
+// Paths that hook gates protect (same as instruction-to-hook-gate checks)
+var HOOK_RULE_PATHS = [
+  /run-modules[/\\]/,
+  /\.claude[/\\]rules[/\\]/,
+  /\.claude[/\\]hooks[/\\]/,
+  /settings\.json$/,
+  /settings\.local\.json$/,
+  /CLAUDE\.md$/,
+  /specs[/\\]/,
+];
+
+module.exports = function(input) {
+  if (input.tool_name !== "Bash") return null;
+
+  var cmd = "";
+  try {
+    var ti = typeof input.tool_input === "string" ? JSON.parse(input.tool_input) : input.tool_input || {};
+    cmd = ti.command || "";
+  } catch(e) {
+    return null;
+  }
+  if (!cmd) return null;
+
+  // Check if this Bash command writes to a file
+  var isWriteCmd = false;
+  for (var i = 0; i < WRITE_PATTERNS.length; i++) {
+    if (WRITE_PATTERNS[i].test(cmd)) {
+      isWriteCmd = true;
+      break;
+    }
+  }
+  if (!isWriteCmd) return null;
+
+  // Check if instruction-to-hook flag is active
+  // If so, this Bash write is bypassing the instruction-to-hook gate
+  var flagActive = false;
+  try {
+    var flagData = fs.readFileSync(FLAG_FILE, "utf-8");
+    if (flagData) flagActive = true;
+  } catch(e) {}
+
+  if (flagActive) {
+    var targetPath = extractTargetPath(cmd);
+    // Allow if writing to hook/rule paths (that's the desired action)
+    if (targetPath) {
+      for (var j = 0; j < HOOK_RULE_PATHS.length; j++) {
+        if (HOOK_RULE_PATHS[j].test(targetPath)) return null;
+      }
+    }
+
+    return {
+      decision: "block",
+      reason: "HOOK BYPASS BLOCKED: A PreToolUse gate (instruction-to-hook) is active " +
+        "but you're using Bash to write a file instead of using the Write/Edit tool.\n\n" +
+        "This is not allowed. Bash must not be used to circumvent hook enforcement.\n" +
+        "FIX: Address the gate's requirement first (create the hook/rule it asks for), " +
+        "then use Write/Edit for the original file.\n" +
+        "If the gate fired incorrectly, fix the gate — don't bypass it."
+    };
+  }
+
+  // Check if the Bash description mentions bypassing
+  var desc = "";
+  try {
+    var ti2 = typeof input.tool_input === "string" ? JSON.parse(input.tool_input) : input.tool_input || {};
+    desc = ti2.description || "";
+  } catch(e) {}
+
+  var bypassPatterns = [
+    /bypass/i,
+    /work\s*around/i,
+    /circumvent/i,
+    /avoid.*hook/i,
+    /dodge.*gate/i,
+    /skip.*check/i,
+  ];
+  for (var k = 0; k < bypassPatterns.length; k++) {
+    if (bypassPatterns[k].test(desc) || bypassPatterns[k].test(cmd)) {
+      return {
+        decision: "block",
+        reason: "HOOK BYPASS BLOCKED: Your description or command mentions bypassing a hook.\n\n" +
+          "If a hook is wrong, fix the hook. If a hook is right, follow it.\n" +
+          "Never use Bash as a backdoor around Write/Edit enforcement."
+      };
+    }
+  }
+
+  return null;
+};

--- a/modules/PreToolUse/no-nested-claude.js
+++ b/modules/PreToolUse/no-nested-claude.js
@@ -1,0 +1,43 @@
+// WORKFLOW: shtd
+// WHY: Nested `claude -p` calls inside a session don't work reliably.
+// Cross-project work must use context_reset.py which opens a proper new terminal session.
+// Also blocks TaskCreate since it's a within-session tracker, not a session spawner.
+"use strict";
+
+module.exports = function(input) {
+  var tool = input.tool_name;
+
+  // Block Bash commands that try to run claude as a subprocess
+  if (tool === "Bash") {
+    var cmd = (input.tool_input || {}).command || "";
+
+    // Skip if "claude" only appears inside a search pattern (grep, rg, findstr, etc.)
+    // FP incident: `grep -E "vpn|monitor|claude"` matched the pipe-into-claude regex
+    // because `|claude` inside the quoted grep pattern looked like `| claude`.
+    var isSearchPattern = /\b(grep|rg|findstr|awk|sed)\b/.test(cmd) &&
+                          /["'].*claude.*["']/.test(cmd);
+    if (isSearchPattern) return null;
+
+    // Skip git/gh_auto commands — "claude" appears in paths (e.g. ~/.claude/hooks)
+    // and commit messages but these aren't running claude as a subprocess.
+    // FP incident: `git commit -m "$(cat <<'EOF'\nT32..."` blocked because
+    // the heredoc contained "claude" in a path reference.
+    if (/^\s*(git\s|gh_auto\s)/.test(cmd)) return null;
+
+    // Match: claude -p, claude --print, claude -m, or piped into claude
+    if (/\bclaude\s+(-p|--print|-m|--message)\b/.test(cmd) ||
+        /\|\s*claude\b/.test(cmd) ||
+        /\bclaude\s+-/.test(cmd)) {
+      return {
+        decision: "block",
+        reason: "NO NESTED CLAUDE: Cannot run claude as a subprocess — it doesn't work reliably.\n" +
+          "FIX: Use context_reset.py to spawn a proper new session:\n" +
+          "  python ~/Documents/ProjectsCL1/context-reset/context_reset.py \\\n" +
+          "    --target-project /path/to/other/project \\\n" +
+          "    --no-close --prompt \"your instructions here\""
+      };
+    }
+  }
+
+  return null;
+};

--- a/modules/PreToolUse/publish-json-guard.js
+++ b/modules/PreToolUse/publish-json-guard.js
@@ -1,0 +1,63 @@
+// WORKFLOW: shtd
+// WHY: ep-incident-response (private customer data) was published to grobomo (public).
+// Root cause: nothing prevented Claude from editing publish.json or git remotes,
+// which control which GitHub account receives pushes. This gate blocks all edits
+// to publish.json, git remote config, and git remote commands.
+"use strict";
+
+module.exports = function(input) {
+  var tool = input.tool_name;
+
+  // Guard file edits (Edit, Write)
+  if (tool === "Edit" || tool === "Write") {
+    var filePath = (input.tool_input && (input.tool_input.file_path || "")) || "";
+    filePath = filePath.replace(/\\/g, "/");
+
+    if (/\.github\/publish\.json$/i.test(filePath)) {
+      return {
+        decision: "block",
+        reason: "[publish-json-guard] publish.json controls GitHub account routing.\n" +
+          "Editing it can redirect pushes to the wrong org (e.g. private data \u2192 public repo).\n" +
+          "If this change is intentional, the user must edit the file manually."
+      };
+    }
+  }
+
+  // Guard bash commands that modify git remote or publish.json
+  // Only check the primary command, not strings embedded in heredocs/python/etc.
+  if (tool === "Bash") {
+    var cmd = (input.tool_input && input.tool_input.command) || "";
+    // Extract first line only — heredoc/python content is not the primary command
+    var firstLine = cmd.split("\n")[0];
+
+    // Block git remote set-url / add / remove (only as the primary command)
+    if (/^\s*(cd\s+[^;]+;\s*)?git\s+remote\s+(set-url|add|remove|rename)\b/.test(firstLine)) {
+      return {
+        decision: "block",
+        reason: "[publish-json-guard] Changing git remotes can redirect pushes to the wrong org.\n" +
+          "If this change is intentional, the user must run the command manually."
+      };
+    }
+
+    // Block direct shell writes to publish.json (only as the primary command)
+    if (/^\s*(sed|tee|cp|mv)\b.*publish\.json/.test(firstLine) ||
+        />\s*\S*publish\.json/.test(firstLine)) {
+      return {
+        decision: "block",
+        reason: "[publish-json-guard] Modifying publish.json via shell can break GitHub account routing.\n" +
+          "If this change is intentional, the user must edit the file manually."
+      };
+    }
+
+    // Block git config changes to remote URLs (only as the primary command)
+    if (/^\s*(cd\s+[^;]+;\s*)?git\s+config\b.*\bremote\./.test(firstLine)) {
+      return {
+        decision: "block",
+        reason: "[publish-json-guard] Changing git remote config can redirect pushes to the wrong org.\n" +
+          "If this change is intentional, the user must run the command manually."
+      };
+    }
+  }
+
+  return null;
+};

--- a/workflows/shtd.yml
+++ b/workflows/shtd.yml
@@ -70,6 +70,11 @@ modules:
   - test-checkpoint-gate
   - why-reminder
   - workflow-gate
+  - blueprint-no-sleep
+  - gh-auto-gate
+  - no-hook-bypass
+  - no-nested-claude
+  - publish-json-guard
   # Code quality (was: code-quality)
   - archive-not-delete
   - claude-p-pattern


### PR DESCRIPTION
## Summary
- Added 5 live-only modules to repo catalog: blueprint-no-sleep, gh-auto-gate, no-hook-bypass, no-nested-claude, publish-json-guard
- Retagged from stale workflow names (performance, security, session-management) to shtd
- Updated shtd.yml (85→90 modules) and README module table (+5 rows)

## Test plan
- [x] Workflow audit: 90 shtd modules, all matching YAML
- [x] Batch module validation: 99/99 pass
- [x] Health: 115 OK, 0 failures