### PR TITLE
T439: Stop-message.txt portability fix

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1148,7 +1148,7 @@ Status:
 
 ## Session Maintenance (2026-04-11i)
 
-- [ ] T439: Session maintenance — health check, log scan for incomplete tangents, code review pass, optimize if needed
+- [x] T439: Session maintenance — health 116/0/0, no incomplete tangents, stop-message.txt portability fix (hardcoded path → $CONTEXT_RESET_PY env var)
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog

--- a/TODO.md
+++ b/TODO.md
@@ -1116,15 +1116,39 @@ What was done this session:
 - gh auth on default (joel-ginsberg_tmemu)
 
 Status:
-- Version: 2.24.4
+- Version: 2.24.6
+- 0 pending tasks
 
 ## DRY & Gate Fixes (T434+)
 
-- [x] T434: Fix spec-before-code-gate catch-22 + cat regex false positive — gate blocks TODO.md edits, but demands TODO.md edits. Exempt TODO.md/SESSION_STATE.md/spec files from the gate.
-- [x] T435: DRY FILE_MODIFY_PATTERNS — duplicated in commit-counter-gate.js and spec-before-code-gate.js. Extract to shared helper.
-- [x] T436: Version bump to 2.24.5 + CHANGELOG
-- [x] T437: Fix health check false failure on _prefix helper files — setup.js healthCheck treats all .js as gate modules, fails on array-exporting helpers
-- [x] T438: Version bump to 2.24.6 + CHANGELOG
+- [x] T434: Fix spec-before-code-gate catch-22 + cat regex false positive (PR #325)
+- [x] T435: DRY FILE_MODIFY_PATTERNS into shared _file-modify-patterns.js helper (PR #325)
+- [x] T436: Version bump to 2.24.5 + CHANGELOG (PR #325)
+- [x] T437: Fix health check false failure on _prefix helper files (PR #326)
+- [x] T438: Version bump to 2.24.6 + CHANGELOG (PR #326)
+
+## Session Handoff (2026-04-11h)
+What was done this session:
+- T434 (PR #325): Fixed spec-before-code-gate catch-22 — exempts TODO.md/SESSION_STATE.md/CLAUDE.md/specs/ from gate. Tightened cat regex false positive.
+- T435 (PR #325): DRY FILE_MODIFY_PATTERNS into shared _file-modify-patterns.js helper
+- T437 (PR #326): Fixed health check false failure on _prefix helper files
+- T438 (PR #326): Version bump to 2.24.6
+- Updated GitHub repo description (100 modules, 5 workflows)
+- Marketplace synced to v2.24.6, live hooks synced
+- Code review: no hardcoded paths (except detection patterns in share-is-generic), no security issues, all execSync sanitized
+- gh auth on default (joel-ginsberg_tmemu)
+
+Status:
+- 0 pending tasks
+- Version: 2.24.6
+- Health: 116 OK, 0 warnings, 0 failures
+- Batch validation: 100/100 modules pass
+- Workflow audit: 98 modules, all matching YAML
+- Clean git on main
+
+## Session Maintenance (2026-04-11i)
+
+- [ ] T439: Session maintenance — health check, log scan for incomplete tangents, code review pass, optimize if needed
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog

--- a/modules/Stop/stop-message.txt
+++ b/modules/Stop/stop-message.txt
@@ -5,10 +5,12 @@ DO NOT STOP. DO NOT SUMMARIZE. DO NOT LIST OPTIONS. Follow this order:
 3) Organize, modularize, optimize, secure the project. Code review, DRY, clean up, harden.
 4) Zoom out: why does this project exist, how does it integrate, what real-world value comes next? How can we share it with the team — publish, document, demo, package? Write new tasks to TODO.md then EXECUTE. No breaks. No asking. Plan then do.
 
-If context is getting long, save state to $CLAUDE_PROJECT_DIR/TODO.md (always the launch directory, not cwd), then run: python C:/Users/joelg/Documents/ProjectsCL1/context-reset/context_reset.py --project-dir $CLAUDE_PROJECT_DIR
+If context is getting long, save state to $CLAUDE_PROJECT_DIR/TODO.md (always the launch directory, not cwd), then run context-reset if available:
+  python "$CONTEXT_RESET_PY" --project-dir $CLAUDE_PROJECT_DIR
+  (CONTEXT_RESET_PY defaults to ~/Documents/ProjectsCL1/_grobomo/context-reset/context_reset.py)
 To keep the old tab open for review: touch ~/.claude/.preserve-tab before running context_reset.py (one-shot, auto-deleted)
 
 CROSS-PROJECT WORK: If you created TODOs in another project's TODO.md, preserve this tab and open a new session for that project:
   touch ~/.claude/.preserve-tab
-  python C:/Users/joelg/Documents/ProjectsCL1/context-reset/context_reset.py --project-dir <OTHER_PROJECT_DIR>
+  python "$CONTEXT_RESET_PY" --project-dir <OTHER_PROJECT_DIR>
 This keeps the current tab for user review while a new Claude tab picks up the cross-project work.


### PR DESCRIPTION
## Summary
- Replace hardcoded context-reset.py path in stop-message.txt with `$CONTEXT_RESET_PY` env var
- Makes the auto-continue stop message portable for other users who install hook-runner

## Test plan
- [x] Batch module validation: 100/100 pass
- [x] Health check: 116/0/0
- [x] Live hooks synced