### PR TITLE
T368: Add result-review-gate for report/PDF file reads

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -999,15 +999,15 @@ Context: Claude declares E2E tests "PASSED" and commits without investigating fa
 
 Root cause: Claude optimizes for "task complete" status. Once it sees mostly-green results, it skips to commit+push without enumerating every issue. No hook forces thorough review before declaring done.
 
-- [ ] T368: **Result review gate** — PostToolUse module on Read (PDF/report files). When Claude reads a test report or PDF, inject a checklist reminder: "Before committing results: 1) List every FAIL/WARN/timeout/error/empty in this report. 2) For each: is it a real bug, expected behavior, or needs investigation? Justify. 3) File a TODO for each unresolved issue. 4) Only then commit." Non-blocking advisory but highly visible. Must fire EVERY time a report is read, not just first time.
+- [ ] T368: **Result review gate** — `result-review-gate.js` PostToolUse on Read. Fires on report/results/coverage/PDF/summary/health-check files and reports/ directories. Injects checklist: enumerate every FAIL/WARN/timeout, justify each, file TODOs, check for missing items. 15/15 tests. shtd.
 
 - [x] T369: **Victory-declaration detector** — `victory-declaration-gate.js`. Blocks title-line claims like "all tests pass", "all green", "succeeded", "100%". Only checks title so body can quote phrases. 15/15 tests. shtd + starter.
 
 - [x] T370: **FAIL/error scan before commit** — `unresolved-issues-gate.js`. Scans TODO.md for unchecked FAIL/timeout/MISMATCH/WARN/ERROR. FP protection for completed tasks, "0 failed". Acknowledges "known"/"pre-existing"/"intermittent". 15/15 tests. shtd.
 
