### PR TITLE
T424: Version bump to 2.23.4 + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.23.4] — 2026-04-11
+
+### Added
+- **5 orphan modules to catalog** (T423) — blueprint-no-sleep, gh-auto-gate, no-hook-bypass, no-nested-claude, publish-json-guard. Retagged from stale workflow names (performance, security, session-management) to shtd. shtd.yml updated 85→90 modules.
+
 ## [2.23.3] — 2026-04-11
 
 ### Fixed

--- a/TODO.md
+++ b/TODO.md
@@ -1042,6 +1042,9 @@ Status:
 ## Catalog Sync
 - [x] T423: Add 5 orphan modules to catalog (PR #311) — blueprint-no-sleep, gh-auto-gate, no-hook-bypass, no-nested-claude, publish-json-guard. Retagged to shtd. shtd.yml 85→90. README +5 rows.
 
+## Release
+- [ ] T424: Version bump to 2.23.4 + CHANGELOG for T423 + marketplace sync
+
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog
 - `modules/` has all available modules organized by event type

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.23.3",
+  "version": "2.23.4",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Version bump 2.23.3 → 2.23.4
- CHANGELOG entry for T423 (5 orphan modules added to catalog)

## Test plan
- [x] Health: 115 OK, 0 failures
- [x] Workflow audit: 90 shtd modules, all matching YAML