### PR TITLE
T429: Adoption polish — example config, multi-tag fixes

### DIFF
--- a/generate-manifest.js
+++ b/generate-manifest.js
@@ -68,8 +68,8 @@ for (var ei = 0; ei < EVENTS.length; ei++) {
       ? whyMatch[1].replace(/\n\/\/\s*/g, " ").trim()
       : "(no WHY comment)";
 
-    var workflowMatch = src.match(/\/\/\s*WORKFLOW:\s*(\S+)/);
-    var workflow = workflowMatch ? workflowMatch[1] : "untagged";
+    var workflowMatch = src.match(/\/\/\s*WORKFLOW:\s*(.+)/);
+    var workflow = workflowMatch ? workflowMatch[1].replace(/\s+$/, "") : "untagged";
 
     // Determine module role
     var role;

--- a/modules.example.yaml
+++ b/modules.example.yaml
@@ -5,49 +5,56 @@
 # modules: which modules to install per event type
 # Each module name maps to modules/<Event>/<name>.js in the source repo
 #
+# TIP: Instead of picking individual modules, use workflows:
+#   npx grobomo/hook-runner --yes          # installs starter workflow (11 modules)
+#   node setup.js --workflow enable shtd   # full development pipeline (90 modules)
+#
+# This file is for fine-grained control when you want specific modules
+# without enabling an entire workflow.
+#
 # Logging: runners write to ~/.claude/hooks/hook-log.jsonl (auto-rotates at 10MB)
-# Add hook-log.jsonl to .gitignore if you symlink or copy logs into a project
 
 source: grobomo/hook-runner
 branch: main
 
 modules:
   PreToolUse:
-    # Workflow enforcement (recommended)
-    - enforcement-gate       # git repo + clean tree + TODO.md required
-    - branch-pr-gate         # Model C branching: feature branch → task branch → PR
-    - remote-tracking-gate   # blocks edits if branch not pushed to remote
-    - spec-gate              # blocks code without specs/tasks.md
-    - test-checkpoint-gate    # blocks code without e2e test (auto-detects scripts/test/test-TXXX*.sh)
-    - continuous-claude-gate # blocks code without tracked task workflow
-
-    # Safety
-    - root-cause-gate        # blocks retry/cleanup without diagnosis
-    - archive-not-delete     # blocks rm -rf, forces archive/ instead
-    - no-adhoc-commands      # blocks raw aws/ssh/docker/kubectl, forces scripts/
+    # === Starter workflow modules (safe defaults for everyone) ===
+    - force-push-gate        # blocks git push --force to main/master
+    - git-destructive-guard  # blocks git reset --hard, checkout ., clean -f
     - secret-scan-gate       # blocks git commit if staged diff contains secrets
+    - commit-quality-gate    # blocks generic commit messages (< 5 words)
+    - archive-not-delete     # blocks rm -rf, forces archive/ instead
     - no-hardcoded-paths     # blocks Write/Edit with absolute user paths in content
+    - preserve-iterated-content  # warns on full-file rewrites of iterated files
 
-    # Optional / niche
-    # - aws-tagging-gate     # enforce AWS resource tags (needs AWS_TAG_REQUIRED_VALUE env)
+    # === SHTD workflow extras (development discipline) ===
+    # - enforcement-gate     # git repo + TODO.md required before edits
+    # - branch-pr-gate       # feature branch + task branch + PR workflow
+    # - remote-tracking-gate # blocks edits if branch not pushed to remote
+    # - spec-gate            # blocks code without specs/tasks.md
+    # - test-checkpoint-gate # blocks code without e2e test
+    # - continuous-claude-gate # blocks code without tracked task workflow
+    # - root-cause-gate      # blocks retry/cleanup without diagnosis
 
-  UserPromptSubmit:
-    # Prompt audit (optional)
-    - prompt-logger          # log prompts to ~/.claude/hooks/prompt-log.jsonl
+    # === Niche / optional ===
+    # - no-adhoc-commands    # blocks raw aws/ssh/docker/kubectl, forces scripts/
+    # - aws-tagging-gate     # enforce AWS resource tags
 
   PostToolUse:
-    - rule-hygiene           # validates rule files are granular
-    - commit-msg-check       # blocks WIP/fixup commits and over-long first lines
     - test-coverage-check    # warns when source files with tests are modified
+    # - commit-msg-check     # blocks WIP/fixup commits
+    # - rule-hygiene         # validates rule files are granular
 
   Stop:
-    - auto-continue          # never stop, always find next task
-    - push-unpushed          # blocks stop if unpushed commits exist
+    # - auto-continue        # never stop, always find next task
+    # - push-unpushed        # blocks stop if unpushed commits exist
 
   SessionStart:
-    - load-instructions      # inject working instructions at session start
-    - project-health         # run health check on session start, warn about issues
-    # - backup-check         # async: warn if claude-backup is stale (>72h)
+    - project-health         # run health check on session start
+    - workflow-summary       # inject active workflow context
+    - terminal-title         # set terminal title to project name
+    # - load-instructions    # inject working instructions at session start
 
 # Project-scoped modules (optional)
 # These only run when CLAUDE_PROJECT_DIR basename matches the key

--- a/report.js
+++ b/report.js
@@ -67,12 +67,13 @@ function getModuleDescription(filePath) {
 
 /**
  * Parse "// WORKFLOW: name" from a module's header lines.
+ * Supports comma-separated multi-tag: "// WORKFLOW: shtd, starter"
  */
 function getModuleWorkflow(filePath) {
   var lines = getHeaderLines(filePath);
   for (var i = 0; i < lines.length; i++) {
-    var match = lines[i].match(/^\/\/\s*WORKFLOW:\s*(\S+)/i);
-    if (match) return match[1];
+    var match = lines[i].match(/^\/\/\s*WORKFLOW:\s*(.+)/i);
+    if (match) return match[1].replace(/\s+$/g, "");
   }
   return null;
 }


### PR DESCRIPTION
## Summary
- Reorganized modules.example.yaml around starter workflow with clear sections
- Fixed report.js and generate-manifest.js to handle comma-separated multi-tag (`// WORKFLOW: shtd, starter`)

## Test plan
- [x] report.js getModuleWorkflow returns full multi-tag string
- [x] generate-manifest.js captures full workflow tag