-- [ ] T371: **Empty-output detector** — PostToolUse module. When a Bash command returns empty stdout where content was expected (e.g., `ls` on screenshots/, `check-file` returning blank), inject warning: "Empty output where content was expected. This likely means something failed silently. Investigate before proceeding." Heuristic: detect common dir-listing patterns followed by empty output.
+- [x] T371: **Empty-output detector** — `empty-output-detector.js` PostToolUse. Warns on empty output from ls, cat, find, curl, kubectl, az. Skips commands where empty is normal (cp, mkdir, git add). 15/15 tests. shtd. (PR #331)
 
-- [ ] T372: **Stop hook: unresolved issues check** — Stop module enhancement. Before session end, scan TODO.md for items still marked "TESTING NOW" or "IN PROGRESS" that weren't updated to pass/fail. Also grep recent conversation history for FAIL/WARN/timeout that were never addressed with a fix or TODO entry. Block with: "Unresolved test issues found — update TODO with actual outcomes before stopping."
+- [x] T372: **Stop hook: unresolved issues check** — `unresolved-issues-check.js` Stop module. Blocks session end when TODO.md has unchecked tasks with TESTING NOW/IN PROGRESS/WIP/INVESTIGATING or FAIL/MISMATCH/BROKEN. 12/12 tests. shtd. (PR #331)
 - Batch module validation: 94/94 pass
 - Workflow audit: 93 modules, 92 tagged, all matching YAML
 

--- a/modules/PostToolUse/result-review-gate.js
+++ b/modules/PostToolUse/result-review-gate.js
@@ -1,0 +1,58 @@
+// WORKFLOW: shtd
+// WHY: Claude reads test reports and PDFs, sees mostly-green results, and immediately
+// commits without enumerating every FAIL/WARN/timeout. Hours wasted in E2E cycles
+// when bugs shipped because the report "looked fine" at a glance.
+"use strict";
+
+var REPORT_PATTERNS = [
+  /\.report/i,
+  /report\./i,
+  /results?\./i,
+  /test[-_]?results?/i,
+  /coverage/i,
+  /\.pdf$/i,
+  /summary/i,
+  /health[-_]?check/i
+];
+
+module.exports = function(input) {
+  if (input.tool_name !== "Read") return null;
+
+  var filePath = "";
+  try {
+    filePath = (typeof input.tool_input === "string" ? JSON.parse(input.tool_input) : input.tool_input || {}).file_path || "";
+  } catch(e) { filePath = (input.tool_input || {}).file_path || ""; }
+
+  if (!filePath) return null;
+
+  // Check if the file looks like a report
+  var basename = filePath.replace(/\\/g, "/").split("/").pop() || "";
+  var isReport = false;
+  for (var i = 0; i < REPORT_PATTERNS.length; i++) {
+    if (REPORT_PATTERNS[i].test(basename)) { isReport = true; break; }
+  }
+
+  // Also check directory name
+  if (!isReport) {
+    var dirPart = filePath.replace(/\\/g, "/");
+    if (/\/reports?\//i.test(dirPart) || /\/results?\//i.test(dirPart)) {
+      isReport = true;
+    }
+  }
+
+  if (!isReport) return null;
+
+  // Non-blocking advisory — inject checklist every time
+  return {
+    decision: "block",
+    reason: "REPORT FILE READ — Review checklist before acting on results.\n\n" +
+      "File: " + basename + "\n\n" +
+      "Before committing or declaring results:\n" +
+      "  1. List EVERY FAIL, WARN, timeout, error, and empty section in this report\n" +
+      "  2. For each: is it a real bug, expected behavior, or needs investigation?\n" +
+      "  3. File a TODO for each unresolved issue\n" +
+      "  4. Check what's MISSING from the report that should be there\n" +
+      "  5. Only then commit or declare results\n\n" +
+      "Do NOT skim and assume green. Enumerate every issue explicitly."
+  };
+};

--- a/scripts/test/test-T368-result-review-gate.js
+++ b/scripts/test/test-T368-result-review-gate.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+"use strict";
+// Test suite for result-review-gate module (T368)
+
+var path = require("path");
+var MOD = path.join(__dirname, "../../modules/PostToolUse/result-review-gate.js");
+
+var pass = 0, fail = 0;
+function assert(name, ok) {
+  if (ok) { console.log("  PASS: " + name); pass++; }
+  else { console.log("  FAIL: " + name); fail++; }
+}
+
+var gate = require(MOD);
+
+console.log("=== hook-runner: result-review-gate (T368) ===");
+
+// 1. Non-Read tool passes
+assert("non-Read passes", gate({ tool_name: "Bash", tool_input: {} }) === null);
+
+// 2. Normal source file passes
+assert("source file passes", gate({ tool_name: "Read", tool_input: { file_path: "/project/src/index.js" } }) === null);
+
+// 3. TODO.md passes
+assert("TODO.md passes", gate({ tool_name: "Read", tool_input: { file_path: "/project/TODO.md" } }) === null);
+
+// 4. .report-data.json blocks
+var r4 = gate({ tool_name: "Read", tool_input: { file_path: "/project/.report-data.json" } });
+assert(".report-data.json blocks", r4 && r4.decision === "block");
+
+// 5. test-results.html blocks
+var r5 = gate({ tool_name: "Read", tool_input: { file_path: "/project/test-results.html" } });
+assert("test-results.html blocks", r5 && r5.decision === "block");
+
+// 6. PDF file blocks
+var r6 = gate({ tool_name: "Read", tool_input: { file_path: "/project/output/analysis.pdf" } });
+assert("PDF blocks", r6 && r6.decision === "block");
+
+// 7. coverage.json blocks
+var r7 = gate({ tool_name: "Read", tool_input: { file_path: "/project/coverage.json" } });
+assert("coverage.json blocks", r7 && r7.decision === "block");
+
+// 8. File in reports/ directory blocks
+var r8 = gate({ tool_name: "Read", tool_input: { file_path: "/project/reports/deploy-log.txt" } });
+assert("reports/ directory blocks", r8 && r8.decision === "block");
+
+// 9. summary.md blocks
+var r9 = gate({ tool_name: "Read", tool_input: { file_path: "/project/summary.md" } });
+assert("summary.md blocks", r9 && r9.decision === "block");
+
+// 10. health-check.log blocks
+var r10 = gate({ tool_name: "Read", tool_input: { file_path: "/project/health-check.log" } });
+assert("health-check.log blocks", r10 && r10.decision === "block");
+
+// 11. Block message includes checklist
+assert("block has checklist", r4.reason.indexOf("FAIL") !== -1 && r4.reason.indexOf("WARN") !== -1);
+
+// 12. Block message includes filename
+assert("block has filename", r4.reason.indexOf(".report-data.json") !== -1);
+
+// 13. Normal config file passes
+assert("config file passes", gate({ tool_name: "Read", tool_input: { file_path: "/project/tsconfig.json" } }) === null);
+
+// 14. CHANGELOG passes
+assert("CHANGELOG passes", gate({ tool_name: "Read", tool_input: { file_path: "/project/CHANGELOG.md" } }) === null);
+
+// 15. Windows path with report blocks
+var r15 = gate({ tool_name: "Read", tool_input: { file_path: "C:\\Users\\test\\project\\test-results.json" } });
+assert("Windows path report blocks", r15 && r15.decision === "block");
+
+console.log("\n" + pass + "/" + (pass + fail) + " passed");
+process.exit(fail > 0 ? 1 : 0);

--- a/workflows/shtd.yml
+++ b/workflows/shtd.yml
@@ -91,6 +91,7 @@ modules:
   - rule-hygiene
   - test-coverage-check
   - empty-output-detector
+  - result-review-gate
   - update-stale-docs
   - hook-health-monitor
   - hook-self-test


### PR DESCRIPTION
## Summary
- **T368**: `result-review-gate.js` — PostToolUse on Read that fires when reading report, results, coverage, PDF, summary, or health-check files. Injects review checklist requiring explicit enumeration of every FAIL/WARN/timeout before committing. 15/15 tests. Added to shtd workflow.
- **T371/T372 TODO fix**: Corrected TODO.md entries that were unmarked after squash merge ordering issue.

## Test plan
- [x] `node scripts/test/test-T368-result-review-gate.js` — 15/15
- [x] Synced to live hooks