### PR TITLE
T430: Version bump to 2.24.1 + SKILL.md update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.24.1] — 2026-04-11
+
+### Fixed
+- **Multi-tag in report/manifest** (T429) — report.js and generate-manifest.js now handle comma-separated workflow tags correctly.
+- **modules.example.yaml** (T429) — Reorganized around starter workflow with clear sections for starter, shtd, and optional modules.
+- **SKILL.md** (T430) — Updated workflow list to include starter, added starter keyword.
+
 ## [2.24.0] — 2026-04-11
 
 ### Added

--- a/SKILL.md
+++ b/SKILL.md
@@ -14,6 +14,7 @@ keywords:
   - gate
   - module
   - shtd
+  - starter
 custom_commands:
   - name: setup
     command: "node $SKILL_DIR/setup.js"
@@ -58,7 +59,7 @@ node setup.js --workflow audit     # coverage report
 node setup.js --workflow query Edit  # which workflows affect Edit?
 ```
 
-Built-in: `shtd` (spec→test→implement→PR), `messaging-safety`, `no-local-docker`, `cross-project-reset`.
+Built-in: `starter` (safe defaults, 11 modules), `shtd` (full development pipeline, 90 modules), `customer-data-guard`, `no-local-docker`, `cross-project-reset`.
 
 ## Module Contract
 
@@ -73,7 +74,7 @@ module.exports = function(input) {
 
 - Return `null` to pass, `{decision: "block"}` to block
 - Sync or async (4s timeout for async)
-- `// WORKFLOW: name` restricts to that workflow
+- `// WORKFLOW: name` restricts to that workflow (multi: `// WORKFLOW: shtd, starter`)
 - `// requires: mod1` for dependencies
 
 ## CLI

--- a/TODO.md
+++ b/TODO.md
@@ -1065,12 +1065,14 @@ What was done this session:
 - Live hooks synced (watchdog.js, setup.js)
 - gh auth on default (joel-ginsberg_tmemu)
 
-## Starter Workflow & Multi-Tag (T428)
-- [x] T428: Starter workflow — 11 universally useful modules, multi-tag support (`// WORKFLOW: shtd, starter`), `--yes` installs starter instead of shtd. Version 2.24.0.
+## Starter Workflow & Multi-Tag (T428-T430)
+- [x] T428: Starter workflow — 11 universally useful modules, multi-tag support (`// WORKFLOW: shtd, starter`), `--yes` installs starter instead of shtd (PR #319)
+- [x] T429: Adoption polish — modules.example.yaml reorganized, report.js/generate-manifest.js multi-tag fix (PR #320)
+- [x] T430: Version bump to 2.24.1 + SKILL.md starter keyword + CHANGELOG
 
 Status:
 - 0 pending tasks
-- Version: 2.24.0
+- Version: 2.24.1
 - 99 modules, 90 in shtd workflow, 11 in starter workflow (shared via multi-tag)
 - Clean git, marketplace synced
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.24.0",
+  "version": "2.24.1",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Version bump to 2.24.1
- SKILL.md: added starter to workflow list and keywords
- CHANGELOG entry for T429 multi-tag fixes