### PR TITLE
T371-T372: Empty-output detector + stop-check + unresolved-issues FP fix

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1001,9 +1001,9 @@ Root cause: Claude optimizes for "task complete" status. Once it sees mostly-gre
 
 - [ ] T368: **Result review gate** — PostToolUse module on Read (PDF/report files). When Claude reads a test report or PDF, inject a checklist reminder: "Before committing results: 1) List every FAIL/WARN/timeout/error/empty in this report. 2) For each: is it a real bug, expected behavior, or needs investigation? Justify. 3) File a TODO for each unresolved issue. 4) Only then commit." Non-blocking advisory but highly visible. Must fire EVERY time a report is read, not just first time.
 
-- [ ] T369: **Victory-declaration detector** — PreToolUse on Bash (git commit). When commit message contains "PASS", "succeeded", "all green", "complete", "done", "all tests" — inject advisory: "You're declaring success. Did you: review every failure? check for empty/missing outputs? investigate warnings? look at what's NOT in the results that should be? If not, fix issues first." Catches premature victory laps.
+- [x] T369: **Victory-declaration detector** — `victory-declaration-gate.js`. Blocks title-line claims like "all tests pass", "all green", "succeeded", "100%". Only checks title so body can quote phrases. 15/15 tests. shtd + starter.
 
-- [ ] T370: **FAIL/error scan before commit** — PreToolUse on Bash (git commit). Scan the TODO.md and any .report-data.json in the project for unresolved FAIL, timeout, error, WARN, MISMATCH. If found and the commit message doesn't reference them, block with: "Unresolved issues in project: [list]. Address each in TODO with a specific plan, or explain in commit message why they're acceptable."
+- [x] T370: **FAIL/error scan before commit** — `unresolved-issues-gate.js`. Scans TODO.md for unchecked FAIL/timeout/MISMATCH/WARN/ERROR. FP protection for completed tasks, "0 failed". Acknowledges "known"/"pre-existing"/"intermittent". 15/15 tests. shtd.
 
 - [ ] T371: **Empty-output detector** — PostToolUse module. When a Bash command returns empty stdout where content was expected (e.g., `ls` on screenshots/, `check-file` returning blank), inject warning: "Empty output where content was expected. This likely means something failed silently. Investigate before proceeding." Heuristic: detect common dir-listing patterns followed by empty output.
 

--- a/modules/PostToolUse/empty-output-detector.js
+++ b/modules/PostToolUse/empty-output-detector.js
@@ -1,0 +1,65 @@
+// WORKFLOW: shtd
+// WHY: Claude treats empty command output as success — e.g., `ls screenshots/` returning
+// nothing means no screenshots exist, but Claude proceeds as if they do. Empty output
+// from directory listings, file checks, and query commands often means silent failure.
+"use strict";
+
+// Commands where empty output likely means a problem
+var EXPECT_OUTPUT = [
+  /^\s*ls\b/,
+  /^\s*find\b/,
+  /^\s*cat\b/,
+  /^\s*node\s+.*--test/,
+  /^\s*node\s+setup\.js\s+--/,
+  /^\s*curl\b/,
+  /^\s*az\s/,
+  /^\s*kubectl\s+(get|describe|logs)\b/
+];
+
+// Commands where empty output is normal
+var EMPTY_OK = [
+  /^\s*(cp|mv|mkdir|rm|chmod|touch|cd)\b/,
+  /^\s*git\s+(add|checkout|push|pull|fetch|merge)\b/,
+  />/,           // redirects
+  /2>&1\s*$/,    // stderr redirect at end (might be piped)
+  /\|\s*wc\b/    // piped to wc (will have output)
+];
+
+module.exports = function(input) {
+  if (input.tool_name !== "Bash") return null;
+
+  var cmd = "";
+  try {
+    cmd = (typeof input.tool_input === "string" ? JSON.parse(input.tool_input) : input.tool_input || {}).command || "";
+  } catch(e) { cmd = (input.tool_input || {}).command || ""; }
+
+  // Check if output is empty/whitespace-only
+  var output = (input.tool_result || "").toString().trim();
+  if (output.length > 0) return null;
+
+  // Skip commands where empty output is expected
+  for (var e = 0; e < EMPTY_OK.length; e++) {
+    if (EMPTY_OK[e].test(cmd)) return null;
+  }
+
+  // Check if this command normally produces output
+  var expectsOutput = false;
+  for (var i = 0; i < EXPECT_OUTPUT.length; i++) {
+    if (EXPECT_OUTPUT[i].test(cmd)) { expectsOutput = true; break; }
+  }
+
+  if (!expectsOutput) return null;
+
+  // Non-blocking advisory
+  return {
+    decision: "block",
+    reason: "EMPTY OUTPUT from command that normally produces output.\n\n" +
+      "Command: " + cmd.substring(0, 150) + "\n\n" +
+      "This likely means:\n" +
+      "  - Directory is empty (no files where expected)\n" +
+      "  - File doesn't exist at that path\n" +
+      "  - Query returned no results\n" +
+      "  - Command failed silently\n\n" +
+      "Investigate before proceeding. Do not assume empty = success."
+  };
+};

