### PR TITLE
T428: Starter workflow + multi-tag support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.24.0] — 2026-04-11
+
+### Added
+- **Starter workflow** (T428) — New `starter` workflow with 11 universally useful modules (force-push-gate, git-destructive-guard, secret-scan-gate, commit-quality-gate, archive-not-delete, no-hardcoded-paths, test-coverage-check, preserve-iterated-content, project-health, workflow-summary, terminal-title). Safe defaults for any Claude Code user.
+- **Multi-tag workflow support** — Modules can now belong to multiple workflows with comma-separated tags: `// WORKFLOW: shtd, starter`. Module runs if ANY tagged workflow is enabled.
+
+### Changed
+- **`--yes` installs starter instead of shtd** — New users get 11 essential modules instead of 90 advanced ones. Enables `shtd` manually when ready.
+
 ## [2.23.5] — 2026-04-11
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ node setup.js --test    # runs all suites, auto-discovers scripts/test/test-*.sh
 - Async: `module.exports = async function(input) { ... }` — 4s timeout
 - Return `null` to pass, `{decision: "block", reason: "..."}` to block
 - `// WHY:` comment required — explains the real incident that caused the module
-- `// WORKFLOW: name` — only runs when that workflow is active
+- `// WORKFLOW: name` — only runs when that workflow is active (comma-separated for multi: `// WORKFLOW: shtd, starter`)
 - `// requires: mod1, mod2` — missing deps = module skipped
 
 ## CLI Commands

--- a/README.md
+++ b/README.md
@@ -49,7 +49,12 @@ The setup wizard will:
 1. Scan your current hooks and generate a styled HTML report
 2. Back up existing hooks to `~/.claude/hooks/archive/`
 3. Install the runner system
-4. Enable default workflows (with `--yes`)
+4. Enable the `starter` workflow (with `--yes`) — 11 universally useful modules
+
+Ready for more? Enable the full development pipeline:
+```bash
+node setup.js --workflow enable shtd    # 90 modules: spec-first, test-first, PR discipline
+```
 
 To undo everything: `node setup.js --uninstall --confirm`
 
@@ -69,6 +74,7 @@ node setup.js --workflow query Edit        # which workflows affect Edit?
 
 | Workflow | Modules | What it enforces |
 |----------|---------|-----------------|
+| `starter` | 11 | **Start here.** Safe defaults for any user — blocks force-push, destructive git, secret commits, file deletion. Adds commit quality checks, test reminders, and session context. |
 | `shtd` | 90 | Spec-Hook-Test-Driven — the full development pipeline. Enforces spec → branch → test → implement → PR, plus code quality, infrastructure safety, messaging guards, session lifecycle, and self-improvement. |
 | `customer-data-guard` | 3 | Read-only incident response — blocks env changes, data exfil, and V1 modifications. |
 | `dispatcher-worker` | 3 | Role-aware fleet workflow. Dispatcher specs/distributes, workers implement/test/PR. |
@@ -160,7 +166,7 @@ Rules:
 - **Return null** to pass, `{decision: "block", reason: "..."}` to block
 - **Sync or async** — return a Promise for async work (4s timeout)
 - **Dependencies** — `// requires: mod1, mod2` in first 5 lines
-- **Workflow tag** — `// WORKFLOW: name` restricts module to that workflow
+- **Workflow tag** — `// WORKFLOW: name` restricts module to that workflow (comma-separated for multiple: `// WORKFLOW: shtd, starter`)
 
 ### Event Types
 

--- a/TODO.md
+++ b/TODO.md
@@ -1065,15 +1065,13 @@ What was done this session:
 - Live hooks synced (watchdog.js, setup.js)
 - gh auth on default (joel-ginsberg_tmemu)
 
-Next session (step 4 — zoom out):
-- Consider what real-world value comes next for external adopters
-- E2E pipeline test freshness (full suite takes minutes — optimize or batch)
-- Any new module patterns worth adding to catalog
+## Starter Workflow & Multi-Tag (T428)
+- [x] T428: Starter workflow — 11 universally useful modules, multi-tag support (`// WORKFLOW: shtd, starter`), `--yes` installs starter instead of shtd. Version 2.24.0.
 
 Status:
 - 0 pending tasks
