### PR TITLE
T444: Fix brain-bridge flaky test + README module docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,8 @@ Full catalog in `modules/` directory:
 | `claude-p-pattern` | Enforces correct `claude -p` invocation pattern |
 | `commit-counter-gate` | Forces commit after every 5 edits — prevents losing work on context reset |
 | `commit-quality-gate` | Blocks generic commit messages (< 5 words, "fix"/"update" without detail) |
+| `victory-declaration-gate` | Blocks vague success claims in commit titles ("all tests pass", "all green", "100%") |
+| `unresolved-issues-gate` | Scans TODO.md for unchecked FAIL/WARN/timeout tasks before allowing commit |
 | `continuous-claude-gate` | Blocks code without tracked task workflow |
 | `crlf-ssh-key-check` | Blocks SSH key copy without CRLF stripping |
 | `cwd-drift-detector` | Blocks cross-project file access |

--- a/README.md
+++ b/README.md
@@ -409,6 +409,8 @@ Full catalog in `modules/` directory:
 | `test-coverage-check` | Warns when source files modified without tests |
 | `troubleshoot-detector` | Detects fail-fail-succeed patterns |
 | `update-stale-docs` | Detects stale docs after code edits |
+| `empty-output-detector` | Warns when ls/cat/find/curl/kubectl/az return empty output |
+| `result-review-gate` | Injects review checklist when reading report/PDF/coverage files |
 
 ### UserPromptSubmit (processes user prompts)
 | Module | Description |
@@ -433,6 +435,7 @@ Full catalog in `modules/` directory:
 | `self-reflection` | LLM-powered review of recent gate decisions (async, calls claude -p) |
 | `session-brain-analysis` | Sends session summary to unified-brain for cross-session analysis |
 | `test-before-done` | Reminds to run e2e tests before done |
+| `unresolved-issues-check` | Blocks session end with stale TESTING NOW/IN PROGRESS/WIP tasks |
 
 #### Project-Scoped Stop
 | Module | Project | Description |

--- a/TODO.md
+++ b/TODO.md
@@ -1190,6 +1190,9 @@ Status:
 ## Version Bump + Marketplace Sync (2026-04-14)
 
 - [x] T443: Version bump to v2.25.0 + CHANGELOG + marketplace sync for T368-T372, T442. Pushed to grobomo/claude-code-skills.
+- [ ] T444: Fix T331 brain-bridge test flaky crash — HTTP servers in tests 4/8 don't close cleanly, causing intermittent non-zero exit. Fix: explicit process.exit(0) after server.close().
+
+## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog
 - `modules/` has all available modules organized by event type
 - `~/.claude/hooks/modules.yaml` controls which modules are installed locally

--- a/TODO.md
+++ b/TODO.md
@@ -1190,7 +1190,7 @@ Status:
 ## Version Bump + Marketplace Sync (2026-04-14)
 
 - [x] T443: Version bump to v2.25.0 + CHANGELOG + marketplace sync for T368-T372, T442. Pushed to grobomo/claude-code-skills.
-- [ ] T444: Fix T331 brain-bridge test flaky crash — HTTP servers in tests 4/8 don't close cleanly, causing intermittent non-zero exit. Fix: explicit process.exit(0) after server.close().
+- [ ] T444: Fix T331 brain-bridge test flaky crash + add 5 new modules to README (T094 test failure)
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog

--- a/TODO.md
+++ b/TODO.md
@@ -1190,7 +1190,7 @@ Status:
 ## Version Bump + Marketplace Sync (2026-04-14)
 
 - [x] T443: Version bump to v2.25.0 + CHANGELOG + marketplace sync for T368-T372, T442. Pushed to grobomo/claude-code-skills.
-- [ ] T444: Fix T331 brain-bridge test flaky crash + add 5 new modules to README (T094 test failure)
+- [x] T444: Fix T331 brain-bridge test flaky crash (process.exit(0) in server.close) + add 5 new modules to README (T094 7/7). Full suite: 51 suites, 817 passed.
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog

--- a/scripts/test/test-T331-brain-bridge.sh
+++ b/scripts/test/test-T331-brain-bridge.sh
@@ -223,7 +223,7 @@ RESULT=$(node -e "
                  receivedPayload.question.length > 0 &&
                  receivedPayload.metadata && receivedPayload.metadata.type === 'reflection';
         console.log(ok ? 'OK' : 'FAIL: ' + JSON.stringify(receivedPayload));
-        server.close();
+        server.close(function() { process.exit(0); });
       });
     });
     req.write(payload);

--- a/scripts/test/test-T331-brain-bridge.sh
+++ b/scripts/test/test-T331-brain-bridge.sh
@@ -88,7 +88,7 @@ RESULT=$(node -e "
       res.on('data', function(c) { data += c; });
       res.on('end', function() {
         var health = JSON.parse(data);
-        if (health.status !== 'ok') { console.log('FAIL-health'); server.close(); return; }
+        if (health.status !== 'ok') { console.log('FAIL-health'); server.close(function() { process.exit(0); }); return; }
         // Test /ask
         var payload = JSON.stringify({
           question: 'test reflection prompt',
@@ -110,7 +110,7 @@ RESULT=$(node -e "
             } else {
               console.log('FAIL-content');
             }
-            server.close();
+            server.close(function() { process.exit(0); });
           });
         });
         req.write(payload);


### PR DESCRIPTION
## Summary
- **Brain-bridge test fix**: Added `process.exit(0)` in `server.close()` callbacks for tests 4 and 8 in `test-T331-brain-bridge.sh`. The HTTP servers weren't closing cleanly, causing intermittent non-zero exit codes reported as "suite crashed". 5/5 consecutive runs clean after fix.
- **README module docs**: Added 5 new v2.25.0 modules to README tables (victory-declaration-gate, unresolved-issues-gate, empty-output-detector, result-review-gate, unresolved-issues-check). Fixed T094-module-docs test failure (now 7/7).

## Test plan
- [x] `bash scripts/test/test-T331-brain-bridge.sh` — 8/0, 5 consecutive clean runs
- [x] `bash scripts/test/test-T094-module-docs.sh` — 7/7
- [x] Full suite: 51 suites, 817 passed (only T094 had failed before this fix)