### PR TITLE
T426: Fix stale workflow refs — watchdog, setup, tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1045,6 +1045,10 @@ Status:
 ## Release
 - [x] T424: Version bump to 2.23.4 + CHANGELOG for T423 + marketplace sync (PR #312)
 
+## Stale Workflow References
+- [x] T425: Fix hardcoded path in no-nested-claude.js (PR #314)
+- [ ] T426: Fix stale workflow names in watchdog.js + setup.js — code-quality, self-improvement, session-management, messaging-safety were consolidated into shtd in T313. Watchdog reports false failures. Setup default workflows reference nonexistent messaging-safety.
+
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog
 - `modules/` has all available modules organized by event type

--- a/scripts/test/test-T122-watchdog.sh
+++ b/scripts/test/test-T122-watchdog.sh
@@ -80,7 +80,7 @@ fi
 # Test 7: missing config file → uses defaults
 rm -f "$TMPDIR/watchdog-config.json"
 echo "// stub" > "$TMPDIR/run-stop.js"
-echo '{"shtd": true, "code-quality": true, "self-improvement": true, "session-management": true, "messaging-safety": true}' > "$TMPDIR/workflow-config.json"
+echo '{"shtd": true, "customer-data-guard": true}' > "$TMPDIR/workflow-config.json"
 EC4=0
 OUT4=$(node watchdog.js --hooks-dir "$TMPDIR" 2>&1) || EC4=$?
 assert "no config file uses defaults" "0" "$EC4"

--- a/scripts/test/test-watchdog-health.js
+++ b/scripts/test/test-watchdog-health.js
@@ -20,7 +20,7 @@ var alertFile = path.join(tmpDir, ".watchdog-alert");
 
 // Create minimal required files so other watchdog checks pass
 var wcPath = path.join(tmpDir, "workflow-config.json");
-fs.writeFileSync(wcPath, JSON.stringify({shtd: true, "code-quality": true, "self-improvement": true, "session-management": true, "messaging-safety": true}));
+fs.writeFileSync(wcPath, JSON.stringify({shtd: true, "customer-data-guard": true}));
 
 // Create required runner files
 var requiredRunners = ["run-pretooluse.js", "run-posttooluse.js", "run-stop.js", "run-sessionstart.js", "run-userpromptsubmit.js", "load-modules.js", "workflow.js", "hook-log.js", "run-async.js", "workflow-cli.js", "constants.js"];

--- a/setup.js
+++ b/setup.js
@@ -1310,7 +1310,7 @@ function cmdWizard(reportOnly, dryRun, openMode, autoYes, analyzeMode, deepMode,
       console.log("  " + dryChanges[d].action + ": " + dryChanges[d].file);
     }
     if (autoYes) {
-      console.log("  [--yes] Would enable default workflows: shtd, messaging-safety");
+      console.log("  [--yes] Would enable default workflows: shtd");
     }
     console.log("\n[hook-runner] Dry-run complete. No changes made.");
     return;
@@ -1346,7 +1346,7 @@ function cmdWizard(reportOnly, dryRun, openMode, autoYes, analyzeMode, deepMode,
     console.log("[6/6] Enabling default workflows...");
     var wf = require("./workflow");
     var globalDir = path.join(os.homedir(), ".claude", "hooks");
-    var defaultWorkflows = ["shtd", "messaging-safety"];
+    var defaultWorkflows = ["shtd"];
     for (var wi = 0; wi < defaultWorkflows.length; wi++) {
       var wfName = defaultWorkflows[wi];
       try {
@@ -1377,7 +1377,7 @@ function cmdWizard(reportOnly, dryRun, openMode, autoYes, analyzeMode, deepMode,
   console.log("  Backup: " + backup.backupDir);
   console.log("  Report: " + afterReport);
   if (enableWorkflows) {
-    console.log("  Default workflows enabled: shtd, messaging-safety");
+    console.log("  Default workflows enabled: shtd");
   }
   console.log("");
   console.log("  To add a hook module:");

--- a/watchdog.js
+++ b/watchdog.js
@@ -23,7 +23,7 @@ var configFile = getArg("--config") || path.join(hooksDir, "watchdog-config.json
 
 // --- Load watchdog config (what "healthy" looks like) ---
 var DEFAULT_CONFIG = {
-  required_workflows: ["shtd", "code-quality", "self-improvement", "session-management", "messaging-safety"],
+  required_workflows: ["shtd", "customer-data-guard"],
   required_runners: [
     "run-pretooluse.js", "run-posttooluse.js", "run-stop.js",
     "run-sessionstart.js", "run-userpromptsubmit.js",


### PR DESCRIPTION
## Summary
- watchdog.js: required_workflows updated from 5 stale names to `["shtd", "customer-data-guard"]` (T313 consolidated code-quality, self-improvement, session-management, messaging-safety into shtd)
- setup.js: default workflow for `--yes` install simplified to just `shtd`
- Test files updated to match new defaults

## Test plan
- [x] test-T122-watchdog.sh: 8/8 pass
- [x] test-watchdog-health.js: 6/6 pass
- [x] test-setup-wizard.sh: 7/7 pass