--- a/modules/PreToolUse/unresolved-issues-gate.js
+++ b/modules/PreToolUse/unresolved-issues-gate.js
@@ -66,8 +66,8 @@ module.exports = function(input) {
     // Check for issue patterns in unchecked tasks or status lines
     for (var p = 0; p < ISSUE_PATTERNS.length; p++) {
       if (ISSUE_PATTERNS[p].test(line)) {
-        // Only flag lines that look like task items or status entries
-        if (/^\s*-\s*\[ \]/.test(line) || /^\s*-\s/.test(line) || /Status:|TESTING|IN PROGRESS/i.test(line)) {
+        // Only flag unchecked task items or explicit status markers
+        if (/^\s*-\s*\[ \]/.test(line) || /Status:|TESTING|IN PROGRESS/i.test(line)) {
           issues.push("  L" + (i + 1) + ": " + line.trim().substring(0, 120));
           break;
         }

--- a/modules/Stop/unresolved-issues-check.js
+++ b/modules/Stop/unresolved-issues-check.js
@@ -1,0 +1,66 @@
+// WORKFLOW: shtd
+// WHY: Claude ends sessions with tasks still marked "TESTING NOW" or "IN PROGRESS"
+// in TODO.md, or with FAIL/WARN/timeout mentioned but never resolved.
+// Next session starts with stale state and wastes time rediscovering issues.
+"use strict";
+
+var fs = require("fs");
+var path = require("path");
+
+var STALE_MARKERS = /\b(TESTING NOW|IN PROGRESS|INVESTIGATING|DEBUGGING|WIP)\b/i;
+var ISSUE_WORDS = /\b(FAIL|MISMATCH|BROKEN|crash(ed|es|ing)?)\b/;
+
+module.exports = function(input) {
+  var projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+  var todoPath = path.join(projectDir, "TODO.md");
+
+  if (!fs.existsSync(todoPath)) return null;
+
+  var content = "";
+  try { content = fs.readFileSync(todoPath, "utf-8"); } catch(e) { return null; }
+
+  var lines = content.split("\n");
+  var staleItems = [];
+  var unresolvedIssues = [];
+
+  for (var i = 0; i < lines.length; i++) {
+    var line = lines[i];
+    // Skip completed tasks
+    if (/- \[x\]/.test(line)) continue;
+    // Only check unchecked task items
+    if (!/^\s*-\s*\[ \]/.test(line)) continue;
+
+    // Check for stale progress markers
+    if (STALE_MARKERS.test(line)) {
+      staleItems.push("  L" + (i + 1) + ": " + line.trim().substring(0, 100));
+    }
+
+    // Check for unresolved issue words
+    if (ISSUE_WORDS.test(line)) {
+      // Skip task descriptions that define gates/detectors (they mention these words by design)
+      if (/gate|detector|scan|module|check/i.test(line)) continue;
+      unresolvedIssues.push("  L" + (i + 1) + ": " + line.trim().substring(0, 100));
+    }
+  }
+
+  if (staleItems.length === 0 && unresolvedIssues.length === 0) return null;
+
+  var msg = "UNRESOLVED SESSION STATE in TODO.md:\n\n";
+
+  if (staleItems.length > 0) {
+    msg += "Stale progress markers (update to done or blocked):\n";
+    msg += staleItems.slice(0, 5).join("\n") + "\n\n";
+  }
+
+  if (unresolvedIssues.length > 0) {
+    msg += "Unresolved issues (fix, file a plan, or mark complete):\n";
+    msg += unresolvedIssues.slice(0, 5).join("\n") + "\n\n";
+  }
+
+  msg += "Update TODO.md with actual outcomes before ending the session.";
+
+  return {
+    decision: "block",
+    reason: msg
+  };
+};

--- a/scripts/test/test-T370-unresolved-issues-gate.js
+++ b/scripts/test/test-T370-unresolved-issues-gate.js
@@ -110,6 +110,16 @@ var errorDir = setupProject("has-error", "# TODO\n- [ ] T106: ERROR in health ch
 var r15 = runGate(errorDir);
 assert("unchecked ERROR blocks", r15 && r15.decision === "block");
 
+// 16. Plain bullet with issue word passes (not a task checkbox)
+var bulletDir = setupProject("plain-bullet", "# Session Log\n- CI has pre-existing failures in T094\n- FAIL was fixed in commit abc123\n");
+var r16 = runGate(bulletDir);
+assert("plain bullet with FAIL passes (not a task)", r16 === null);
+
+// 17. Session notes with crash/timeout pass
+var notesDir = setupProject("session-notes", "# Notes\n- timeout increased to 360s per suite\n- crash in brain-bridge was intermittent\n");
+var r17 = runGate(notesDir);
+assert("session notes with issue words pass", r17 === null);
+
 // Cleanup
 try { fs.rmSync(tmpBase, { recursive: true, force: true }); } catch(e) {}
 

--- a/scripts/test/test-T371-empty-output-detector.js
+++ b/scripts/test/test-T371-empty-output-detector.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+"use strict";
+// Test suite for empty-output-detector module (T371)
+
+var path = require("path");
+var MOD = path.join(__dirname, "../../modules/PostToolUse/empty-output-detector.js");
+
+var pass = 0, fail = 0;
+function assert(name, ok) {
+  if (ok) { console.log("  PASS: " + name); pass++; }
+  else { console.log("  FAIL: " + name); fail++; }
+}
+
+var gate = require(MOD);
+
+console.log("=== hook-runner: empty-output-detector (T371) ===");
+
+// 1. Non-Bash passes
+assert("non-Bash passes", gate({ tool_name: "Edit", tool_input: {} }) === null);
+
+// 2. Bash with output passes
+assert("bash with output passes", gate({ tool_name: "Bash", tool_input: { command: "ls ." }, tool_result: "file1.js\nfile2.js" }) === null);
+
+// 3. ls with empty output blocks
+var r3 = gate({ tool_name: "Bash", tool_input: { command: "ls screenshots/" }, tool_result: "" });
+assert("ls empty blocks", r3 && r3.decision === "block");
+
+// 4. cat with empty output blocks
+var r4 = gate({ tool_name: "Bash", tool_input: { command: "cat config.json" }, tool_result: "" });
+assert("cat empty blocks", r4 && r4.decision === "block");
+
+// 5. find with empty output blocks
+var r5 = gate({ tool_name: "Bash", tool_input: { command: "find . -name '*.test.js'" }, tool_result: "" });
+assert("find empty blocks", r5 && r5.decision === "block");
+
+// 6. cp with empty output passes (empty is normal)
+assert("cp empty passes", gate({ tool_name: "Bash", tool_input: { command: "cp a.js b.js" }, tool_result: "" }) === null);
+
+// 7. mkdir with empty output passes
+assert("mkdir empty passes", gate({ tool_name: "Bash", tool_input: { command: "mkdir -p dist/" }, tool_result: "" }) === null);
+
+// 8. git add with empty output passes
+assert("git add empty passes", gate({ tool_name: "Bash", tool_input: { command: "git add ." }, tool_result: "" }) === null);
+
+// 9. curl with empty output blocks
+var r9 = gate({ tool_name: "Bash", tool_input: { command: "curl http://localhost:8080/health" }, tool_result: "" });
+assert("curl empty blocks", r9 && r9.decision === "block");
+
+// 10. kubectl get with empty output blocks
+var r10 = gate({ tool_name: "Bash", tool_input: { command: "kubectl get pods -n test" }, tool_result: "" });
+assert("kubectl get empty blocks", r10 && r10.decision === "block");
+
+// 11. echo (not in expect-output list) passes even when empty
+assert("echo empty passes", gate({ tool_name: "Bash", tool_input: { command: "echo" }, tool_result: "" }) === null);
+
+// 12. Block message mentions investigation
+assert("block mentions investigate", r3.reason.indexOf("Investigate") !== -1);
+
+// 13. Whitespace-only output treated as empty
+var r13 = gate({ tool_name: "Bash", tool_input: { command: "ls empty-dir/" }, tool_result: "   \n  " });
+assert("whitespace-only treated as empty", r13 && r13.decision === "block");
+
+// 14. node setup.js --test with empty blocks
+var r14 = gate({ tool_name: "Bash", tool_input: { command: "node setup.js --health" }, tool_result: "" });
+assert("node setup.js --health empty blocks", r14 && r14.decision === "block");
+
+// 15. az command with empty blocks
+var r15 = gate({ tool_name: "Bash", tool_input: { command: "az vm list" }, tool_result: "" });
+assert("az command empty blocks", r15 && r15.decision === "block");
+
+console.log("\n" + pass + "/" + (pass + fail) + " passed");
+process.exit(fail > 0 ? 1 : 0);

--- a/scripts/test/test-T372-unresolved-issues-check.js
+++ b/scripts/test/test-T372-unresolved-issues-check.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+"use strict";
+// Test suite for unresolved-issues-check Stop module (T372)
+
+var path = require("path");
+var fs = require("fs");
+var os = require("os");
+var MOD = path.join(__dirname, "../../modules/Stop/unresolved-issues-check.js");
+
+var pass = 0, fail = 0;
+function assert(name, ok) {
+  if (ok) { console.log("  PASS: " + name); pass++; }
+  else { console.log("  FAIL: " + name); fail++; }
+}
+
+var tmpBase = path.join(os.tmpdir(), "hook-runner-test-T372-" + Date.now());
+fs.mkdirSync(tmpBase, { recursive: true });
+
+function setupProject(name, todoContent) {
+  var dir = path.join(tmpBase, name);
+  fs.mkdirSync(dir, { recursive: true });
+  if (todoContent !== null) {
+    fs.writeFileSync(path.join(dir, "TODO.md"), todoContent, "utf-8");
+  }
+  return dir;
+}
+
+function runGate(projectDir) {
+  var origDir = process.env.CLAUDE_PROJECT_DIR;
+  process.env.CLAUDE_PROJECT_DIR = projectDir;
+  delete require.cache[require.resolve(MOD)];
+  var gate = require(MOD);
+  var result = gate({ session_id: "test" });
+  process.env.CLAUDE_PROJECT_DIR = origDir || "";
+  return result;
+}
+
+console.log("=== hook-runner: unresolved-issues-check (T372) ===");
+
+// 1. Clean TODO passes
+var cleanDir = setupProject("clean", "# TODO\n- [x] T1: Done\n- [x] T2: Done\n");
+assert("clean TODO passes", runGate(cleanDir) === null);
+
+// 2. No TODO passes
+var noTodoDir = setupProject("no-todo", null);
+assert("no TODO.md passes", runGate(noTodoDir) === null);
+
+// 3. "TESTING NOW" stale marker blocks
+var staleDir = setupProject("stale", "# TODO\n- [ ] T99: TESTING NOW — verify deploy\n");
+var r3 = runGate(staleDir);
+assert("TESTING NOW blocks", r3 && r3.decision === "block");
+
+// 4. "IN PROGRESS" stale marker blocks
+var progressDir = setupProject("progress", "# TODO\n- [ ] T100: IN PROGRESS — refactoring module\n");
+var r4 = runGate(progressDir);
+assert("IN PROGRESS blocks", r4 && r4.decision === "block");
+
+// 5. "WIP" stale marker blocks
+var wipDir = setupProject("wip", "# TODO\n- [ ] T101: WIP brain integration\n");
+var r5 = runGate(wipDir);
+assert("WIP blocks", r5 && r5.decision === "block");
+
+// 6. Unchecked FAIL blocks
+var failDir = setupProject("fail", "# TODO\n- [ ] T102: FAIL in brain-bridge suite\n");
+var r6 = runGate(failDir);
+assert("unchecked FAIL blocks", r6 && r6.decision === "block");
+
+// 7. Completed tasks with stale markers pass
+var completedDir = setupProject("completed", "# TODO\n- [x] T103: TESTING NOW (done)\n- [x] T104: IN PROGRESS (resolved)\n");
+assert("completed stale markers pass", runGate(completedDir) === null);
+
+// 8. Plain bullets (not tasks) pass
+var bulletDir = setupProject("bullets", "# Log\n- FAIL was seen but fixed\n- crash in module resolved\n");
+assert("plain bullets pass", runGate(bulletDir) === null);
+
+// 9. Task describing a gate/detector passes (gate/detector keyword skip)
+var gateDir = setupProject("gate-desc", "# TODO\n- [ ] T105: FAIL/error scan gate module\n");
+assert("gate description with FAIL passes", runGate(gateDir) === null);
+
+// 10. Block message includes line numbers
+assert("stale block has line numbers", r3.reason.indexOf("L") !== -1);
+
+// 11. Block message includes guidance
+assert("block has update guidance", r3.reason.indexOf("Update TODO") !== -1);
+
+// 12. INVESTIGATING blocks
+var investDir = setupProject("investigating", "# TODO\n- [ ] T106: INVESTIGATING memory leak\n");
+var r12 = runGate(investDir);
+assert("INVESTIGATING blocks", r12 && r12.decision === "block");
+
+// Cleanup
+try { fs.rmSync(tmpBase, { recursive: true, force: true }); } catch(e) {}
+
+console.log("\n" + pass + "/" + (pass + fail) + " passed");
+process.exit(fail > 0 ? 1 : 0);

--- a/workflows/shtd.yml
+++ b/workflows/shtd.yml
@@ -70,6 +70,7 @@ modules:
   - task-completion-gate
   - test-before-done
   - test-checkpoint-gate
+  - unresolved-issues-check
   - why-reminder
   - workflow-gate
   - blueprint-no-sleep
@@ -89,6 +90,7 @@ modules:
   - no-rules-gate
   - rule-hygiene
   - test-coverage-check
+  - empty-output-detector
   - update-stale-docs
   - hook-health-monitor
   - hook-self-test


### PR DESCRIPTION
## Summary
- **T370 bugfix**: `unresolved-issues-gate.js` was matching plain bullet points (`- text`) as well as unchecked tasks (`- [ ] text`). Tightened to only scan `- [ ]` lines. Added 2 FP regression tests (17/17 total).
- **T371**: `empty-output-detector.js` — PostToolUse module that warns when ls, cat, find, curl, kubectl, az return empty output where content is expected. Skips commands where empty is normal (cp, mkdir, git add). 15/15 tests.
- **T372**: `unresolved-issues-check.js` — Stop module that blocks session end when TODO.md has unchecked tasks with TESTING NOW, IN PROGRESS, WIP, INVESTIGATING, or unresolved FAIL/MISMATCH/BROKEN. 12/12 tests.

## Test plan
- [x] `node scripts/test/test-T370-unresolved-issues-gate.js` — 17/17
- [x] `node scripts/test/test-T371-empty-output-detector.js` — 15/15
- [x] `node scripts/test/test-T372-unresolved-issues-check.js` — 12/12
- [x] All modules synced to live hooks