### PR TITLE
T445: Fix --test to discover .js test files

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1192,6 +1192,11 @@ Status:
 - [x] T443: Version bump to v2.25.0 + CHANGELOG + marketplace sync for T368-T372, T442. Pushed to grobomo/claude-code-skills.
 - [x] T444: Fix T331 brain-bridge test flaky crash (process.exit(0) in server.close) + add 5 new modules to README (T094 7/7). Full suite: 51 suites, 817 passed.
 
+## Test & Code Quality (2026-04-14b)
+
+- [ ] T445: Fix --test to discover .js test files — 15 JS test suites (145+ tests) silently skipped because cmdTest() only discovers .sh files
+- [ ] T446: Performance audit — PreToolUse ~281ms overhead. Document top offenders, add perf baseline to CI
+
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog
 - `modules/` has all available modules organized by event type

--- a/setup.js
+++ b/setup.js
@@ -1162,7 +1162,9 @@ function cmdTest() {
   var testDir = path.join(REPO_DIR, "scripts", "test");
   var testFiles;
   try {
-    testFiles = fs.readdirSync(testDir).filter(function(f) { return f.indexOf("test-") === 0 && f.slice(-3) === ".sh"; }).sort();
+    testFiles = fs.readdirSync(testDir).filter(function(f) {
+      return f.indexOf("test-") === 0 && (f.slice(-3) === ".sh" || f.slice(-3) === ".js");
+    }).sort();
   } catch(e) {
     console.log("  ERROR: test directory not found: " + testDir);
     process.exit(1);
@@ -1189,11 +1191,13 @@ function cmdTest() {
   var totalPass = 0, totalFail = 0, suiteFail = 0, failedSuites = [];
   for (var ti = 0; ti < testFiles.length; ti++) {
     var testPath = path.join(testDir, testFiles[ti]);
-    var suiteName = testFiles[ti].replace("test-", "").replace(".sh", "");
+    var isJs = testFiles[ti].slice(-3) === ".js";
+    var suiteName = testFiles[ti].replace("test-", "").replace(/\.(sh|js)$/, "");
     console.log("");
     console.log("  [" + suiteName + "] " + testFiles[ti]);
     try {
-      var result = cp.execSync("bash " + JSON.stringify(testPath), {
+      var execCmd = isJs ? "node " + JSON.stringify(testPath) : "bash " + JSON.stringify(testPath);
+      var result = cp.execSync(execCmd, {
         cwd: REPO_DIR,
         encoding: "utf-8",
         stdio: ["pipe", "pipe", "pipe"],


### PR DESCRIPTION
## Summary
- `cmdTest()` only discovered `.sh` test files, silently skipping 15 JS test suites (~76 tests)
- Now discovers both `.sh` and `.js`, using `node` for JS and `bash` for shell
- Suite count: 51 → 66, test count: 817 → 893

## Test plan
- [x] `node setup.js --test` discovers and runs all 66 suites
- [x] Verified e2e-enforcement failures are pre-existing (environmental)