### PR TITLE
T434-T436: Fix spec-before-code-gate catch-22 + DRY patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.24.5] — 2026-04-11
+
+### Fixed
+- **spec-before-code-gate catch-22** (T434) — Gate blocked TODO.md edits but demanded TODO.md edits. Now exempts TODO.md, SESSION_STATE.md, CLAUDE.md, and specs/ paths.
+- **cat regex false positive** (T434) — `/\bcat\s+.*>/` matched read-only cat commands when path contained special chars. Tightened to `/\bcat\s+\S+\s+>/` requiring explicit redirect.
+- **Batch module test helper validation** (T435) — `_file-modify-patterns.js` exports array, not function. Test now accepts non-function helper exports.
+
+### Changed
+- **DRY FILE_MODIFY_PATTERNS** (T435) — Extracted duplicated regex array from commit-counter-gate.js and spec-before-code-gate.js into shared `_file-modify-patterns.js` helper.
+
 ## [2.24.4] — 2026-04-11
 
 ### Fixed

--- a/TODO.md
+++ b/TODO.md
@@ -1120,9 +1120,9 @@ Status:
 
 ## DRY & Gate Fixes (T434+)
 
-- [ ] T434: Fix spec-before-code-gate catch-22 — gate blocks TODO.md edits, but demands TODO.md edits. Exempt TODO.md/SESSION_STATE.md/spec files from the gate.
-- [ ] T435: DRY FILE_MODIFY_PATTERNS — duplicated in commit-counter-gate.js and spec-before-code-gate.js. Extract to shared helper.
-- [ ] T436: Code review pass + version bump
+- [x] T434: Fix spec-before-code-gate catch-22 + cat regex false positive — gate blocks TODO.md edits, but demands TODO.md edits. Exempt TODO.md/SESSION_STATE.md/spec files from the gate.
+- [x] T435: DRY FILE_MODIFY_PATTERNS — duplicated in commit-counter-gate.js and spec-before-code-gate.js. Extract to shared helper.
+- [x] T436: Version bump to 2.24.5 + CHANGELOG
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog

--- a/TODO.md
+++ b/TODO.md
@@ -1116,10 +1116,13 @@ What was done this session:
 - gh auth on default (joel-ginsberg_tmemu)
 
 Status:
-- 0 pending tasks
 - Version: 2.24.4
-- Project mature, all code review items addressed
-- Full test suite: 51 suites, 405 passed, 0 failed (modules suite timeout on Windows is known)
+
+## DRY & Gate Fixes (T434+)
+
+- [ ] T434: Fix spec-before-code-gate catch-22 — gate blocks TODO.md edits, but demands TODO.md edits. Exempt TODO.md/SESSION_STATE.md/spec files from the gate.
+- [ ] T435: DRY FILE_MODIFY_PATTERNS — duplicated in commit-counter-gate.js and spec-before-code-gate.js. Extract to shared helper.
+- [ ] T436: Code review pass + version bump
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog

