### PR TITLE
T369-T370: Victory-declaration and unresolved-issues commit gates

### DIFF
--- a/modules/PreToolUse/unresolved-issues-gate.js
+++ b/modules/PreToolUse/unresolved-issues-gate.js
@@ -1,0 +1,105 @@
+// WORKFLOW: shtd
+// WHY: Claude commits code while TODO.md or report data still has unresolved FAIL, timeout,
+// MISMATCH, or WARN entries. Bugs ship because the commit focused on what worked and skipped
+// what didn't. Scanning TODO.md before commit catches overlooked issues.
+"use strict";
+
+var fs = require("fs");
+var path = require("path");
+
+var ISSUE_PATTERNS = [
+  /\bFAIL\b/,
+  /\btimeout\b/i,
+  /\bMISMATCH\b/,
+  /\bWARN(?:ING)?\b/,
+  /\bERROR\b/,
+  /\bBROKEN\b/i,
+  /\bcrash(?:ed|es|ing)?\b/i
+];
+
+// Contexts where issue words are expected (completed tasks, descriptions of what was fixed)
+var FALSE_POSITIVE_PATTERNS = [
+  /- \[x\].*\bFAIL/i,        // completed task mentioning FAIL
+  /\bfix(?:ed|es|ing)?\b.*\bFAIL/i,  // "fixed the FAIL"
+  /\b0\s+fail/i,             // "0 failed"
+  /\b0\s+FAIL/,              // "0 FAIL"
+  /passed,\s*0\s+failed/i,   // "405 passed, 0 failed"
+  /\bno\s+fail/i,            // "no failures"
+  /FAIL\/WARN/               // meta-references like "scan for FAIL/WARN"
+];
+
+module.exports = function(input) {
+  if (input.tool_name !== "Bash") return null;
+
+  var cmd = "";
+  try {
+    cmd = (typeof input.tool_input === "string" ? JSON.parse(input.tool_input) : input.tool_input || {}).command || "";
+  } catch(e) { cmd = (input.tool_input || {}).command || ""; }
+
+  if (!/git\s+commit/.test(cmd)) return null;
+
+  // Find project root (look for .git)
+  var projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+  var todoPath = path.join(projectDir, "TODO.md");
+
+  if (!fs.existsSync(todoPath)) return null;
+
+  var content = "";
+  try { content = fs.readFileSync(todoPath, "utf-8"); } catch(e) { return null; }
+
+  // Scan for unchecked tasks with issue keywords
+  var lines = content.split("\n");
+  var issues = [];
+
+  for (var i = 0; i < lines.length; i++) {
+    var line = lines[i];
+
+    // Skip completed tasks
+    if (/- \[x\]/.test(line)) continue;
+    // Skip lines that are clearly meta-references
+    var isFP = false;
+    for (var f = 0; f < FALSE_POSITIVE_PATTERNS.length; f++) {
+      if (FALSE_POSITIVE_PATTERNS[f].test(line)) { isFP = true; break; }
+    }
+    if (isFP) continue;
+
+    // Check for issue patterns in unchecked tasks or status lines
+    for (var p = 0; p < ISSUE_PATTERNS.length; p++) {
+      if (ISSUE_PATTERNS[p].test(line)) {
+        // Only flag lines that look like task items or status entries
+        if (/^\s*-\s*\[ \]/.test(line) || /^\s*-\s/.test(line) || /Status:|TESTING|IN PROGRESS/i.test(line)) {
+          issues.push("  L" + (i + 1) + ": " + line.trim().substring(0, 120));
+          break;
+        }
+      }
+    }
+  }
+
+  if (issues.length === 0) return null;
+
+  // Check if commit message already references the issues
+  var msg = "";
+  var heredocMatch = cmd.match(/\-m\s+"\$\(cat\s+<<'?EOF'?\s*\n([\s\S]*?)\nEOF/);
+  if (heredocMatch) {
+    msg = heredocMatch[1].trim();
+  } else {
+    var mMatch = cmd.match(/\-m\s+["']([^"']+)["']/);
+    if (mMatch) msg = mMatch[1].trim();
+  }
+
+  // If commit message acknowledges the issues (mentions FAIL, known, etc.), allow
+  if (msg && /\b(known|pre-existing|intermittent|expected|acknowledged|wontfix)\b/i.test(msg)) {
+    return null;
+  }
+
+  return {
+    decision: "block",
+    reason: "UNRESOLVED ISSUES in TODO.md (" + issues.length + " found):\n\n" +
+      issues.slice(0, 8).join("\n") +
+      (issues.length > 8 ? "\n  ... and " + (issues.length - 8) + " more" : "") +
+      "\n\nBefore committing:\n" +
+      "  1. Address each issue (fix it, file a plan, or mark as known)\n" +
+      "  2. Update TODO.md with the resolution\n" +
+      "  3. Or add 'known'/'pre-existing'/'intermittent' to commit message to acknowledge"
+  };
+};

--- a/modules/PreToolUse/victory-declaration-gate.js
+++ b/modules/PreToolUse/victory-declaration-gate.js
@@ -1,0 +1,53 @@
+// WORKFLOW: shtd, starter
+// WHY: Claude declares victory prematurely — "all tests pass", "complete", "all green" in
+// commit messages when failures were skipped, warnings ignored, or outputs not reviewed.
+// This cost hours in E2E cycles where bugs shipped because the commit message said "done".
+"use strict";
+
+var VICTORY_WORDS = /\b(all\s+(tests?\s+)?pass(ed|ing|es)?|all\s+green|succeeded|fully\s+working|complete[ds]?\s+(successfully)?|100%|zero\s+fail)/i;
+
+module.exports = function(input) {
+  if (input.tool_name !== "Bash") return null;
+
+  var cmd = "";
+  try {
+    cmd = (typeof input.tool_input === "string" ? JSON.parse(input.tool_input) : input.tool_input || {}).command || "";
+  } catch(e) { cmd = (input.tool_input || {}).command || ""; }
+
+  // Only gate git commit commands
+  if (!/git\s+commit/.test(cmd)) return null;
+
+  // Extract commit message (heredoc or simple -m)
+  var msg = "";
+  var heredocMatch = cmd.match(/\-m\s+"\$\(cat\s+<<'?EOF'?\s*\n([\s\S]*?)\nEOF/);
+  if (heredocMatch) {
+    msg = heredocMatch[1].trim();
+  } else {
+    var mMatch = cmd.match(/\-m\s+["']([^"']+)["']/);
+    if (mMatch) msg = mMatch[1].trim();
+  }
+
+  if (!msg) return null;
+
+  // Only check the title (first line) — body may quote victory words in descriptions
+  var title = msg.split("\n")[0];
+
+  // Check for victory declarations in the title only
+  if (!VICTORY_WORDS.test(title)) return null;
+
+  // Block — force specifics instead of vague success claims
+  return {
+    decision: "block",
+    reason: "VICTORY DECLARATION in commit message.\n\n" +
+      "Your message claims success: \"" + msg.substring(0, 120) + "\"\n\n" +
+      "Before committing, verify:\n" +
+      "  1. Did you review EVERY failure, warning, and timeout in the output?\n" +
+      "  2. Did you check for empty/missing outputs that should have content?\n" +
+      "  3. Did you look at what's NOT in the results that should be?\n" +
+      "  4. Are there unresolved FAIL/WARN/MISMATCH in TODO.md?\n\n" +
+      "Rephrase with specifics:\n" +
+      "  BAD:  \"All tests pass\"\n" +
+      "  GOOD: \"T442: Fix testbox gate — 17/17 tests pass, synced to live\"\n\n" +
+      "Include the count, the scope, and what was tested."
+  };
+};

--- a/scripts/test/test-T369-victory-gate.js
+++ b/scripts/test/test-T369-victory-gate.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+"use strict";
+// Test suite for victory-declaration-gate module (T369)
+
+var path = require("path");
+var MOD = path.join(__dirname, "../../modules/PreToolUse/victory-declaration-gate.js");
+
+var pass = 0, fail = 0;
+function assert(name, ok) {
+  if (ok) { console.log("  PASS: " + name); pass++; }
+  else { console.log("  FAIL: " + name); fail++; }
+}
+
+var gate = require(MOD);
+
+console.log("=== hook-runner: victory-declaration-gate (T369) ===");
+
+// 1. Non-Bash tool passes
+assert("non-Bash passes", gate({ tool_name: "Edit", tool_input: {} }) === null);
+
+// 2. Non-commit bash passes
+assert("non-commit bash passes", gate({ tool_name: "Bash", tool_input: { command: "echo hello" } }) === null);
+
+// 3. Specific commit message passes
+var r3 = gate({ tool_name: "Bash", tool_input: { command: 'git commit -m "T442: Fix testbox gate — 17/17 tests pass, synced to live"' } });
+assert("specific message with count passes", r3 === null);
+
+// 4. "All tests pass" blocks
+var r4 = gate({ tool_name: "Bash", tool_input: { command: 'git commit -m "All tests pass"' } });
+assert("all tests pass blocks", r4 && r4.decision === "block");
+
+// 5. "all green" blocks
+var r5 = gate({ tool_name: "Bash", tool_input: { command: 'git commit -m "Everything is all green now"' } });
+assert("all green blocks", r5 && r5.decision === "block");
+
+// 6. "completed successfully" blocks
+var r6 = gate({ tool_name: "Bash", tool_input: { command: 'git commit -m "Task completed successfully"' } });
+assert("completed successfully blocks", r6 && r6.decision === "block");
+
+// 7. "100%" blocks
+var r7 = gate({ tool_name: "Bash", tool_input: { command: 'git commit -m "100% coverage achieved"' } });
+assert("100% blocks", r7 && r7.decision === "block");
+
+// 8. "zero failures" blocks
+var r8 = gate({ tool_name: "Bash", tool_input: { command: 'git commit -m "Deploy with zero failures"' } });
+assert("zero failures blocks", r8 && r8.decision === "block");
+
+// 9. Normal descriptive message passes
+var r9 = gate({ tool_name: "Bash", tool_input: { command: 'git commit -m "T370: Add unresolved-issues-gate module with 12 test cases"' } });
+assert("normal descriptive message passes", r9 === null);
+
+// 10. "succeeded" blocks
+var r10 = gate({ tool_name: "Bash", tool_input: { command: 'git commit -m "Deploy succeeded"' } });
+assert("succeeded blocks", r10 && r10.decision === "block");
+
+// 11. Heredoc message with victory words blocks
+var heredocCmd = 'git commit -m "$(cat <<\'EOF\'\nAll tests passed and everything works\nEOF\n)"';
+var r11 = gate({ tool_name: "Bash", tool_input: { command: heredocCmd } });
+assert("heredoc victory blocks", r11 && r11.decision === "block");
+
+// 12. Block message includes guidance
+assert("block has verification checklist", r4.reason.indexOf("verify") !== -1 || r4.reason.indexOf("VERIFY") !== -1 || r4.reason.indexOf("Verify") !== -1);
+assert("block has rephrase guidance", r4.reason.indexOf("Rephrase") !== -1 || r4.reason.indexOf("GOOD") !== -1);
+
+// 14. Victory words in body (not title) should pass — body may describe/quote them
+var bodyCmd = 'git commit -m "$(cat <<\'EOF\'\nT369: Add victory-declaration gate\n\nBlocks messages like all tests pass or all green in the title line.\nEOF\n)"';
+var r14 = gate({ tool_name: "Bash", tool_input: { command: bodyCmd } });
+assert("victory words in body only passes", r14 === null);
+
+// 15. Victory words in title of heredoc still blocks
+var titleVictoryCmd = 'git commit -m "$(cat <<\'EOF\'\nAll tests pass — ship it\n\nDetails here.\nEOF\n)"';
+var r15 = gate({ tool_name: "Bash", tool_input: { command: titleVictoryCmd } });
+assert("victory words in heredoc title blocks", r15 && r15.decision === "block");
+
+console.log("\n" + pass + "/" + (pass + fail) + " passed");
+process.exit(fail > 0 ? 1 : 0);

--- a/scripts/test/test-T370-unresolved-issues-gate.js
+++ b/scripts/test/test-T370-unresolved-issues-gate.js
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+"use strict";
+// Test suite for unresolved-issues-gate module (T370)
+
+var path = require("path");
+var fs = require("fs");
+var os = require("os");
+var MOD = path.join(__dirname, "../../modules/PreToolUse/unresolved-issues-gate.js");
+
+var pass = 0, fail = 0;
+function assert(name, ok) {
+  if (ok) { console.log("  PASS: " + name); pass++; }
+  else { console.log("  FAIL: " + name); fail++; }
+}
+
+// Create temp project dirs with various TODO.md states
+var tmpBase = path.join(os.tmpdir(), "hook-runner-test-T370-" + Date.now());
+fs.mkdirSync(tmpBase, { recursive: true });
+
+function setupProject(name, todoContent) {
+  var dir = path.join(tmpBase, name);
+  fs.mkdirSync(dir, { recursive: true });
+  if (todoContent !== null) {
+    fs.writeFileSync(path.join(dir, "TODO.md"), todoContent, "utf-8");
+  }
+  return dir;
+}
+
+// Helper to run gate with a specific project dir
+function runGate(projectDir, commitMsg) {
+  var origDir = process.env.CLAUDE_PROJECT_DIR;
+  process.env.CLAUDE_PROJECT_DIR = projectDir;
+
+  // Clear module cache so it re-reads TODO.md
+  delete require.cache[require.resolve(MOD)];
+  var gate = require(MOD);
+
+  var cmd = commitMsg
+    ? 'git commit -m "' + commitMsg + '"'
+    : 'git commit -m "Fix something specific here"';
+
+  var result = gate({ tool_name: "Bash", tool_input: { command: cmd } });
+  process.env.CLAUDE_PROJECT_DIR = origDir || "";
+  return result;
+}
+
+console.log("=== hook-runner: unresolved-issues-gate (T370) ===");
+
+// 1. Non-Bash passes
+delete require.cache[require.resolve(MOD)];
+var gate = require(MOD);
+assert("non-Bash passes", gate({ tool_name: "Edit", tool_input: {} }) === null);
+
+// 2. Non-commit bash passes
+assert("non-commit passes", gate({ tool_name: "Bash", tool_input: { command: "echo hello" } }) === null);
+
+// 3. Clean TODO.md passes
+var cleanDir = setupProject("clean", "# TODO\n- [x] T1: Done task\n- [x] T2: Another done\n");
+assert("clean TODO passes", runGate(cleanDir) === null);
+
+// 4. No TODO.md passes
+var noTodoDir = setupProject("no-todo", null);
+assert("no TODO.md passes", runGate(noTodoDir) === null);
+
+// 5. Unchecked task with FAIL blocks
+var failDir = setupProject("has-fail", "# TODO\n- [ ] T99: FAIL in brain-bridge test suite\n");
+var r5 = runGate(failDir);
+assert("unchecked FAIL blocks", r5 && r5.decision === "block");
+
+// 6. Unchecked task with timeout blocks
+var timeoutDir = setupProject("has-timeout", "# TODO\n- [ ] T100: Fix timeout in deploy script\n");
+var r6 = runGate(timeoutDir);
+assert("unchecked timeout blocks", r6 && r6.decision === "block");
+
+// 7. Unchecked task with MISMATCH blocks
+var mismatchDir = setupProject("has-mismatch", "# TODO\n- [ ] T101: MISMATCH between live and repo\n");
+var r7 = runGate(mismatchDir);
+assert("unchecked MISMATCH blocks", r7 && r7.decision === "block");
+
+// 8. Completed task with FAIL does NOT block (false positive protection)
+var completedFailDir = setupProject("completed-fail", "# TODO\n- [x] T102: Fixed the FAIL in module test\n");
+assert("completed FAIL task passes", runGate(completedFailDir) === null);
+
+// 9. "0 failed" does NOT block (false positive)
+var zeroFailDir = setupProject("zero-fail", "# TODO\n- 51 suites, 405 passed, 0 failed\n");
+assert("0 failed passes (false positive)", runGate(zeroFailDir) === null);
+
+// 10. Commit message with "known" acknowledges issues — passes
+var knownDir = setupProject("known-issues", "# TODO\n- [ ] T103: FAIL in intermittent brain test\n");
+var r10 = runGate(knownDir, "T103: Ship with known intermittent brain-bridge failure");
+assert("known in commit message passes", r10 === null);
+
+// 11. Commit message with "pre-existing" passes
+var r11 = runGate(knownDir, "T104: Fix gate — pre-existing brain failure unchanged");
+assert("pre-existing in commit message passes", r11 === null);
+
+// 12. Block message includes line numbers
+assert("block has line numbers", r5.reason.indexOf("L") !== -1);
+
+// 13. Block message includes guidance
+assert("block has resolution guidance", r5.reason.indexOf("Address") !== -1 || r5.reason.indexOf("fix") !== -1);
+
+// 14. WARNING pattern blocks
+var warnDir = setupProject("has-warn", "# TODO\n- [ ] T105: WARNING: disk space low during deploy\n");
+var r14 = runGate(warnDir);
+assert("unchecked WARNING blocks", r14 && r14.decision === "block");
+
+// 15. ERROR pattern blocks
+var errorDir = setupProject("has-error", "# TODO\n- [ ] T106: ERROR in health check output\n");
+var r15 = runGate(errorDir);
+assert("unchecked ERROR blocks", r15 && r15.decision === "block");
+
+// Cleanup
+try { fs.rmSync(tmpBase, { recursive: true, force: true }); } catch(e) {}
+
+console.log("\n" + pass + "/" + (pass + fail) + " passed");
+process.exit(fail > 0 ? 1 : 0);

--- a/workflows/shtd.yml
+++ b/workflows/shtd.yml
@@ -60,6 +60,8 @@ modules:
   - remote-tracking-gate
   - commit-counter-gate
   - commit-quality-gate
+  - unresolved-issues-gate
+  - victory-declaration-gate
   - deploy-gate
   - deploy-history-reminder
   - secret-scan-gate

--- a/workflows/starter.yml
+++ b/workflows/starter.yml
@@ -15,6 +15,7 @@ modules:
   - git-destructive-guard
   - secret-scan-gate
   - commit-quality-gate
+  - victory-declaration-gate
   # File safety — prevent accidental deletion
   - archive-not-delete
   # Code quality — catch common issues


### PR DESCRIPTION
## Summary
- **T369**: `victory-declaration-gate.js` — blocks vague title-line claims ("all tests pass", "all green", "100%", "succeeded") in commit messages. Only checks the title line so body text can quote these phrases. Forces specific counts and scope. 15/15 tests. Added to shtd + starter workflows.
- **T370**: `unresolved-issues-gate.js` — scans TODO.md for unchecked tasks with FAIL/timeout/MISMATCH/WARN/ERROR. False-positive protection for completed tasks and "0 failed" lines. Commits can acknowledge known issues via "known"/"pre-existing"/"intermittent" in the message. 15/15 tests. Added to shtd workflow.

## Test plan
- [x] `node scripts/test/test-T369-victory-gate.js` — 15/15
- [x] `node scripts/test/test-T370-unresolved-issues-gate.js` — 15/15
- [x] Synced to live hooks, confirmed gate fires correctly
- [ ] Known issue: unresolved-issues-gate matches plain bullet points (not just `- [ ]` tasks) — will fix in follow-up branch