### PR TITLE
T440: Add block examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,28 @@ node setup.js --workflow enable shtd    # 90 modules: spec-first, test-first, PR
 
 To undo everything: `node setup.js --uninstall --confirm`
 
+## What does a block look like?
+
+When Claude tries something a module blocks, the hook fires and Claude sees the block reason inline. Two examples from the `starter` workflow:
+
+**Force push blocked:**
+```
+BLOCKED: Force-push to main is destructive and irreversible.
+Use a regular push or create a revert commit instead.
+```
+
+**Destructive git command blocked:**
+```
+DESTRUCTIVE: git reset --hard destroys uncommitted changes permanently.
+Alternatives:
+  git stash        — save changes for later
+  git reset --soft — move HEAD but keep changes staged
+  git checkout <file> — revert specific files only
+If you truly need --hard, ask the user first.
+```
+
+Claude reads the block message and adjusts its approach — no user intervention needed. Modules that pass return `null` silently, so there's zero overhead on normal operations.
+
 ## Workflows
 
 Workflows are the primary abstraction. Instead of managing 80+ individual modules, you enable a workflow and its modules activate automatically.

--- a/TODO.md
+++ b/TODO.md
@@ -1149,6 +1149,7 @@ Status:
 ## Session Maintenance (2026-04-11i)
 
 - [x] T439: Session maintenance — health 116/0/0, no incomplete tangents, stop-message.txt portability fix (hardcoded path → $CONTEXT_RESET_PY env var)
+- [ ] T440: Add "What does a block look like?" example to README — shows concrete gate output so new users understand the value instantly
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog

--- a/TODO.md
+++ b/TODO.md
@@ -1149,7 +1149,7 @@ Status:
 ## Session Maintenance (2026-04-11i)
 
 - [x] T439: Session maintenance — health 116/0/0, no incomplete tangents, stop-message.txt portability fix (hardcoded path → $CONTEXT_RESET_PY env var)
-- [ ] T440: Add "What does a block look like?" example to README — shows concrete gate output so new users understand the value instantly
+- [x] T440: Add "What does a block look like?" example to README — force-push and git-destructive-guard examples (PR #328)
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog


### PR DESCRIPTION
## Summary
- Add "What does a block look like?" section to README after Quick Start
- Shows concrete force-push and git-destructive-guard block output
- Helps new users understand the value before installing

## Test plan
- [x] Block messages verified against actual module output
- [x] README renders correctly in markdown