### PR TITLE
T432: Code review — ES6 fix, git tags, GitHub release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.24.3] — 2026-04-11
+
+### Fixed
+- **ES6 template literal in load-instructions.js** (T432) — Replaced backtick template with ES5 string concatenation for consistency.
+
+### Added
+- **37 missing git tags** (T432) — Created and pushed tags for v2.9.0 through v2.24.2. GitHub release for v2.24.2.
+
 ## [2.24.2] — 2026-04-11
 
 ### Fixed

--- a/TODO.md
+++ b/TODO.md
@@ -1095,6 +1095,10 @@ Status:
 - 99 modules, 90 in shtd, 11 in starter (shared via multi-tag)
 - Clean git, marketplace synced, health 115/0/0
 
+## Code Review & Tags (T432)
+
+- [ ] T432: Code review — fix ES6 template literal in load-instructions.js, create 37 missing git tags (v2.9.0–v2.24.2), GitHub release for v2.24.2
+
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog
 - `modules/` has all available modules organized by event type

--- a/TODO.md
+++ b/TODO.md
@@ -1097,7 +1097,7 @@ Status:
 
 ## Code Review & Tags (T432)
 
-- [ ] T432: Code review — fix ES6 template literal in load-instructions.js, create 37 missing git tags (v2.9.0–v2.24.2), GitHub release for v2.24.2
+- [x] T432: Code review — fix ES6 template literal in load-instructions.js, create 37 missing git tags (v2.9.0–v2.24.2), GitHub release for v2.24.2, version bump to 2.24.3
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog

--- a/modules/SessionStart/load-instructions.js
+++ b/modules/SessionStart/load-instructions.js
@@ -4,8 +4,6 @@
 module.exports = function(input) {
   // SessionStart hooks output text to Claude as context (not block/allow)
   return {
-    text: `SESSION START INSTRUCTIONS: Check TODO.md in $CLAUDE_PROJECT_DIR for pending tasks. If tasks remain, do the next one. Read jsonl logs in ~/.claude/projects/ for incomplete tangents from previous sessions. Organize, optimize, secure the project. Then zoom out and expand. Always write plans to TODO.md before executing. Save state to $CLAUDE_PROJECT_DIR/TODO.md before context resets.
-
-IMPORTANT: If TODO.md has a session handoff from a previous session, read it FIRST — it tells you what was done and what matters next. Mindset: be slow and systematic. Build repeatable, modular code with excellent user experience. No rush.`
+    text: "SESSION START INSTRUCTIONS: Check TODO.md in $CLAUDE_PROJECT_DIR for pending tasks. If tasks remain, do the next one. Read jsonl logs in ~/.claude/projects/ for incomplete tangents from previous sessions. Organize, optimize, secure the project. Then zoom out and expand. Always write plans to TODO.md before executing. Save state to $CLAUDE_PROJECT_DIR/TODO.md before context resets.\n\nIMPORTANT: If TODO.md has a session handoff from a previous session, read it FIRST — it tells you what was done and what matters next. Mindset: be slow and systematic. Build repeatable, modular code with excellent user experience. No rush."
   };
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Fix ES6 template literal in `load-instructions.js` → ES5 string concatenation
- 37 missing git tags created and pushed (v2.9.0 through v2.24.2)
- GitHub release created for v2.24.2
- Version bump to 2.24.3

## Test plan
- [x] `_batch-module-test.js` — 99/99 modules pass
- [x] load-instructions.js verified: returns string with newlines, 624 chars
- [x] Full test suite: 51 suites, 405 passed, 0 failed