-- Version: 2.23.5
-- 99 modules, 90 in shtd workflow
+- Version: 2.24.0
+- 99 modules, 90 in shtd workflow, 11 in starter workflow (shared via multi-tag)
 - Clean git, marketplace synced
 
 ## Architecture Notes

--- a/load-modules.js
+++ b/load-modules.js
@@ -48,15 +48,30 @@ function parseRequires(filePath) {
 
 /**
  * Parse "// WORKFLOW: workflow-name" from the first 5 lines of a module file.
- * Returns the workflow name or null if no tag found.
+ * Supports comma-separated names: "// WORKFLOW: shtd, starter"
+ * Returns array of workflow names, or empty array if no tag found.
  */
-function parseWorkflowTag(filePath) {
+function parseWorkflowTags(filePath) {
   var lines = getHeaderLines(filePath);
   for (var i = 0; i < lines.length; i++) {
-    var match = lines[i].match(/^\/\/\s*WORKFLOW:\s*(\S+)/i);
-    if (match) return match[1];
+    var match = lines[i].match(/^\/\/\s*WORKFLOW:\s*(.+)/i);
+    if (match) {
+      var tags = match[1].split(",");
+      var result = [];
+      for (var t = 0; t < tags.length; t++) {
+        var tag = tags[t].replace(/^\s+|\s+$/g, "");
+        if (tag) result.push(tag);
+      }
+      if (result.length > 0) return result;
+    }
   }
-  return null;
+  return [];
+}
+
+// Backwards-compatible: returns first tag or null
+function parseWorkflowTag(filePath) {
+  var tags = parseWorkflowTags(filePath);
+  return tags.length > 0 ? tags[0] : null;
 }
 
 /**
@@ -109,11 +124,19 @@ function filterByWorkflow(modulePaths) {
 
   var result = [];
   for (var i = 0; i < modulePaths.length; i++) {
-    var tag = parseWorkflowTag(modulePaths[i]);
-    if (!tag) {
+    var tags = parseWorkflowTags(modulePaths[i]);
+    if (tags.length === 0) {
       result.push(modulePaths[i]); // untagged always passes
-    } else if (enabledSet[tag] && !disabledSet[tag]) {
-      result.push(modulePaths[i]); // workflow enabled
+    } else {
+      // Module passes if ANY of its workflow tags is enabled and not disabled
+      var anyEnabled = false;
+      for (var ti = 0; ti < tags.length; ti++) {
+        if (enabledSet[tags[ti]] && !disabledSet[tags[ti]]) {
+          anyEnabled = true;
+          break;
+        }
+      }
+      if (anyEnabled) result.push(modulePaths[i]);
     }
   }
   return result;
@@ -194,4 +217,5 @@ module.exports = function loadModules(eventDir) {
 module.exports.parseRequires = parseRequires;
 module.exports.validateDeps = validateDeps;
 module.exports.parseWorkflowTag = parseWorkflowTag;
+module.exports.parseWorkflowTags = parseWorkflowTags;
 module.exports.filterByWorkflow = filterByWorkflow;

--- a/modules/PostToolUse/test-coverage-check.js
+++ b/modules/PostToolUse/test-coverage-check.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: Source files were modified but existing tests never ran, hiding regressions.
 // PostToolUse: warn when source files are modified but tests exist that should be run
 // Triggers after Edit or Write tool completions.

--- a/modules/PreToolUse/archive-not-delete.js
+++ b/modules/PreToolUse/archive-not-delete.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: Claude deleted files that turned out to be needed later.
 // Block destructive delete commands. Always archive, never delete.
 // Returns null to pass, {decision:"block", reason:"..."} to block.

--- a/modules/PreToolUse/commit-quality-gate.js
+++ b/modules/PreToolUse/commit-quality-gate.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: Generic commit messages like "fix" or "update" make git history useless.
 // When debugging E2E failures across 10+ deploy cycles, you need to know what
 // each commit actually changed and why. Bad messages waste 10+ minutes per cycle.

--- a/modules/PreToolUse/force-push-gate.js
+++ b/modules/PreToolUse/force-push-gate.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: Force-pushing to main/master can destroy shared history and others' work.
 // There is no undo for a force-push that overwrites remote commits.
 "use strict";

--- a/modules/PreToolUse/git-destructive-guard.js
+++ b/modules/PreToolUse/git-destructive-guard.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: Claude ran `git reset --hard` and `git checkout .` to "clean up" working
 // trees, destroying uncommitted work. These ops are rarely the right solution —
 // investigate root cause instead. Only rebase was gated (git-rebase-safety);

--- a/modules/PreToolUse/no-hardcoded-paths.js
+++ b/modules/PreToolUse/no-hardcoded-paths.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: Hardcoded C:SERS PATHS IN SCRIPTS BROKE PORTABILITY ACROSS MACHINES.
 // BLOCK WRITE/Edit with hardcoded absolute user paths in file content.
 // Catches Windows, Linux, and macOS home directory paths in new_string/content.

--- a/modules/PreToolUse/preserve-iterated-content.js
+++ b/modules/PreToolUse/preserve-iterated-content.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: Claude rewrote a stop hook module, condensing a user-authored message
 // that had been refined over 15 iterations. The message text was treated as
 // "my code" instead of a carefully evolved artifact. This gate catches

--- a/modules/PreToolUse/secret-scan-gate.js
+++ b/modules/PreToolUse/secret-scan-gate.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: API keys were committed to git history and had to be rotated.
 "use strict";
 // PreToolUse: block Bash git-commit if staged diff contains obvious secrets.

--- a/modules/SessionStart/project-health.js
+++ b/modules/SessionStart/project-health.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: Broken hook runners silently failed, leaving gates unenforced.
 // SessionStart: run hook-runner health check on session start
 // Warns if any runners are missing, modules fail to load, or settings are misconfigured.

--- a/modules/SessionStart/terminal-title.js
+++ b/modules/SessionStart/terminal-title.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: With multiple Claude tabs open, they all show the same title making it
 // impossible to find the right session. Setting the terminal title to the CWD
 // folder name gives each tab a distinct label. Also fires after context-reset

--- a/modules/SessionStart/workflow-summary.js
+++ b/modules/SessionStart/workflow-summary.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: On context reset, Claude loses track of which workflows are active.
 // SessionStart: inject active workflow summary so Claude knows all active constraints.
 module.exports = function(input) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.23.5",
+  "version": "2.24.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"

--- a/scripts/test/test-T099-filter-by-config.sh
+++ b/scripts/test/test-T099-filter-by-config.sh
@@ -86,5 +86,48 @@ RESULT4=$(HOME="$FAKE_HOME" USERPROFILE="$FAKE_HOME" CLAUDE_PROJECT_DIR="$TMPDIR
 ")
 check "shtd disabled: tagged-cq + untagged pass" '[ "$RESULT4" = "tagged-cq,untagged" ]'
 
+# Test: multi-tag module — tagged with both shtd AND starter
+cat > "$TMPDIR/run-modules/PreToolUse/multi-tag.js" << 'JS'
+// WORKFLOW: shtd, starter
+module.exports = function(input) { return null; };
+JS
+
+# Reset: disable all, enable only starter
+node -e "
+  var wf = require('$REPO_DIR/workflow.js');
+  wf.disableWorkflow('code-quality', '$TMPDIR');
+  wf.enableWorkflow('starter', '$TMPDIR');
+"
+RESULT5=$(HOME="$FAKE_HOME" USERPROFILE="$FAKE_HOME" CLAUDE_PROJECT_DIR="$TMPDIR" node -e "
+  delete require.cache[require.resolve('$REPO_DIR/load-modules.js')];
+  delete require.cache[require.resolve('$REPO_DIR/workflow.js')];
+  var lm = require('$REPO_DIR/load-modules.js');
+  var mods = lm('$TMPDIR/run-modules/PreToolUse');
+  console.log(mods.map(function(m) { return require('path').basename(m, '.js'); }).sort().join(','));
+")
+check "starter enabled: multi-tag + untagged pass (shtd-only excluded)" '[ "$RESULT5" = "multi-tag,untagged" ]'
+
+# Test: enable shtd too — multi-tag still passes (both workflows active)
+node -e "
+  var wf = require('$REPO_DIR/workflow.js');
+  wf.enableWorkflow('shtd', '$TMPDIR');
+"
+RESULT6=$(HOME="$FAKE_HOME" USERPROFILE="$FAKE_HOME" CLAUDE_PROJECT_DIR="$TMPDIR" node -e "
+  delete require.cache[require.resolve('$REPO_DIR/load-modules.js')];
+  delete require.cache[require.resolve('$REPO_DIR/workflow.js')];
+  var lm = require('$REPO_DIR/load-modules.js');
+  var mods = lm('$TMPDIR/run-modules/PreToolUse');
+  console.log(mods.map(function(m) { return require('path').basename(m, '.js'); }).sort().join(','));
+")
+check "shtd+starter enabled: all tagged + untagged pass" '[ "$RESULT6" = "multi-tag,tagged-shtd,untagged" ]'
+
+# Test: parseWorkflowTags returns both tags
+RESULT7=$(node -e "
+  var lm = require('$REPO_DIR/load-modules.js');
+  var tags = lm.parseWorkflowTags('$TMPDIR/run-modules/PreToolUse/multi-tag.js');
+  console.log(tags.join(','));
+")
+check "parseWorkflowTags returns both tags" '[ "$RESULT7" = "shtd,starter" ]'
+
 echo "=== Results: $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ]

--- a/setup.js
+++ b/setup.js
@@ -1310,7 +1310,7 @@ function cmdWizard(reportOnly, dryRun, openMode, autoYes, analyzeMode, deepMode,
       console.log("  " + dryChanges[d].action + ": " + dryChanges[d].file);
     }
     if (autoYes) {
-      console.log("  [--yes] Would enable default workflows: shtd");
+      console.log("  [--yes] Would enable default workflows: starter");
     }
     console.log("\n[hook-runner] Dry-run complete. No changes made.");
     return;
@@ -1339,14 +1339,15 @@ function cmdWizard(reportOnly, dryRun, openMode, autoYes, analyzeMode, deepMode,
   if (openMode) openFile(afterReport);
 
   // Step 7: Enable default workflows (if --yes or interactive)
-  // WHY: New users don't know which workflows to enable. Defaults provide
-  // immediate value (spec-first, test-first, no accidental messaging).
+  // WHY: New users don't know which workflows to enable. "starter" provides
+  // safe defaults (force-push, secret-scan, archive-not-delete) without
+  // overwhelming them with 90 shtd modules. Users enable shtd manually later.
   var enableWorkflows = autoYes;
   if (enableWorkflows) {
     console.log("[6/6] Enabling default workflows...");
     var wf = require("./workflow");
     var globalDir = path.join(os.homedir(), ".claude", "hooks");
-    var defaultWorkflows = ["shtd"];
+    var defaultWorkflows = ["starter"];
     for (var wi = 0; wi < defaultWorkflows.length; wi++) {
       var wfName = defaultWorkflows[wi];
       try {

--- a/workflow-cli.js
+++ b/workflow-cli.js
@@ -168,27 +168,32 @@ function cmdWorkflow(args) {
       for (var fi = 0; fi < entries.length; fi++) {
         if (entries[fi].isFile() && entries[fi].name.slice(-3) === ".js") {
           var modPath = path.join(evDir, entries[fi].name);
-          var tag = lm.parseWorkflowTag(modPath);
-          allModules.push({ name: entries[fi].name.replace(/\.js$/, ""), event: events[ei], path: modPath, tag: tag });
+          var tags = lm.parseWorkflowTags ? lm.parseWorkflowTags(modPath) : [];
+          var tag = tags.length > 0 ? tags[0] : null;
+          allModules.push({ name: entries[fi].name.replace(/\.js$/, ""), event: events[ei], path: modPath, tag: tag, tags: tags });
         } else if (entries[fi].isDirectory() && entries[fi].name !== "archive" && entries[fi].name.charAt(0) !== "_") {
           var subDir = path.join(evDir, entries[fi].name);
           var subFiles = fs.readdirSync(subDir).filter(function(f) { return f.slice(-3) === ".js"; }).sort();
           for (var si = 0; si < subFiles.length; si++) {
             var subModPath = path.join(subDir, subFiles[si]);
-            var subTag = lm.parseWorkflowTag(subModPath);
-            allModules.push({ name: subFiles[si].replace(/\.js$/, ""), event: events[ei], path: subModPath, tag: subTag });
+            var subTags = lm.parseWorkflowTags ? lm.parseWorkflowTags(subModPath) : [];
+            var subTag = subTags.length > 0 ? subTags[0] : null;
+            allModules.push({ name: subFiles[si].replace(/\.js$/, ""), event: events[ei], path: subModPath, tag: subTag, tags: subTags });
           }
         }
       }
     }
 
-    var tagged = allModules.filter(function(m) { return m.tag; });
-    var untagged = allModules.filter(function(m) { return !m.tag; });
+    var tagged = allModules.filter(function(m) { return m.tags && m.tags.length > 0; });
+    var untagged = allModules.filter(function(m) { return !m.tags || m.tags.length === 0; });
 
-    // Per-workflow counts from actual tags
+    // Per-workflow counts from actual tags (multi-tag modules count toward each)
     var tagCounts = {};
     for (var ti = 0; ti < tagged.length; ti++) {
-      tagCounts[tagged[ti].tag] = (tagCounts[tagged[ti].tag] || 0) + 1;
+      var modTags = tagged[ti].tags || [tagged[ti].tag];
+      for (var tgi = 0; tgi < modTags.length; tgi++) {
+        tagCounts[modTags[tgi]] = (tagCounts[modTags[tgi]] || 0) + 1;
+      }
     }
 
     // Coverage summary
@@ -210,9 +215,12 @@ function cmdWorkflow(args) {
     // Orphan tags: modules tagged with a workflow that has no YAML
     var orphanTags = {};
     for (var oi = 0; oi < tagged.length; oi++) {
-      if (!yamlModules[tagged[oi].tag]) {
-        if (!orphanTags[tagged[oi].tag]) orphanTags[tagged[oi].tag] = [];
-        orphanTags[tagged[oi].tag].push(tagged[oi].event + "/" + tagged[oi].name);
+      var oiTags = tagged[oi].tags || [tagged[oi].tag];
+      for (var oti = 0; oti < oiTags.length; oti++) {
+        if (!yamlModules[oiTags[oti]]) {
+          if (!orphanTags[oiTags[oti]]) orphanTags[oiTags[oti]] = [];
+          orphanTags[oiTags[oti]].push(tagged[oi].event + "/" + tagged[oi].name);
+        }
       }
     }
     var orphanKeys = Object.keys(orphanTags);
@@ -302,8 +310,8 @@ function cmdWorkflow(args) {
           // Check if module source references the tool name (case-sensitive match for tool names)
           var toolPattern = new RegExp('["\'\\s]' + queryTool + '["\'\\s,;)\\]]', 'g');
           if (toolPattern.test(src)) {
-            var tag = lmq.parseWorkflowTag(path.join(modulesDir, files[qi]));
-            matches.push({ name: files[qi].replace(/\.js$/, ""), workflow: tag || "(untagged)" });
+            var qTags = lmq.parseWorkflowTags ? lmq.parseWorkflowTags(path.join(modulesDir, files[qi])) : [];
+            matches.push({ name: files[qi].replace(/\.js$/, ""), workflow: qTags.length > 0 ? qTags.join(", ") : "(untagged)" });
           }
         } catch(e) {}
       }

--- a/workflows/starter.yml
+++ b/workflows/starter.yml
@@ -1,0 +1,27 @@
+name: starter
+description: Safe defaults for any Claude Code user. Blocks common mistakes (force push, destructive git, rm -rf, secret commits) and adds helpful guardrails (commit quality, test reminders). Start here, then enable shtd when you want full development discipline.
+version: 1
+steps:
+  - id: ready
+    name: Ready to work
+    gate:
+      require_files: []
+    completion:
+      require_files: []
+
+modules:
+  # Git safety — prevent irreversible mistakes
+  - force-push-gate
+  - git-destructive-guard
+  - secret-scan-gate
+  - commit-quality-gate
+  # File safety — prevent accidental deletion
+  - archive-not-delete
+  # Code quality — catch common issues
+  - no-hardcoded-paths
+  - test-coverage-check
+  - preserve-iterated-content
+  # Session lifecycle — helpful context
+  - project-health
+  - workflow-summary
+  - terminal-title


### PR DESCRIPTION
## Summary
- New `starter` workflow with 11 universally useful modules — safe defaults for any Claude Code user
- Multi-tag support: `// WORKFLOW: shtd, starter` — modules belong to multiple workflows
- `--yes` now installs `starter` instead of `shtd` (11 modules vs 90)
- 3 new multi-tag filter tests (7/7 pass)
- Workflow audit updated for multi-tag counting

## Test plan
- [x] Batch module validation: 99/99 pass
- [x] Workflow audit: all workflows match YAML (shtd 90, starter 11)
- [x] T099 filter tests: 7/7 pass (includes 3 new multi-tag tests)
- [x] parseWorkflowTags returns correct array for multi-tag modules