--- a/modules/PreToolUse/_file-modify-patterns.js
+++ b/modules/PreToolUse/_file-modify-patterns.js
@@ -1,0 +1,16 @@
+// Shared helper: Bash patterns that indicate file modification.
+// Used by commit-counter-gate.js and spec-before-code-gate.js.
+// Underscore prefix = helper, not a module (skipped by load-modules.js).
+"use strict";
+
+module.exports = [
+  /\bsed\s+-i/,
+  /\bawk\s+-i/,
+  /\becho\s+.*>/,
+  /\bcat\s+\S+\s+>/,
+  /\btee\s/,
+  /\bpython[23]?\s+.*open\s*\(.*['"]\s*w/,
+  /\bprintf\s+.*>/,
+  /\bcp\s+/,
+  /\bmv\s+/
+];

--- a/modules/PreToolUse/commit-counter-gate.js
+++ b/modules/PreToolUse/commit-counter-gate.js
@@ -11,18 +11,8 @@ var os = require("os");
 var COUNTER_FILE = path.join(os.homedir(), ".claude", "hooks", ".uncommitted-edit-count");
 var MAX_EDITS = 5;
 
-// Patterns indicating file-modifying Bash commands (T360)
-var FILE_MODIFY_PATTERNS = [
-  /\bsed\s+-i/,
-  /\bawk\s+-i/,
-  /\becho\s+.*>/,
-  /\bcat\s+.*>/,
-  /\btee\s/,
-  /\bpython[23]?\s+.*open\s*\(.*['"]\s*w/,
-  /\bprintf\s+.*>/,
-  /\bcp\s+/,
-  /\bmv\s+/
-];
+// Patterns indicating file-modifying Bash commands (shared helper — DRY with spec-before-code-gate)
+var FILE_MODIFY_PATTERNS = require("./_file-modify-patterns");
 
 function readCounter() {
   try {

--- a/modules/PreToolUse/spec-before-code-gate.js
+++ b/modules/PreToolUse/spec-before-code-gate.js
@@ -10,16 +10,8 @@ var os = require("os");
 
 var STATE_FILE = path.join(os.homedir(), ".claude", "hooks", ".spec-before-code-state");
 
-// File-modifying Bash patterns (shared with commit-counter-gate)
-var FILE_MODIFY_PATTERNS = [
-  /\bsed\s+-i/,
-  /\bawk\s+-i/,
-  /\becho\s+.*>/,
-  /\bcat\s+\S+\s+>/,
-  /\btee\s/,
-  /\bpython[23]?\s+.*open\s*\(.*['"]\s*w/,
-  /\bprintf\s+.*>/
-];
+// File-modifying Bash patterns (shared helper — DRY with commit-counter-gate)
+var FILE_MODIFY_PATTERNS = require("./_file-modify-patterns");
 
 function readState() {
   try {

--- a/modules/PreToolUse/spec-before-code-gate.js
+++ b/modules/PreToolUse/spec-before-code-gate.js
@@ -15,7 +15,7 @@ var FILE_MODIFY_PATTERNS = [
   /\bsed\s+-i/,
   /\bawk\s+-i/,
   /\becho\s+.*>/,
-  /\bcat\s+.*>/,
+  /\bcat\s+\S+\s+>/,
   /\btee\s/,
   /\bpython[23]?\s+.*open\s*\(.*['"]\s*w/,
   /\bprintf\s+.*>/
@@ -70,6 +70,18 @@ module.exports = function(input) {
   if (input.tool_name === "Bash" && /git\s+commit/.test(cmd)) {
     writeState({ lastCommitTs: Date.now(), specChecked: false });
     return null;
+  }
+
+  // Exempt spec-related files — these ARE the spec, not code
+  if (input.tool_name === "Edit" || input.tool_name === "Write") {
+    var filePath = "";
+    try {
+      filePath = (typeof input.tool_input === "string" ? JSON.parse(input.tool_input) : input.tool_input || {}).file_path || "";
+    } catch(e) { filePath = (input.tool_input || {}).file_path || ""; }
+    var baseName = path.basename(filePath);
+    if (baseName === "TODO.md" || baseName === "SESSION_STATE.md" || baseName === "CLAUDE.md" || filePath.indexOf("/specs/") !== -1 || filePath.indexOf("\\specs\\") !== -1) {
+      return null;
+    }
   }
 
   // Only check on file modifications

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.24.4",
+  "version": "2.24.5",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"

--- a/scripts/test/_batch-module-test.js
+++ b/scripts/test/_batch-module-test.js
@@ -17,9 +17,10 @@ function testHelper(event, name, filePath) {
   try {
     delete require.cache[require.resolve(filePath)];
     var m = require(filePath);
-    if (typeof m !== "function") { failures.push(event + "/" + name + ": helper not a function"); return; }
-    // Call with a safe default arg — helpers typically take a single value (pid, path, etc.)
-    m(0);
+    // Helpers can export functions, arrays, or objects — just verify they load
+    if (m === null || m === undefined) { failures.push(event + "/" + name + ": helper exports nothing"); return; }
+    // If it's a function, call with a safe default arg
+    if (typeof m === "function") m(0);
   } catch(e) {
     failures.push(event + "/" + name + ": helper threw: " + e.message.split("\n")[0]);
   }


### PR DESCRIPTION
## Summary
- **T434**: Fix spec-before-code-gate catch-22 — gate blocked TODO.md edits but demanded TODO.md edits. Now exempts TODO.md, SESSION_STATE.md, CLAUDE.md, and specs/ paths. Also tightened `cat` regex to prevent false positives on read-only commands.
- **T435**: DRY FILE_MODIFY_PATTERNS — extracted duplicated regex array from commit-counter-gate.js and spec-before-code-gate.js into shared `_file-modify-patterns.js` helper.
- **T436**: Version bump to 2.24.5, CHANGELOG, batch test fix for array-exporting helpers.

## Test plan
- [x] spec-before-code-gate: TODO.md/SESSION_STATE.md/specs/ edits pass through
- [x] spec-before-code-gate: regular code edits still checked
- [x] cat without redirect not detected as file modification
- [x] cat with redirect still detected
- [x] commit-counter-gate: shared patterns work correctly
- [x] Batch module validation: 100/100 pass