### PR TITLE
T443: Marketplace sync v2.25.0

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1189,7 +1189,7 @@ Status:
 
 ## Version Bump + Marketplace Sync (2026-04-14)
 
-- [ ] T443: Version bump to v2.25.0 + CHANGELOG + marketplace sync for T368-T372, T442
+- [x] T443: Version bump to v2.25.0 + CHANGELOG + marketplace sync for T368-T372, T442. Pushed to grobomo/claude-code-skills.
 - Repo contains the generic/distributable runner system + module catalog
 - `modules/` has all available modules organized by event type
 - `~/.claude/hooks/modules.yaml` controls which modules are installed locally


### PR DESCRIPTION
## Summary
- Synced v2.25.0 to grobomo/claude-code-skills marketplace
- Marked T443 complete in TODO.md

## Test plan
- [x] Marketplace push verified (10 files, 428 insertions)