### PR TITLE
T455: Fix workflow tier bug — dual-tag 52 shared modules for shtd+gsd

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ Modular hook runner for Claude Code. Workflows group modules into enforceable pi
 - `hook-log.js` — centralized logger (JSONL per invocation, per-module timing)
 - `run-async.js` — async module executor (Promise detection, 4s timeout)
 - `run-*.js` — event runners (pretooluse, posttooluse, stop, sessionstart, userpromptsubmit)
+- `snapshot.js` — ecosystem snapshot, drift detection, and portable backup/restore
 - `modules/` — distributable module catalog organized by event type
 - `workflows/` — built-in workflow definitions (YAML)
 - `specs/` — feature specs with tasks and checkpoints
@@ -52,6 +53,10 @@ node setup.js --test         # run all test suites
 node setup.js --upgrade      # fetch latest from GitHub
 node setup.js --uninstall    # remove hook-runner (--confirm restores backup)
 node setup.js --prune [N]    # prune log entries older than N days
+node setup.js --snapshot     # SHA256 snapshot of current state
+node setup.js --snapshot drift  # detect drift from last snapshot
+node setup.js --snapshot backup # copy to git repo, commit, push
+node setup.js --snapshot restore # clone repo, restore files
 node setup.js --version      # show version
 node setup.js --help         # show all commands
 ```

--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ Full catalog in `modules/` directory:
 | `env-var-check` | Blocks edits if required env vars missing |
 | `force-push-gate` | Blocks git push --force to main/master |
 | `gh-auto-gate` | Forces gh_auto wrapper for all gh/git push commands (EMU account safety) |
+| `gsd-plan-gate` | Blocks code edits without a phase plan in GSD workflow |
 | `git-destructive-guard` | Blocks git reset --hard, checkout ., clean -f without diagnosis |
 | `git-rebase-safety` | Warns about reversed --ours/--theirs during rebase |
 | `hook-editing-gate` | Enforces WORKFLOW tag, WHY comment, exit(1) in hook files |
@@ -446,6 +447,7 @@ Full catalog in `modules/` directory:
 | Module | Description |
 |--------|-------------|
 | `backup-check` | Warns if config backup is stale |
+| `drift-check` | Daily drift detection against last snapshot |
 | `load-instructions` | Injects working instructions at session start |
 | `load-lessons` | Injects recent self-analysis lessons |
 | `hook-self-test` | Validates runner exit codes and block processing at session start |

--- a/TODO.md
+++ b/TODO.md
@@ -1194,8 +1194,21 @@ Status:
 
 ## Test & Code Quality (2026-04-14b)
 
-- [ ] T445: Fix --test to discover .js test files — 15 JS test suites (145+ tests) silently skipped because cmdTest() only discovers .sh files
+- [x] T445: Fix --test to discover .js test files — 15 JS test suites (~76 tests) silently skipped. Suite count 51→66, test count 817→893. (#336)
 - [ ] T446: Performance audit — PreToolUse ~281ms overhead. Document top offenders, add perf baseline to CI
+- [x] T447: Fix e2e-enforcement test — HOOK_RUNNER_MODULES_DIR env var + isolated temp dirs per test. 11/11 pass.
+
+## GSD Workflow Migration (T448-T452)
+
+Replace shtd spec-based enforcement with GSD `.planning/` enforcement.
+Keep: feature branches, PR-per-task, git safety, security gates.
+Replace: spec-gate, spec-before-code-gate, gsd-gate → new gsd-plan-gate.
+
+- [ ] T448: Archive shtd workflow — disable shtd, create `workflows/gsd.yml` workflow definition
+- [ ] T449: Write `gsd-plan-gate.js` PreToolUse module — blocks code edits unless `.planning/ROADMAP.md` exists with an active phase that has PLAN.md. Branch must reference phase number.
+- [ ] T450: Write `gsd-branch-gate.js` PreToolUse module — enforces branch naming `<num>-phase-<N>-<slug>` pattern matching active GSD phases
+- [ ] T451: Write `gsd-pr-gate.js` PreToolUse module — one PR per plan/task in a phase. Branch must map to a single phase.
+- [ ] T452: E2E tests for all new GSD modules + workflow enable/disable
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog

--- a/TODO.md
+++ b/TODO.md
@@ -1210,11 +1210,15 @@ Replace: spec-gate, spec-before-code-gate, gsd-gate → new gsd-plan-gate.
 
 ## Snapshot & Workflow Simplification (T453-T455)
 
-- [ ] T453: Snapshot system — SHA256 manifest, drift detection, git-backed backup/restore (snapshot.js + drift-check SessionStart module)
-- [ ] T454: Promote universal modules to starter — 27 modules that protect system/account/platform should fire regardless of dev workflow
+- [x] T453: Snapshot system — SHA256 manifest, drift detection, git-backed backup/restore (snapshot.js + drift-check SessionStart module) (PR #337)
+- [x] T454: Promote universal modules to starter — 27 modules that protect system/account/platform should fire regardless of dev workflow (PR #337)
 - [ ] T455: Simplify workflow tiers — clarify starter (universal) vs shtd (dev discipline) vs gsd (phase-based), investigate which shtd modules to keep vs merge
 - [ ] T451: Write `gsd-pr-gate.js` PreToolUse module — one PR per plan/task in a phase. Branch must map to a single phase.
 - [x] T452: E2E tests for gsd-plan-gate — 12 tests covering all scenarios. Merged into T448.
+
+## Stop Hook: Add Testing Step (T456)
+
+- [ ] T456: Update stop-message.txt to add step 3: "TEST what you built" before hardening. Claude skips E2E verification and goes straight to code review/hardening after unit tests. New order: (1) TODO tasks, (2) log tangents, (3) E2E test the MVP, (4) code review/harden, (5) zoom out.
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog

--- a/TODO.md
+++ b/TODO.md
@@ -1204,11 +1204,17 @@ Replace shtd spec-based enforcement with GSD `.planning/` enforcement.
 Keep: feature branches, PR-per-task, git safety, security gates.
 Replace: spec-gate, spec-before-code-gate, gsd-gate → new gsd-plan-gate.
 
-- [ ] T448: Archive shtd workflow — disable shtd, create `workflows/gsd.yml` workflow definition
-- [ ] T449: Write `gsd-plan-gate.js` PreToolUse module — blocks code edits unless `.planning/ROADMAP.md` exists with an active phase that has PLAN.md. Branch must reference phase number.
+- [x] T448: Archive shtd workflow — disabled shtd at project level, created `workflows/gsd.yml` with gsd-plan-gate replacing spec-gate. 12 E2E tests pass.
+- [x] T449: `gsd-plan-gate.js` — blocks code edits unless `.planning/ROADMAP.md` exists with active phases+PLAN.md, or TODO.md has tasks. Merged into T448.
 - [ ] T450: Write `gsd-branch-gate.js` PreToolUse module — enforces branch naming `<num>-phase-<N>-<slug>` pattern matching active GSD phases
+
+## Snapshot & Workflow Simplification (T453-T455)
+
+- [ ] T453: Snapshot system — SHA256 manifest, drift detection, git-backed backup/restore (snapshot.js + drift-check SessionStart module)
+- [ ] T454: Promote universal modules to starter — 27 modules that protect system/account/platform should fire regardless of dev workflow
+- [ ] T455: Simplify workflow tiers — clarify starter (universal) vs shtd (dev discipline) vs gsd (phase-based), investigate which shtd modules to keep vs merge
 - [ ] T451: Write `gsd-pr-gate.js` PreToolUse module — one PR per plan/task in a phase. Branch must map to a single phase.
-- [ ] T452: E2E tests for all new GSD modules + workflow enable/disable
+- [x] T452: E2E tests for gsd-plan-gate — 12 tests covering all scenarios. Merged into T448.
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog

--- a/modules/PostToolUse/commit-msg-check.js
+++ b/modules/PostToolUse/commit-msg-check.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Sloppy commit messages made PR history unreadable.
 // Commit message check: warns if git commit messages don't follow conventions
 // PostToolUse module — runs after Bash tool completes

--- a/modules/PostToolUse/crlf-detector.js
+++ b/modules/PostToolUse/crlf-detector.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: On Windows, Write/Edit can produce CRLF line endings that break shell scripts,
 // YAML files, SSH keys, and other Unix-sensitive formats. The crlf-ssh-key-check
 // module only covers SSH keys — this catches CRLF in all sensitive file types.

--- a/modules/PostToolUse/disk-space-detect.js
+++ b/modules/PostToolUse/disk-space-detect.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: Companion to PreToolUse/disk-space-guard.js.
 // Detects disk space errors in tool output and sets alert mode.
 // Alert mode blocks destructive commands until user resolves the issue.

--- a/modules/PostToolUse/empty-output-detector.js
+++ b/modules/PostToolUse/empty-output-detector.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Claude treats empty command output as success — e.g., `ls screenshots/` returning
 // nothing means no screenshots exist, but Claude proceeds as if they do. Empty output
 // from directory listings, file checks, and query commands often means silent failure.

--- a/modules/PostToolUse/hook-autocommit.js
+++ b/modules/PostToolUse/hook-autocommit.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: Hook module edits were lost because they were never committed to the hook-runner repo.
 // Auto-commit hook module changes to the run-modules git repo.
 // Every Write/Edit to a hook module file gets committed automatically.

--- a/modules/PostToolUse/hook-health-monitor.js
+++ b/modules/PostToolUse/hook-health-monitor.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: Stop runner had exit(0) for blocks — TUI silently ignored autocontinue
 // for multiple sessions. Nobody knew until the user noticed. Existing health
 // checks only run at SessionStart and check static properties (files exist).

--- a/modules/PostToolUse/result-review-gate.js
+++ b/modules/PostToolUse/result-review-gate.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Claude reads test reports and PDFs, sees mostly-green results, and immediately
 // commits without enumerating every FAIL/WARN/timeout. Hours wasted in E2E cycles
 // when bugs shipped because the report "looked fine" at a glance.

--- a/modules/PostToolUse/rule-hygiene.js
+++ b/modules/PostToolUse/rule-hygiene.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Rules grew into multi-topic dump files that were hard to maintain.
 // Rule hygiene: validates rule files are granular and path-scoped
 var fs = require("fs");

--- a/modules/PostToolUse/settings-audit-log.js
+++ b/modules/PostToolUse/settings-audit-log.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Settings changes happened silently with no audit trail.
 // Audit log: records all modifications to ~/.claude/ config files.
 // Logs to ~/.claude/audit/settings-changes.jsonl with timestamp, file, tool, and diff.

--- a/modules/PostToolUse/troubleshoot-detector.js
+++ b/modules/PostToolUse/troubleshoot-detector.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Claude tried 3 wrong ways to call claude -p before finding the right
 // pattern in an existing project. The troubleshooting cycle wasted time and
 // the lesson was almost lost. This module detects "fail-fail-succeed" patterns

--- a/modules/PostToolUse/update-stale-docs.js
+++ b/modules/PostToolUse/update-stale-docs.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Dead code references and stale docs accumulate silently. When Claude
 // edits code that removes or renames something, the docs and rules that
 // reference the old thing become misleading for future sessions.

--- a/modules/PreToolUse/aws-tagging-gate.js
+++ b/modules/PreToolUse/aws-tagging-gate.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: AWS resources created without tags were impossible to attribute or clean up.
 // Enforce hackathon26 tags on AWS resource creation commands.
 // Checks: aws cloudformation, aws ec2 run-instances, aws s3api create-bucket,

--- a/modules/PreToolUse/blueprint-no-sleep.js
+++ b/modules/PreToolUse/blueprint-no-sleep.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Claude kept adding `sleep` between Blueprint MCP calls thinking pages
 // needed time to load. Each Claude prompt takes 3-10s to process — more than
 // enough for pages to load. Sleep wastes time twice: once for the sleep, once

--- a/modules/PreToolUse/branch-pr-gate.js
+++ b/modules/PreToolUse/branch-pr-gate.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Claude committed directly to main, bypassing review.
 "use strict";
 // Branch-PR gate: enforces Model C workflow.

--- a/modules/PreToolUse/claude-p-pattern.js
+++ b/modules/PreToolUse/claude-p-pattern.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Claude tried 3 wrong ways to call claude -p (--no-input, pipe via
 // echo, timeout with arg) and then tried to use ANTHROPIC_API_KEY / SDK
 // instead of just using claude -p correctly. The correct pattern is simple:

--- a/modules/PreToolUse/commit-counter-gate.js
+++ b/modules/PreToolUse/commit-counter-gate.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Claude makes 20+ file changes without committing, then context resets
 // and all work is lost or untraceable. User tracks progress via GitHub Mobile.
 // Every 5 edits, force a commit so there's a git trail.

--- a/modules/PreToolUse/continuous-claude-gate.js
+++ b/modules/PreToolUse/continuous-claude-gate.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Claude implemented features without any task tracking, making progress invisible.
 // Tracked workflow gate: blocks implementation code unless the project has a
 // tracked task workflow (specs/tasks.md with T### checkboxes).

--- a/modules/PreToolUse/crlf-ssh-key-check.js
+++ b/modules/PreToolUse/crlf-ssh-key-check.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: Windows scp/cp adds \r\n to SSH keys. OpenSSH rejects them with
 // "error in libcrypto". This happened repeatedly with fleet key deployment.
 "use strict";

--- a/modules/PreToolUse/cross-project-todo-gate.js
+++ b/modules/PreToolUse/cross-project-todo-gate.js
@@ -1,5 +1,5 @@
 "use strict";
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Prevents cross-project TODO items from being written into the current
 // project's TODO.md. These items belong in the referenced project's TODO.md
 // where they'll actually get picked up and executed. The cwd-drift-detector

--- a/modules/PreToolUse/cwd-drift-detector.js
+++ b/modules/PreToolUse/cwd-drift-detector.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: When working in project A, Claude drifts into project B's files (cd, edit, read).
 // Instead of working in-place, spawn a new tab via context-reset so both projects
 // get proper tracking, hooks, and TODO.md context.

--- a/modules/PreToolUse/ddei-email-security/rdp-testbox-gate.js
+++ b/modules/PreToolUse/ddei-email-security/rdp-testbox-gate.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Claude wasted an entire session reinventing RDP connection logic that
 // already worked in start-e2e-test.sh (commit 21e5b3d). This hook fires on
 // any RDP-related command to remind Claude of:

--- a/modules/PreToolUse/ddei-email-security/share-is-generic.js
+++ b/modules/PreToolUse/ddei-email-security/share-is-generic.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: share/ is the customer deliverable shipped to many different customers.
 // Customer names, internal project codenames, meeting note references, and
 // employee names leaked into share/ files multiple times during development.

--- a/modules/PreToolUse/deploy-gate.js
+++ b/modules/PreToolUse/deploy-gate.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: E2E deploy cycles take 10+ minutes. When deployed from a dirty tree,
 // results can't be traced to a specific commit SHA. Wasted debugging time
 // when you can't reproduce what was actually deployed.

--- a/modules/PreToolUse/deploy-history-reminder.js
+++ b/modules/PreToolUse/deploy-history-reminder.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Claude repeats failed deploy approaches because it doesn't check git
 // history first. Each E2E cycle is 10+ minutes. Checking recent commits takes
 // 2 seconds and prevents wasting 30+ minutes on already-tried approaches.

--- a/modules/PreToolUse/disk-space-guard.js
+++ b/modules/PreToolUse/disk-space-guard.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: Claude ran rm -rf on temp files when disk was full without asking.
 // Deleting files to free space is dangerous — wrong target = lost work.
 // This gate blocks destructive commands when the previous error was disk-related.

--- a/modules/PreToolUse/env-var-check.js
+++ b/modules/PreToolUse/env-var-check.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Missing env vars caused silent failures deep in workflows.
 "use strict";
 // PreToolUse: block code edits if required environment variables are missing.

--- a/modules/PreToolUse/gh-auto-gate.js
+++ b/modules/PreToolUse/gh-auto-gate.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: `gh auth switch` is broken with EMU accounts — the API still uses the EMU token
 // even after switching. Raw `gh` and `git push` commands silently use the wrong account,
 // causing 403s or pushing to the wrong org. gh_auto reads .github/publish.json and sets

--- a/modules/PreToolUse/git-rebase-safety.js
+++ b/modules/PreToolUse/git-rebase-safety.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: During a rebase, --ours/--theirs are REVERSED from intuition.
 // Claude used --theirs thinking it meant "my local changes" but during
 // rebase it means the upstream branch. This silently dropped 30+ hook

--- a/modules/PreToolUse/gsd-plan-gate.js
+++ b/modules/PreToolUse/gsd-plan-gate.js
@@ -1,0 +1,259 @@
+// WORKFLOW: gsd
+// WHY: Claude dived into coding without a GSD plan, producing untracked work
+// that couldn't be reviewed via PRs or traced to any roadmap phase.
+// This gate enforces the GSD pipeline: .planning/ROADMAP.md must exist with
+// at least one phase, and code edits require either an active phase with a
+// PLAN.md or unchecked tasks in TODO.md.
+"use strict";
+var fs = require("fs");
+var path = require("path");
+
+// File patterns always allowed (planning, config, tests, docs)
+var ALLOW_PATTERNS = [
+  /TODO\.md$/i, /SESSION_STATE\.md$/i, /CLAUDE\.md$/i, /README\.md$/i,
+  /CHANGELOG\.md$/i,
+  /\.planning[\/\\]/, /\.specify[\/\\]/, /specs[\/\\]/,
+  /\.claude[\/\\]/, /\.github[\/\\]/, /\/hooks[\/\\]/, /\/rules[\/\\]/,
+  /\.gitignore$/, /package\.json$/, /package-lock\.json$/,
+  /tsconfig[^/]*\.json$/, /\.eslintrc/, /\.prettierrc/,
+  /jest\.config/, /vitest\.config/,
+  /scripts\/test\//, /[\/\\]tests?[\/\\]/, /\.test\.[jt]s$/, /\.spec\.[jt]s$/,
+];
+
+// Bash commands that are read-only — always allowed
+var BASH_ALLOW_PATTERNS = [
+  /^\s*git\b/, /^\s*gh\b/, /^\s*gh_auto\b/,
+  /^\s*ls\b/, /^\s*dir\b/, /^\s*cat\b/, /^\s*head\b/, /^\s*tail\b/,
+  /^\s*grep\b/, /^\s*rg\b/, /^\s*find\b/, /^\s*fd\b/,
+  /^\s*wc\b/, /^\s*diff\b/, /^\s*echo\b/, /^\s*printf\b/,
+  /^\s*pwd\b/, /^\s*env\b/, /^\s*which\b/, /^\s*type\b/, /^\s*where\b/,
+  /^\s*file\b/, /^\s*stat\b/, /^\s*du\b/, /^\s*df\b/,
+  /^\s*cd\b/, /^\s*readlink\b/, /^\s*realpath\b/,
+  /^\s*jq\b/, /^\s*yq\b/, /^\s*sort\b/, /^\s*uniq\b/, /^\s*cut\b/, /^\s*tr\b/,
+  /^\s*test\b/, /^\s*\[\s/, /^\s*true\b/, /^\s*false\b/,
+  /^\s*date\b/, /^\s*hostname\b/, /^\s*whoami\b/, /^\s*id\b/,
+  /^\s*node\s+-e\b/, /^\s*node\s+--eval\b/,
+  /^\s*python\s+-c\b/,
+  /^\s*bash\s+scripts\/test\//,
+  /^\s*node\s+setup\.js\s+--test/,
+  /^\s*curl\s/,
+];
+
+// Cache for ROADMAP.md parsing (per process — each hook invocation is fresh)
+var _cache = {};
+
+function findProjectRoot(startDir) {
+  var dir = startDir;
+  for (var d = 0; d < 20; d++) {
+    if (fs.existsSync(path.join(dir, ".git"))) return dir.replace(/\\/g, "/");
+    var parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+/**
+ * Parse ROADMAP.md to extract phases.
+ * Returns array of {number, name, hasDir, hasPlan}
+ */
+function parseRoadmap(projectDir) {
+  var cacheKey = projectDir;
+  if (_cache[cacheKey]) return _cache[cacheKey];
+
+  var roadmapPath = path.join(projectDir, ".planning", "ROADMAP.md");
+  if (!fs.existsSync(roadmapPath)) {
+    _cache[cacheKey] = null;
+    return null;
+  }
+
+  var content;
+  try { content = fs.readFileSync(roadmapPath, "utf-8"); }
+  catch (e) { _cache[cacheKey] = null; return null; }
+
+  // Match ## Phase N: Title or ## Phase N — Title
+  var phaseRegex = /^##\s+Phase\s+(\d+(?:\.\d+)?)[:\s—–-]+(.*)$/gm;
+  var phases = [];
+  var match;
+  while ((match = phaseRegex.exec(content)) !== null) {
+    var num = match[1];
+    var name = match[2].trim();
+    var slug = name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+
+    // Check for phase directory (pattern: N-slug)
+    var phasesDir = path.join(projectDir, ".planning", "phases");
+    var hasDir = false;
+    var hasPlan = false;
+    if (fs.existsSync(phasesDir)) {
+      try {
+        var entries = fs.readdirSync(phasesDir);
+        for (var i = 0; i < entries.length; i++) {
+          // Match directories starting with the phase number
+          if (entries[i].indexOf(num + "-") === 0 || entries[i] === num) {
+            var phaseDir = path.join(phasesDir, entries[i]);
+            if (fs.statSync(phaseDir).isDirectory()) {
+              hasDir = true;
+              // Check for PLAN.md or *-PLAN.md
+              var phaseFiles = fs.readdirSync(phaseDir);
+              for (var j = 0; j < phaseFiles.length; j++) {
+                if (/PLAN\.md$/i.test(phaseFiles[j])) {
+                  hasPlan = true;
+                  break;
+                }
+              }
+              break;
+            }
+          }
+        }
+      } catch (e) {}
+    }
+
+    phases.push({ number: num, name: name, slug: slug, hasDir: hasDir, hasPlan: hasPlan });
+  }
+
+  _cache[cacheKey] = phases;
+  return phases;
+}
+
+/**
+ * Check if TODO.md has unchecked tasks (fallback for simple projects)
+ */
+function hasTodoTasks(projectDir) {
+  var todoPath = path.join(projectDir, "TODO.md");
+  try {
+    var content = fs.readFileSync(todoPath, "utf-8");
+    return /- \[ \] /.test(content);
+  } catch (e) { return false; }
+}
+
+/**
+ * Extract phase number from branch name.
+ * Patterns: phase-3-slug, 338-phase-3-slug, NNN-T448-..., phase3/slug
+ */
+function branchPhaseNumber(branch) {
+  if (!branch || branch === "main" || branch === "master" || branch === "HEAD") return "";
+  // "phase-3-slug" or "338-phase-3-slug"
+  var m = branch.match(/phase[- ]?(\d+(?:\.\d+)?)/i);
+  if (m) return m[1];
+  return "";
+}
+
+module.exports = function(input) {
+  var tool = input.tool_name;
+  var isBash = (tool === "Bash");
+  if (tool !== "Edit" && tool !== "Write" && !isBash) return null;
+
+  // For Bash: check if it's a read-only command
+  if (isBash) {
+    var bashInput = input.tool_input;
+    if (typeof bashInput === "string") { try { bashInput = JSON.parse(bashInput); } catch(e) { bashInput = {}; } }
+    var cmd = ((bashInput || {}).command || "").trim();
+    if (!cmd) return null;
+
+    var realCmd = cmd.replace(/^(\s*cd\s+[^;&|]+\s*&&\s*)+/, "").trim();
+    var firstCmd = realCmd.split("|")[0].trim();
+
+    for (var bai = 0; bai < BASH_ALLOW_PATTERNS.length; bai++) {
+      if (BASH_ALLOW_PATTERNS[bai].test(firstCmd)) return null;
+    }
+    // Non-read-only Bash falls through to plan check
+  }
+
+  // For Edit/Write: check file path allowlist
+  var targetFile = "";
+  if (!isBash) {
+    try { targetFile = (typeof input.tool_input === "string" ? JSON.parse(input.tool_input) : input.tool_input || {}).file_path || ""; }
+    catch(e) { targetFile = (input.tool_input || {}).file_path || ""; }
+    if (!targetFile) return null;
+    var norm = targetFile.replace(/\\/g, "/");
+
+    for (var i = 0; i < ALLOW_PATTERNS.length; i++) {
+      if (ALLOW_PATTERNS[i].test(norm)) return null;
+    }
+
+    // Allow user home config
+    var home = (process.env.HOME || process.env.USERPROFILE || "").replace(/\\/g, "/");
+    if (home && norm.indexOf(home + "/.claude/") === 0) return null;
+  }
+
+  // Find project root(s)
+  var projectDir = (process.env.CLAUDE_PROJECT_DIR || "").replace(/\\/g, "/");
+  var roots = [];
+  if (projectDir) roots.push(projectDir);
+  if (!isBash && targetFile) {
+    var fileRoot = findProjectRoot(path.dirname(targetFile));
+    if (fileRoot && roots.indexOf(fileRoot) === -1) roots.push(fileRoot);
+  }
+  if (roots.length === 0) return null;
+
+  // Check each root for GSD artifacts
+  for (var ri = 0; ri < roots.length; ri++) {
+    var root = roots[ri];
+    var phases = parseRoadmap(root);
+
+    // No .planning/ROADMAP.md — check TODO.md fallback
+    if (!phases) {
+      if (hasTodoTasks(root)) return null; // simple project with TODO tasks
+      continue; // try next root
+    }
+
+    // ROADMAP exists but no phases parsed — project is initializing
+    if (phases.length === 0) {
+      return {
+        decision: "block",
+        reason: "GSD GATE: .planning/ROADMAP.md exists but has no phases.\n" +
+          "WHY: Every code change must trace to a roadmap phase for team visibility.\n" +
+          "FIX: Add phases to ROADMAP.md with /gsd-new-milestone or /gsd-add-phase\n" +
+          "Blocked: " + (isBash ? "Bash: " + (cmd || "").substring(0, 80) : path.basename(targetFile))
+      };
+    }
+
+    // At least one phase with a PLAN.md = ready to execute
+    var anyPlan = false;
+    for (var pi = 0; pi < phases.length; pi++) {
+      if (phases[pi].hasPlan) { anyPlan = true; break; }
+    }
+
+    // TODO.md with unchecked tasks is also valid (for quick tasks, bug fixes)
+    if (hasTodoTasks(root)) return null;
+
+    if (!anyPlan) {
+      // Roadmap exists, phases exist, but no plans yet
+      // Allow if this is a young project (< 3 phases, no phase dirs yet)
+      var anyDir = false;
+      for (var di = 0; di < phases.length; di++) {
+        if (phases[di].hasDir) { anyDir = true; break; }
+      }
+      if (!anyDir) {
+        // No phase directories — project is in early planning, allow work
+        return null;
+      }
+
+      return {
+        decision: "block",
+        reason: "GSD GATE: No active phase has a PLAN.md.\n" +
+          "WHY: Code changes must be planned before execution so the team can\n" +
+          "review the approach via PRs and track progress on the roadmap.\n" +
+          "FIX: Run /gsd-plan-phase to create a plan, then execute it.\n" +
+          "Phases in roadmap: " + phases.map(function(p) { return p.number + " " + p.name; }).join(", ") + "\n" +
+          "Blocked: " + (isBash ? "Bash: " + (cmd || "").substring(0, 80) : path.basename(targetFile))
+      };
+    }
+
+    // Has a plan — allow
+    return null;
+  }
+
+  // No roots had GSD artifacts or TODO tasks — block
+  var blocked = isBash ? "Bash: " + (cmd || "").substring(0, 80) : path.basename(targetFile);
+  return {
+    decision: "block",
+    reason: "GSD GATE: No .planning/ROADMAP.md or TODO.md with tasks found.\n" +
+      "WHY: Every change must be tracked — either through GSD phases or TODO.md tasks.\n" +
+      "Untracked work is invisible to the team and can't be reviewed.\n" +
+      "FIX:\n" +
+      "  Option A: /gsd-new-project to initialize GSD planning\n" +
+      "  Option B: Add tasks to TODO.md: '- [ ] description'\n" +
+      "Blocked: " + blocked
+  };
+};

--- a/modules/PreToolUse/hook-editing-gate.js
+++ b/modules/PreToolUse/hook-editing-gate.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: A rogue Claude tab silently weakened spec-gate.js by removing Bash from
 // the gated tools list. No audit trail, no alert. Any session could modify hooks
 // to bypass its own enforcement. This gate now locks hook editing to the

--- a/modules/PreToolUse/hook-system-reminder.js
+++ b/modules/PreToolUse/hook-system-reminder.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Claude repeatedly tries to create .claude/rules/ files despite being
 // told dozens of times across dozens of sessions. This hook fires when Claude
 // tries to WRITE or EDIT anything in ~/.claude/ to remind it how the system works.

--- a/modules/PreToolUse/instruction-to-hook-gate.js
+++ b/modules/PreToolUse/instruction-to-hook-gate.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: User instructions ("always X") were forgotten next session. Must become hooks or SHTD workflows.
 "use strict";
 // PreToolUse: enforce that user instructions ("always X", "never Y") become hooks/rules.

--- a/modules/PreToolUse/messaging-safety-gate.js
+++ b/modules/PreToolUse/messaging-safety-gate.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: Claude autonomously sent messages to real people during testing.
 // This gate blocks all outbound messaging (email, Teams, meetings) unless
 // the target is explicitly authorized. Prevents accidental spam to colleagues.

--- a/modules/PreToolUse/no-adhoc-commands.js
+++ b/modules/PreToolUse/no-adhoc-commands.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Ad-hoc AWS/SSH/Azure commands died with the session. Scripts survive.
 // Block ad-hoc Bash commands for AWS, Azure, SSH, Docker, and infrastructure.
 // ALL operations must go through reusable scripts in scripts/.

--- a/modules/PreToolUse/no-focus-steal.js
+++ b/modules/PreToolUse/no-focus-steal.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: Background claude -p self-analysis opened a visible terminal tab that
 // stole focus from the user's work. On Windows, child_process.spawn with
 // detached+windowsHide still flashes a console.

--- a/modules/PreToolUse/no-fragile-heuristics.js
+++ b/modules/PreToolUse/no-fragile-heuristics.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Claude wrote pixel-ratio thresholds and color-counting heuristics to
 // detect blank screenshots and login pages. These broke on F5 (dark login page)
 // and would false-positive on white dashboards. The user corrected: "don't make

--- a/modules/PreToolUse/no-hook-bypass.js
+++ b/modules/PreToolUse/no-hook-bypass.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: Claude circumvented a PreToolUse gate by using Bash (cat >, echo >) instead
 // of the blocked Write/Edit tool. This defeats the entire hook enforcement system.
 // If a gate blocks Write/Edit, Bash must not be used as a backdoor to write the same file.

--- a/modules/PreToolUse/no-nested-claude.js
+++ b/modules/PreToolUse/no-nested-claude.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: Nested `claude -p` calls inside a session don't work reliably.
 // Cross-project work must use context_reset.py which opens a proper new terminal session.
 // Also blocks TaskCreate since it's a within-session tracker, not a session spawner.

--- a/modules/PreToolUse/no-passive-rules.js
+++ b/modules/PreToolUse/no-passive-rules.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Claude kept creating .md rule files in .claude/rules/ instead of active
 // hook modules. Rule files are passive — Claude has to read and choose to follow
 // them. Hook modules are active — they execute and block. Persistent lessons and

--- a/modules/PreToolUse/no-rules-gate.js
+++ b/modules/PreToolUse/no-rules-gate.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: User has instructed at least 3 times across sessions to never use
 // ~/.claude/rules/ or .claude/rules/ — only hook-runner modules and workflows.
 // Rules are invisible, unenforceable, and duplicate what hooks already do.

--- a/modules/PreToolUse/pr-first-gate.js
+++ b/modules/PreToolUse/pr-first-gate.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Claude created specs and wrote code on branches without opening a PR first.
 // The dev team monitors progress via GitHub Mobile notifications — without a PR,
 // nobody knows work is happening. The correct flow is:

--- a/modules/PreToolUse/pr-per-task-gate.js
+++ b/modules/PreToolUse/pr-per-task-gate.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Batched PRs with multiple tasks made mobile monitoring and rollbacks impossible.
 "use strict";
 // PR-per-task gate: blocks `gh pr create` if PR title doesn't include a task ID.

--- a/modules/PreToolUse/publish-json-guard.js
+++ b/modules/PreToolUse/publish-json-guard.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: ep-incident-response (private customer data) was published to grobomo (public).
 // Root cause: nothing prevented Claude from editing publish.json or git remotes,
 // which control which GitHub account receives pushes. This gate blocks all edits

--- a/modules/PreToolUse/reflection-gate.js
+++ b/modules/PreToolUse/reflection-gate.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Self-reflection module (Stop event) flags workflow violations via LLM
 // analysis, but those flags are useless if Claude keeps editing without seeing
 // them. This gate checks the reflection log for unresolved high-severity issues

--- a/modules/PreToolUse/remote-tracking-gate.js
+++ b/modules/PreToolUse/remote-tracking-gate.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Commits on untracked branches were invisible on mobile.
 "use strict";
 // PreToolUse: block code edits if the feature branch doesn't track a remote.

--- a/modules/PreToolUse/root-cause-gate.js
+++ b/modules/PreToolUse/root-cause-gate.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Claude masked bugs with cleanup instead of fixing root causes.
 // Root cause gate: block retry/cleanup patterns without diagnosis
 // Detects when Claude is about to re-run a command that just failed,

--- a/modules/PreToolUse/settings-change-gate.js
+++ b/modules/PreToolUse/settings-change-gate.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: Config changes happened without stated rationale, causing confusion later.
 // Settings change gate: injects a reminder when modifying ~/.claude/ config files.
 // Doesn't block — just ensures Claude states the reason in its response.

--- a/modules/PreToolUse/settings-hooks-gate.js
+++ b/modules/PreToolUse/settings-hooks-gate.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: Claude added hooks directly to settings.json instead of using the
 // hook-runner module system (run-modules/{Event}/*.js). Direct settings.json
 // hook entries bypass the modular architecture and create one-off hooks that

--- a/modules/PreToolUse/task-completion-gate.js
+++ b/modules/PreToolUse/task-completion-gate.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: A claude -p session marked T020-T024 as [x] complete in TODO.md without
 // creating PRs, deploying, or verifying. The "fixes" were never tested. This
 // happened because nothing enforced the link between task completion and evidence.

--- a/modules/PreToolUse/test-checkpoint-gate.js
+++ b/modules/PreToolUse/test-checkpoint-gate.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: PRs merged from mobile had no tests, breaking production.
 "use strict";
 // requires: enforcement-gate, spec-gate

--- a/modules/PreToolUse/unresolved-issues-gate.js
+++ b/modules/PreToolUse/unresolved-issues-gate.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Claude commits code while TODO.md or report data still has unresolved FAIL, timeout,
 // MISMATCH, or WARN entries. Bugs ship because the commit focused on what worked and skipped
 // what didn't. Scanning TODO.md before commit catches overlooked issues.

--- a/modules/PreToolUse/why-reminder.js
+++ b/modules/PreToolUse/why-reminder.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Comments that describe WHAT code does are useless — Claude can read code.
 // Comments that explain WHY decisions were made are invaluable — they survive context
 // resets, guide fleet workers, and prevent future sessions from repeating mistakes.

--- a/modules/PreToolUse/windowless-spawn-gate.js
+++ b/modules/PreToolUse/windowless-spawn-gate.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: Hook modules using execSync("git ...") spawn cmd.exe on Windows,
 // creating visible console popups that steal focus. Every tool call fires
 // 2-5 hooks, each potentially spawning multiple cmd.exe windows. Fix:

--- a/modules/PreToolUse/workflow-compliance-gate.js
+++ b/modules/PreToolUse/workflow-compliance-gate.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: A Claude session on ddei project ran ad-hoc commands for 45 minutes without
 // SHTD active. When asked, it admitted "no, I just jumped straight into ad hoc commands."
 // Globally enforced workflows must be active in EVERY project. No exceptions by default.

--- a/modules/PreToolUse/workflow-gate.js
+++ b/modules/PreToolUse/workflow-gate.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 "use strict";
 // WHY: Steps in a workflow were skipped — build ran before setup, deploy before test.
 // Workflow gate: enforces step order in active workflows.

--- a/modules/PreToolUse/worktree-gate.js
+++ b/modules/PreToolUse/worktree-gate.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Multiple Claude tabs working on the same repo directory caused git
 // conflicts — stash collisions, dirty working trees, branch switches stomping
 // each other's changes. Git worktrees give each branch its own directory,

--- a/modules/SessionStart/backup-check.js
+++ b/modules/SessionStart/backup-check.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: Backups went stale for weeks without anyone noticing.
 // SessionStart: check backup freshness at session start.
 // Requires: claude-backup skill installed at ~/.claude/skills/claude-backup/

--- a/modules/SessionStart/drift-check.js
+++ b/modules/SessionStart/drift-check.js
@@ -1,0 +1,68 @@
+// WORKFLOW: starter
+// WHY: Hook system broke silently after modules drifted from known-good state.
+//   Periodic drift detection catches changes before they cause session failures.
+// SessionStart: compare live files against last snapshot (daily).
+var fs = require("fs");
+var path = require("path");
+
+module.exports = function(input) {
+  var hooksDir = path.join(process.env.HOME || process.env.USERPROFILE, ".claude", "hooks");
+  var snapshotsDir = path.join(process.env.HOME || process.env.USERPROFILE, ".claude", "snapshots");
+  var markerPath = path.join(hooksDir, ".drift-last-check");
+
+  // Only check once per day
+  if (fs.existsSync(markerPath)) {
+    try {
+      var lastCheck = parseInt(fs.readFileSync(markerPath, "utf-8").trim(), 10);
+      if (Date.now() - lastCheck < 24 * 60 * 60 * 1000) return null;
+    } catch (e) {}
+  }
+
+  // Update marker
+  try { fs.writeFileSync(markerPath, "" + Date.now()); } catch (e) {}
+
+  // Check for snapshot
+  var latestPath = path.join(snapshotsDir, "latest.json");
+  if (!fs.existsSync(latestPath)) {
+    return { text: "DRIFT-CHECK: No snapshot exists. Run `node snapshot.js create` from hook-runner to baseline your setup." };
+  }
+
+  var snapshot;
+  try { snapshot = JSON.parse(fs.readFileSync(latestPath, "utf-8")); } catch (e) { return null; }
+
+  // Quick check: snapshot age
+  var ageHours = (Date.now() - new Date(snapshot.timestamp).getTime()) / (1000 * 60 * 60);
+  if (ageHours > 168) { // 7 days
+    return { text: "DRIFT-CHECK: Snapshot is " + Math.round(ageHours / 24) + " days old. Consider running `node snapshot.js create` to update it." };
+  }
+
+  // Fast drift check — only check runners, config, and workflow files (not all modules)
+  var crypto = require("crypto");
+  function sha256(filePath) {
+    try { return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex"); }
+    catch (e) { return null; }
+  }
+
+  var drifted = [];
+  var labels = Object.keys(snapshot.files);
+  for (var i = 0; i < labels.length; i++) {
+    var entry = snapshot.files[labels[i]];
+    // Only check critical categories in the fast check
+    if (entry.category !== "runner" && entry.category !== "config" && entry.category !== "workflow" && entry.category !== "state") continue;
+    var absPath = (entry.absPath || "").replace(/\//g, path.sep);
+    var hash = sha256(absPath);
+    if (!hash) {
+      drifted.push(labels[i] + " (missing)");
+    } else if (hash !== entry.sha256) {
+      drifted.push(labels[i] + " (modified)");
+    }
+  }
+
+  if (drifted.length === 0) return null;
+
+  return {
+    text: "DRIFT-CHECK: " + drifted.length + " critical file(s) changed since snapshot:\n" +
+      drifted.map(function(d) { return "  - " + d; }).join("\n") +
+      "\nRun `node snapshot.js drift` for full report, or `node snapshot.js create` to accept current state."
+  };
+};

--- a/modules/SessionStart/hook-self-test.js
+++ b/modules/SessionStart/hook-self-test.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: Stop runner had exit(0) for blocks instead of exit(1). TUI silently
 // ignored autocontinue — user had to notice manually. project-health.js
 // checks that files exist and modules load, but never validates that runners

--- a/modules/SessionStart/lesson-effectiveness.js
+++ b/modules/SessionStart/lesson-effectiveness.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Self-analysis lessons were captured (T381) but never checked for repetition.
 // If the same lesson appears 3+ times, it means Claude keeps making the same mistake
 // and the lesson alone isn't enough — a gate module should enforce it instead.

--- a/modules/SessionStart/load-instructions.js
+++ b/modules/SessionStart/load-instructions.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: Important operational context was missing at session start.
 // SessionStart: inject working instructions at start of every session
 module.exports = function(input) {

--- a/modules/SessionStart/load-lessons.js
+++ b/modules/SessionStart/load-lessons.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Self-analysis generates lessons from interrupts, but those lessons
 // are only useful if Claude reads them at the start of each session.
 // This module reads self-analysis-lessons.jsonl and injects recent

--- a/modules/SessionStart/reflection-score-inject.js
+++ b/modules/SessionStart/reflection-score-inject.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Every session starts blank. Without injecting the reflection score,
 // Claude has no memory of past performance and repeats the same mistakes.
 // This module injects the score, level, streak, and WHY into context so

--- a/modules/SessionStart/session-cleanup.js
+++ b/modules/SessionStart/session-cleanup.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: Session-scoped temp files (.claude-*-<ppid>) accumulate when Claude Code
 // tabs crash or close without cleanup. Stale files waste disk and could confuse
 // modules if PIDs get reused. This runs at SessionStart to sweep orphaned files.

--- a/modules/SessionStart/session-collision-detector.js
+++ b/modules/SessionStart/session-collision-detector.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: Context-reset spawns new Claude Code tabs that all work on the same project
 // simultaneously. This caused 4-5 parallel sessions doing git checkout, git commit,
 // branch switching — total chaos. index.lock contention, parallel commits stomping

--- a/modules/Stop/auto-continue.js
+++ b/modules/Stop/auto-continue.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: starter
 // WHY: Claude stops and lists options instead of doing the work.
 // The message text in stop-message.txt was iterated over 15+ versions by the user.
 // DO NOT rewrite, condense, or rephrase it. It is a user-authored artifact.

--- a/modules/Stop/chat-export.js
+++ b/modules/Stop/chat-export.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Chat sessions contain valuable context that gets lost when sessions end.
 // Auto-exporting to HTML preserves every conversation for later reference without
 // manual intervention. Runs async so it doesn't block the stop flow.

--- a/modules/Stop/drift-review.js
+++ b/modules/Stop/drift-review.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Claude drifted off-spec, doing unrelated work while tasks remained.
 "use strict";
 // Stop hook: drift review. Before auto-continue, check if recent work

--- a/modules/Stop/log-gotchas.js
+++ b/modules/Stop/log-gotchas.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Hard-won lessons from debugging sessions get lost between context
 // resets. This gate ensures gotchas are captured as rule files so future
 // sessions don't repeat the same mistakes.

--- a/modules/Stop/mark-turn-complete.js
+++ b/modules/Stop/mark-turn-complete.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Need to detect when the user interrupts Claude mid-response.
 // Interrupts are social cues that something went wrong — they should
 // trigger self-analysis. This module writes a marker file when Claude

--- a/modules/Stop/never-give-up.js
+++ b/modules/Stop/never-give-up.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: starter
 // WHY: Claude declares things "impossible" after one failed attempt.
 // Past examples: "can't screenshot VM" (solved by Azure Boot Diagnostics),
 // "can't send email" (solved by SMTP relay). Research before giving up.

--- a/modules/Stop/push-unpushed.js
+++ b/modules/Stop/push-unpushed.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Commits sat on local branches, invisible to mobile monitoring.
 "use strict";
 // Stop hook: block stopping if there are unpushed commits.

--- a/modules/Stop/reflection-score.js
+++ b/modules/Stop/reflection-score.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: You can't improve what you can't measure. Every session starts blank —
 // no memory of past performance. This score is the memory that survives context
 // resets. It measures how well you protect the user's time: high score = autonomous

--- a/modules/Stop/self-reflection.js
+++ b/modules/Stop/self-reflection.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Hook-runner gates made wrong decisions (T321: branch T319 allowed edits
 // for T321 work). Regex gates can't catch semantic mismatches. This module
 // reviews recent gate decisions at natural pause points and flags issues for

--- a/modules/Stop/session-brain-analysis.js
+++ b/modules/Stop/session-brain-analysis.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Self-reflection catches issues in-session but misses cross-session patterns.
 // User has given the same instruction 3+ times ("no rules, only hooks") without it
 // sticking. This module triggers brain-level analysis at session end to review

--- a/modules/Stop/test-before-done.js
+++ b/modules/Stop/test-before-done.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Claude declares features "done" without running tests. The user
 // then discovers broken code on mobile. This gate reminds Claude to test
 // before stopping, and that "test it" means real e2e, not unit tests.

--- a/modules/Stop/unresolved-issues-check.js
+++ b/modules/Stop/unresolved-issues-check.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Claude ends sessions with tasks still marked "TESTING NOW" or "IN PROGRESS"
 // in TODO.md, or with FAIL/WARN/timeout mentioned but never resolved.
 // Next session starts with stale state and wastes time rediscovering issues.

--- a/modules/UserPromptSubmit/hook-integrity-monitor.js
+++ b/modules/UserPromptSubmit/hook-integrity-monitor.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: A background process silently overwrote live hook modules between prompts,
 // stripping WORKFLOW tags from 37 modules. Mid-session drift went undetected.
 "use strict";

--- a/modules/UserPromptSubmit/instruction-detector.js
+++ b/modules/UserPromptSubmit/instruction-detector.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: User directives were treated as one-time context instead of persistent rules.
 // UserPromptSubmit: detect instruction-like directives in user messages.
 // When user says "always", "never", "make sure", "from now on", "whenever",

--- a/modules/UserPromptSubmit/interrupt-detector.js
+++ b/modules/UserPromptSubmit/interrupt-detector.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: User interrupts are social cues that Claude did something wrong.
 // In real life, people correct you with raised eyebrows or "wait, no."
 // In TUI, the interrupt IS that signal. When detected, this spawns a

--- a/modules/UserPromptSubmit/prompt-logger.js
+++ b/modules/UserPromptSubmit/prompt-logger.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, starter
 // WHY: No record of what was asked across sessions, making handoffs lossy.
 // UserPromptSubmit: log user prompts to JSONL for audit and review
 // Logs prompt text, timestamp, and project context to ~/.claude/hooks/prompt-log.jsonl

--- a/run-posttooluse.js
+++ b/run-posttooluse.js
@@ -27,7 +27,8 @@ if (input && input.tool_input && typeof input.tool_input.path === "string") {
 }
 
 var ctx = hookLog.extractContext("PostToolUse", input);
-var modules = loadModules(path.join(__dirname, "run-modules", "PostToolUse"));
+var modulesDir = process.env.HOOK_RUNNER_MODULES_DIR || path.join(__dirname, "run-modules");
+var modules = loadModules(path.join(modulesDir, "PostToolUse"));
 
 // T378: Run all modules before exiting (consistent with T376 Stop runner fix).
 // PostToolUse is monitoring/reporting — all modules should run even if one blocks.

--- a/run-pretooluse.js
+++ b/run-pretooluse.js
@@ -53,7 +53,8 @@ try {
 } catch (e) { /* not in a git repo — modules handle this gracefully */ }
 
 var ctx = hookLog.extractContext("PreToolUse", input);
-var modules = loadModules(path.join(__dirname, "run-modules", "PreToolUse"));
+var modulesDir = process.env.HOOK_RUNNER_MODULES_DIR || path.join(__dirname, "run-modules");
+var modules = loadModules(path.join(modulesDir, "PreToolUse"));
 
 runAsync.runModules(modules, input,
   function handleResult(modName, result, err, ms) {

--- a/run-sessionstart.js
+++ b/run-sessionstart.js
@@ -20,7 +20,8 @@ try {
 }
 
 var ctx = hookLog.extractContext("SessionStart", input);
-var modules = loadModules(path.join(__dirname, "run-modules", "SessionStart"));
+var modulesDir = process.env.HOOK_RUNNER_MODULES_DIR || path.join(__dirname, "run-modules");
+var modules = loadModules(path.join(modulesDir, "SessionStart"));
 var output = [];
 
 runAsync.runModules(modules, input,

--- a/run-stop.js
+++ b/run-stop.js
@@ -24,7 +24,8 @@ try {
 if (input.stop_hook_active) process.exit(0);
 
 var ctx = hookLog.extractContext("Stop", input);
-var modulePaths = loadModules(path.join(__dirname, "run-modules", "Stop"));
+var modulesDir = process.env.HOOK_RUNNER_MODULES_DIR || path.join(__dirname, "run-modules");
+var modulePaths = loadModules(path.join(modulesDir, "Stop"));
 
 // Known blocking modules — these return {decision:"block"} and are fast.
 // Run them directly. Everything else goes to background.

--- a/scripts/test/test-e2e-enforcement.js
+++ b/scripts/test/test-e2e-enforcement.js
@@ -1,12 +1,15 @@
 #!/usr/bin/env node
 "use strict";
-// T403b: E2E enforcement tests — pipe real input through the full runner pipeline
-// and verify block/pass results. Tests the actual enforcement, not just module loading.
+// T447: E2E enforcement tests — isolated from live hooks environment.
+// Each test creates a temp modules dir with only the specific module(s) needed,
+// a workflow-config.json enabling shtd, and runs the runner against that.
 //
-// Each test case:
-// 1. Creates realistic hook input JSON
-// 2. Pipes it through the actual runner (run-pretooluse.js, run-stop.js, etc.)
-// 3. Checks exit code and stdout for expected block/pass behavior
+// Previously failed because:
+// 1. Repo's run-modules/ only had a subset of modules (missing git-destructive-guard etc.)
+// 2. Live session state (commit-counter, workflow) interfered with test expectations
+// 3. No Stop modules in repo's run-modules/ at all
+//
+// Fix: HOOK_RUNNER_MODULES_DIR env var + per-test isolated temp dirs.
 //
 // Usage: node scripts/test/test-e2e-enforcement.js
 
@@ -16,19 +19,79 @@ var fs = require("fs");
 var os = require("os");
 
 var runnerDir = path.join(__dirname, "..", "..");
+var catalogDir = path.join(runnerDir, "modules");
 var passed = 0, failed = 0;
+
+// Create isolated temp environment for a test
+function createIsolatedEnv(modules) {
+  // modules: [{event: "PreToolUse", name: "git-destructive-guard.js"}, ...]
+  var tmpBase = path.join(os.tmpdir(), "e2e-" + process.pid + "-" + Date.now());
+  var modulesDir = path.join(tmpBase, "run-modules");
+  var projectDir = path.join(tmpBase, "project");
+
+  fs.mkdirSync(tmpBase, { recursive: true });
+  fs.mkdirSync(projectDir, { recursive: true });
+
+  // Create workflow-config.json enabling shtd + starter
+  fs.writeFileSync(path.join(projectDir, "workflow-config.json"),
+    JSON.stringify({ shtd: true, starter: true }) + "\n");
+
+  // Create a minimal .git/HEAD so git-related checks don't crash
+  var gitDir = path.join(projectDir, ".git");
+  fs.mkdirSync(gitDir, { recursive: true });
+  fs.writeFileSync(path.join(gitDir, "HEAD"), "ref: refs/heads/test-branch\n");
+
+  // Create TODO.md with an unchecked task (so spec-gate doesn't block)
+  fs.writeFileSync(path.join(projectDir, "TODO.md"), "- [ ] T999: Test task\n");
+
+  // Copy requested modules into isolated run-modules dir
+  var events = {};
+  for (var i = 0; i < modules.length; i++) {
+    var m = modules[i];
+    if (!events[m.event]) events[m.event] = [];
+    events[m.event].push(m.name);
+  }
+  var eventNames = Object.keys(events);
+  for (var e = 0; e < eventNames.length; e++) {
+    var eventName = eventNames[e];
+    var eventDir = path.join(modulesDir, eventName);
+    fs.mkdirSync(eventDir, { recursive: true });
+    var modNames = events[eventName];
+    for (var j = 0; j < modNames.length; j++) {
+      var src = path.join(catalogDir, eventName, modNames[j]);
+      var dest = path.join(eventDir, modNames[j]);
+      if (fs.existsSync(src)) {
+        fs.copyFileSync(src, dest);
+      }
+    }
+  }
+
+  return { tmpBase: tmpBase, modulesDir: modulesDir, projectDir: projectDir };
+}
+
+function cleanupEnv(env) {
+  try { fs.rmSync(env.tmpBase, { recursive: true, force: true }); } catch (e) {}
+}
 
 function test(name, opts) {
   var runner = path.join(runnerDir, opts.runner);
   var input = JSON.stringify(opts.input);
+
+  // Create isolated environment
+  var isolated = createIsolatedEnv(opts.modules || []);
+
+  // Build clean env
   var env = {};
   var envKeys = Object.keys(process.env);
   for (var i = 0; i < envKeys.length; i++) env[envKeys[i]] = process.env[envKeys[i]];
+
   // Use temp file approach like run-hidden.js does
   var tmpFile = path.join(os.tmpdir(), "e2e-test-" + process.pid + "-" + Date.now() + ".json");
   fs.writeFileSync(tmpFile, input);
   env.HOOK_INPUT_FILE = tmpFile;
   env.HOOK_RUNNER_TEST = "1";
+  env.HOOK_RUNNER_MODULES_DIR = isolated.modulesDir;
+  env.CLAUDE_PROJECT_DIR = opts.projectDir || isolated.projectDir;
 
   var result = cp.spawnSync(process.execPath, [runner], {
     input: input,
@@ -39,6 +102,7 @@ function test(name, opts) {
   });
 
   try { fs.unlinkSync(tmpFile); } catch (e) {}
+  cleanupEnv(isolated);
 
   var exitCode = result.status;
   var stdout = (result.stdout || "").toString();
@@ -71,17 +135,14 @@ function test(name, opts) {
     }
   } else {
     // Expect pass
-    if (exitCode !== 0 || stdout.length > 0) {
-      // Check if stdout is a block
-      if (stdout.length > 0) {
-        try {
-          var p = JSON.parse(stdout);
-          if (p.decision === "block") {
-            ok = false;
-            reasons.push("expected pass but got block: " + (p.reason || "").slice(0, 100));
-          }
-        } catch (e) {}
-      }
+    if (stdout.length > 0) {
+      try {
+        var p = JSON.parse(stdout);
+        if (p.decision === "block") {
+          ok = false;
+          reasons.push("expected pass but got block: " + (p.reason || "").slice(0, 150));
+        }
+      } catch (e) {}
     }
   }
 
@@ -94,107 +155,85 @@ function test(name, opts) {
     for (var r = 0; r < reasons.length; r++) {
       console.log("  " + reasons[r]);
     }
-    if (stderr.length > 0) {
-      console.log("  stderr: " + stderr.slice(0, 200));
+    if (stderr.length > 0 && !ok) {
+      console.log("  stderr: " + stderr.slice(0, 300));
     }
   }
 }
 
 // === PreToolUse E2E Tests ===
 
-// 1. spec-gate: reads real .git/HEAD (not input._git), so we test with a
-// command that spec-gate always blocks regardless of branch: implementation
-// commands on main. Since we run on a feature branch, we test the allowlist
-// instead — npm install is NOT in the safe-command list on feature branches
-// without specs. But hook-runner HAS specs/ so it passes. This is correct.
-// The E2E test for spec-gate requires a repo without specs/ to trigger blocks.
-// Replaced with: spec-gate allows safe commands (git log)
-test("spec-gate: allows safe read-only commands", {
-  runner: "run-pretooluse.js",
-  input: {
-    tool_name: "Bash",
-    tool_input: { command: "git log --oneline -5" },
-    _git: { branch: "main", tracking: true }
-  },
-  expectBlock: false
-});
-
-// 2. spec-gate: should pass for git status (always allowed)
-test("spec-gate: allows git status on any branch", {
-  runner: "run-pretooluse.js",
-  input: {
-    tool_name: "Bash",
-    tool_input: { command: "git status" },
-    _git: { branch: "main", tracking: true }
-  },
-  expectBlock: false
-});
-
-// 3. git-destructive-guard: should block git reset --hard
+// 1. git-destructive-guard: should block git reset --hard
 test("git-destructive-guard: blocks git reset --hard", {
   runner: "run-pretooluse.js",
+  modules: [{ event: "PreToolUse", name: "git-destructive-guard.js" }],
   input: {
     tool_name: "Bash",
     tool_input: { command: "git reset --hard HEAD~1" },
-    _git: { branch: "265-T403-enforcement-visibility", tracking: true }
+    _git: { branch: "test-branch", tracking: true }
   },
   expectBlock: true,
   expectReason: "DESTRUCTIVE"
 });
 
-// 4. git-destructive-guard: should block git checkout .
+// 2. git-destructive-guard: should block git checkout .
 test("git-destructive-guard: blocks git checkout .", {
   runner: "run-pretooluse.js",
+  modules: [{ event: "PreToolUse", name: "git-destructive-guard.js" }],
   input: {
     tool_name: "Bash",
     tool_input: { command: "git checkout ." },
-    _git: { branch: "265-T403-enforcement-visibility", tracking: true }
+    _git: { branch: "test-branch", tracking: true }
   },
   expectBlock: true,
   expectReason: "DESTRUCTIVE"
 });
 
-// 5. archive-not-delete: should block rm command
+// 3. archive-not-delete: should block rm command
 test("archive-not-delete: blocks rm on files", {
   runner: "run-pretooluse.js",
+  modules: [{ event: "PreToolUse", name: "archive-not-delete.js" }],
   input: {
     tool_name: "Bash",
     tool_input: { command: "rm scripts/test/old-test.js" },
-    _git: { branch: "265-T403-enforcement-visibility", tracking: true }
+    _git: { branch: "test-branch", tracking: true }
   },
   expectBlock: true,
   expectReason: "delete"
 });
 
-// 6. force-push-gate: should block git push --force
-test("force-push-gate: blocks force push to main", {
+// 4. force-push-gate: should block git push --force
+test("force-push-gate: blocks force push", {
   runner: "run-pretooluse.js",
+  modules: [{ event: "PreToolUse", name: "force-push-gate.js" }],
   input: {
     tool_name: "Bash",
     tool_input: { command: "git push --force origin main" },
-    _git: { branch: "265-T403-enforcement-visibility", tracking: true }
+    _git: { branch: "test-branch", tracking: true }
   },
   expectBlock: true
 });
 
-// 7. no-rules-gate: should block creating .claude/rules files
+// 5. no-rules-gate: should block creating .claude/rules files
 test("no-rules-gate: blocks creating rules files", {
   runner: "run-pretooluse.js",
+  modules: [{ event: "PreToolUse", name: "no-rules-gate.js" }],
   input: {
     tool_name: "Write",
     tool_input: {
       file_path: path.join(os.homedir(), ".claude", "rules", "new-rule.md").replace(/\\/g, "/"),
       content: "# Some rule\nDo this thing."
     },
-    _git: { branch: "265-T403-enforcement-visibility", tracking: true }
+    _git: { branch: "test-branch", tracking: true }
   },
   expectBlock: true,
   expectReason: "rules"
 });
 
-// 8. branch-pr-gate: Edit on main should be blocked
+// 6. branch-pr-gate: Edit on main should be blocked
 test("branch-pr-gate: blocks Edit on main", {
   runner: "run-pretooluse.js",
+  modules: [{ event: "PreToolUse", name: "branch-pr-gate.js" }],
   input: {
     tool_name: "Edit",
     tool_input: {
@@ -207,50 +246,52 @@ test("branch-pr-gate: blocks Edit on main", {
   expectBlock: true
 });
 
-// 9. Normal operation: Bash echo should pass
-test("normal: Bash echo passes all gates", {
-  runner: "run-pretooluse.js",
-  input: {
-    tool_name: "Bash",
-    tool_input: { command: "echo hello" },
-    _git: { branch: "265-T403-enforcement-visibility", tracking: true }
-  },
-  expectBlock: false
-});
-
-// 10. Normal operation: Read should always pass
+// 7. Normal operation: Read should always pass (no modules = no blocks)
 test("normal: Read always passes", {
   runner: "run-pretooluse.js",
+  modules: [{ event: "PreToolUse", name: "git-destructive-guard.js" }],
   input: {
     tool_name: "Read",
     tool_input: { file_path: "/tmp/test.js" },
-    _git: { branch: "265-T403-enforcement-visibility", tracking: true }
+    _git: { branch: "test-branch", tracking: true }
   },
   expectBlock: false
 });
 
-// 11. hook-editing-gate: should block cp to hooks dir from non-hook-runner project
-test("hook-editing-gate: blocks Bash cp to hooks dir", {
+// 8. Normal operation: safe Bash commands pass destructive guard
+test("normal: git log passes destructive guard", {
   runner: "run-pretooluse.js",
+  modules: [{ event: "PreToolUse", name: "git-destructive-guard.js" }],
   input: {
     tool_name: "Bash",
-    tool_input: { command: "cp my-module.js ~/.claude/hooks/run-modules/PreToolUse/" },
-    _git: { branch: "265-T403-enforcement-visibility", tracking: true }
+    tool_input: { command: "git log --oneline -5" },
+    _git: { branch: "test-branch", tracking: true }
   },
-  // This will only block if CLAUDE_PROJECT_DIR is NOT hook-runner.
-  // Since we run from hook-runner, it should pass (allowed for sync-live).
   expectBlock: false
 });
 
-// 12. hook-editing-gate: should block mv to hooks dir from non-hook-runner project
-test("hook-editing-gate: blocks Bash mv to run-modules/", {
+// 9. archive-not-delete: allows mv (not a delete)
+test("archive-not-delete: allows mv command", {
   runner: "run-pretooluse.js",
+  modules: [{ event: "PreToolUse", name: "archive-not-delete.js" }],
   input: {
     tool_name: "Bash",
-    tool_input: { command: "mv gate.js $HOME/.claude/hooks/run-modules/PreToolUse/" },
-    _git: { branch: "265-T403-enforcement-visibility", tracking: true }
+    tool_input: { command: "mv old.js archive/old.js" },
+    _git: { branch: "test-branch", tracking: true }
   },
-  expectBlock: false // allowed from hook-runner
+  expectBlock: false
+});
+
+// 10. force-push-gate: allows normal push
+test("force-push-gate: allows normal push", {
+  runner: "run-pretooluse.js",
+  modules: [{ event: "PreToolUse", name: "force-push-gate.js" }],
+  input: {
+    tool_name: "Bash",
+    tool_input: { command: "git push origin main" },
+    _git: { branch: "test-branch", tracking: true }
+  },
+  expectBlock: false
 });
 
 // === Stop E2E Tests ===
@@ -258,6 +299,7 @@ test("hook-editing-gate: blocks Bash mv to run-modules/", {
 // 11. auto-continue: Stop should block (auto-continue fires)
 test("auto-continue: Stop hook blocks to continue work", {
   runner: "run-stop.js",
+  modules: [{ event: "Stop", name: "auto-continue.js" }],
   input: {
     session_id: "test-e2e",
     stop_hook_active: false

--- a/scripts/test/test-gsd-plan-gate.js
+++ b/scripts/test/test-gsd-plan-gate.js
@@ -1,0 +1,313 @@
+#!/usr/bin/env node
+"use strict";
+// T452: E2E tests for gsd-plan-gate module.
+// Tests the GSD pipeline enforcement: .planning/ROADMAP.md → phases → PLAN.md
+//
+// Uses HOOK_RUNNER_MODULES_DIR for isolation (same pattern as test-e2e-enforcement.js).
+
+var cp = require("child_process");
+var path = require("path");
+var fs = require("fs");
+var os = require("os");
+
+var runnerDir = path.join(__dirname, "..", "..");
+var catalogDir = path.join(runnerDir, "modules");
+var passed = 0, failed = 0;
+
+function createEnv(opts) {
+  // opts: { hasRoadmap, phases, hasTodo, phaseDirs }
+  var tmpBase = path.join(os.tmpdir(), "gsd-test-" + process.pid + "-" + Date.now() + "-" + Math.random().toString(36).slice(2, 6));
+  var modulesDir = path.join(tmpBase, "run-modules");
+  var projectDir = path.join(tmpBase, "project");
+
+  fs.mkdirSync(tmpBase, { recursive: true });
+  fs.mkdirSync(projectDir, { recursive: true });
+
+  // Workflow config enabling gsd
+  fs.writeFileSync(path.join(projectDir, "workflow-config.json"),
+    JSON.stringify({ gsd: true }) + "\n");
+
+  // Minimal .git/HEAD
+  var gitDir = path.join(projectDir, ".git");
+  fs.mkdirSync(gitDir, { recursive: true });
+  fs.writeFileSync(path.join(gitDir, "HEAD"), "ref: refs/heads/test-branch\n");
+
+  // TODO.md
+  if (opts.hasTodo) {
+    fs.writeFileSync(path.join(projectDir, "TODO.md"), "- [ ] Fix something\n");
+  }
+
+  // .planning/ROADMAP.md
+  if (opts.hasRoadmap) {
+    var planningDir = path.join(projectDir, ".planning");
+    fs.mkdirSync(planningDir, { recursive: true });
+
+    var roadmapContent = "# Roadmap\n\n";
+    var phases = opts.phases || [];
+    for (var i = 0; i < phases.length; i++) {
+      roadmapContent += "## Phase " + phases[i].number + ": " + phases[i].name + "\n\n";
+      roadmapContent += "**Goal:** " + phases[i].name + "\n\n";
+    }
+    fs.writeFileSync(path.join(planningDir, "ROADMAP.md"), roadmapContent);
+
+    // Phase directories with optional PLAN.md
+    var phaseDirs = opts.phaseDirs || [];
+    if (phaseDirs.length > 0) {
+      var phasesBaseDir = path.join(planningDir, "phases");
+      fs.mkdirSync(phasesBaseDir, { recursive: true });
+      for (var j = 0; j < phaseDirs.length; j++) {
+        var pd = phaseDirs[j];
+        var dirName = pd.number + "-" + pd.slug;
+        var phaseDir = path.join(phasesBaseDir, dirName);
+        fs.mkdirSync(phaseDir, { recursive: true });
+        if (pd.hasPlan) {
+          fs.writeFileSync(path.join(phaseDir, "PLAN.md"), "# Plan\n\nDo the thing.\n");
+        }
+      }
+    }
+  }
+
+  // Copy gsd-plan-gate module
+  var eventDir = path.join(modulesDir, "PreToolUse");
+  fs.mkdirSync(eventDir, { recursive: true });
+  fs.copyFileSync(
+    path.join(catalogDir, "PreToolUse", "gsd-plan-gate.js"),
+    path.join(eventDir, "gsd-plan-gate.js")
+  );
+
+  return { tmpBase: tmpBase, modulesDir: modulesDir, projectDir: projectDir };
+}
+
+function cleanup(env) {
+  try { fs.rmSync(env.tmpBase, { recursive: true, force: true }); } catch (e) {}
+}
+
+function test(name, opts) {
+  var runner = path.join(runnerDir, opts.runner || "run-pretooluse.js");
+  var input = JSON.stringify(opts.input);
+  var isolated = createEnv(opts.env || {});
+
+  var env = {};
+  var envKeys = Object.keys(process.env);
+  for (var i = 0; i < envKeys.length; i++) env[envKeys[i]] = process.env[envKeys[i]];
+
+  var tmpFile = path.join(os.tmpdir(), "gsd-test-input-" + process.pid + "-" + Date.now() + ".json");
+  fs.writeFileSync(tmpFile, input);
+  env.HOOK_INPUT_FILE = tmpFile;
+  env.HOOK_RUNNER_TEST = "1";
+  env.HOOK_RUNNER_MODULES_DIR = isolated.modulesDir;
+  env.CLAUDE_PROJECT_DIR = isolated.projectDir;
+
+  var result = cp.spawnSync(process.execPath, [runner], {
+    input: input,
+    env: env,
+    timeout: 10000,
+    windowsHide: true,
+    maxBuffer: 1024 * 1024
+  });
+
+  try { fs.unlinkSync(tmpFile); } catch (e) {}
+  cleanup(isolated);
+
+  var stdout = (result.stdout || "").toString();
+  var stderr = (result.stderr || "").toString();
+
+  var ok = true;
+  var reasons = [];
+
+  if (opts.expectBlock) {
+    if (result.status === 0 && stdout.length === 0) {
+      ok = false;
+      reasons.push("expected block but got pass (exit 0, no stdout)");
+    }
+    if (stdout.length > 0) {
+      try {
+        var parsed = JSON.parse(stdout);
+        if (parsed.decision !== "block") {
+          ok = false;
+          reasons.push("stdout JSON has decision=" + parsed.decision + ", expected block");
+        }
+        if (opts.expectReason && stdout.indexOf(opts.expectReason) === -1) {
+          ok = false;
+          reasons.push("block reason missing '" + opts.expectReason + "'");
+        }
+      } catch (e) {}
+    }
+  } else {
+    if (stdout.length > 0) {
+      try {
+        var p = JSON.parse(stdout);
+        if (p.decision === "block") {
+          ok = false;
+          reasons.push("expected pass but got block: " + (p.reason || "").slice(0, 150));
+        }
+      } catch (e) {}
+    }
+  }
+
+  if (ok) {
+    passed++;
+    console.log("OK: " + name);
+  } else {
+    failed++;
+    console.log("FAIL: " + name);
+    for (var r = 0; r < reasons.length; r++) console.log("  " + reasons[r]);
+    if (stderr.length > 0 && !ok) console.log("  stderr: " + stderr.slice(0, 300));
+  }
+}
+
+// === Tests ===
+
+// 1. No .planning, no TODO.md → block
+test("blocks when no .planning and no TODO.md", {
+  env: { hasRoadmap: false, hasTodo: false },
+  input: {
+    tool_name: "Edit",
+    tool_input: { file_path: "/tmp/project/src/app.js", old_string: "a", new_string: "b" },
+    _git: { branch: "test-branch", tracking: true }
+  },
+  expectBlock: true,
+  expectReason: "GSD GATE"
+});
+
+// 2. No .planning but TODO.md with tasks → pass
+test("allows when TODO.md has unchecked tasks", {
+  env: { hasRoadmap: false, hasTodo: true },
+  input: {
+    tool_name: "Edit",
+    tool_input: { file_path: "/tmp/project/src/app.js", old_string: "a", new_string: "b" },
+    _git: { branch: "test-branch", tracking: true }
+  },
+  expectBlock: false
+});
+
+// 3. ROADMAP.md with no phases → block
+test("blocks when ROADMAP.md has no phases", {
+  env: { hasRoadmap: true, phases: [], hasTodo: false },
+  input: {
+    tool_name: "Edit",
+    tool_input: { file_path: "/tmp/project/src/app.js", old_string: "a", new_string: "b" },
+    _git: { branch: "test-branch", tracking: true }
+  },
+  expectBlock: true,
+  expectReason: "no phases"
+});
+
+// 4. ROADMAP.md with phases but no phase dirs (early project) → pass
+test("allows early project with phases but no phase dirs", {
+  env: {
+    hasRoadmap: true,
+    phases: [{ number: "1", name: "Setup" }, { number: "2", name: "Core" }],
+    hasTodo: false
+  },
+  input: {
+    tool_name: "Edit",
+    tool_input: { file_path: "/tmp/project/src/app.js", old_string: "a", new_string: "b" },
+    _git: { branch: "test-branch", tracking: true }
+  },
+  expectBlock: false
+});
+
+// 5. Phase dirs exist but no PLAN.md → block
+test("blocks when phase dirs exist but no PLAN.md", {
+  env: {
+    hasRoadmap: true,
+    phases: [{ number: "1", name: "Setup" }],
+    phaseDirs: [{ number: "1", slug: "setup", hasPlan: false }],
+    hasTodo: false
+  },
+  input: {
+    tool_name: "Edit",
+    tool_input: { file_path: "/tmp/project/src/app.js", old_string: "a", new_string: "b" },
+    _git: { branch: "test-branch", tracking: true }
+  },
+  expectBlock: true,
+  expectReason: "No active phase has a PLAN.md"
+});
+
+// 6. Phase dir with PLAN.md → pass
+test("allows when phase has PLAN.md", {
+  env: {
+    hasRoadmap: true,
+    phases: [{ number: "1", name: "Setup" }],
+    phaseDirs: [{ number: "1", slug: "setup", hasPlan: true }],
+    hasTodo: false
+  },
+  input: {
+    tool_name: "Edit",
+    tool_input: { file_path: "/tmp/project/src/app.js", old_string: "a", new_string: "b" },
+    _git: { branch: "test-branch", tracking: true }
+  },
+  expectBlock: false
+});
+
+// 7. .planning/ files always allowed (even without roadmap)
+test("allows editing .planning/ files always", {
+  env: { hasRoadmap: false, hasTodo: false },
+  input: {
+    tool_name: "Write",
+    tool_input: { file_path: "/tmp/project/.planning/ROADMAP.md", content: "# Roadmap" },
+    _git: { branch: "test-branch", tracking: true }
+  },
+  expectBlock: false
+});
+
+// 8. TODO.md always allowed
+test("allows editing TODO.md always", {
+  env: { hasRoadmap: false, hasTodo: false },
+  input: {
+    tool_name: "Edit",
+    tool_input: { file_path: "/tmp/project/TODO.md", old_string: "a", new_string: "b" },
+    _git: { branch: "test-branch", tracking: true }
+  },
+  expectBlock: false
+});
+
+// 9. Read-only Bash always passes
+test("allows read-only bash commands", {
+  env: { hasRoadmap: false, hasTodo: false },
+  input: {
+    tool_name: "Bash",
+    tool_input: { command: "git status" },
+    _git: { branch: "test-branch", tracking: true }
+  },
+  expectBlock: false
+});
+
+// 10. State-changing Bash blocked without plan
+test("blocks state-changing bash without plan", {
+  env: { hasRoadmap: false, hasTodo: false },
+  input: {
+    tool_name: "Bash",
+    tool_input: { command: "npm run build" },
+    _git: { branch: "test-branch", tracking: true }
+  },
+  expectBlock: true,
+  expectReason: "GSD GATE"
+});
+
+// 11. Read tool always passes
+test("Read tool always passes", {
+  env: { hasRoadmap: false, hasTodo: false },
+  input: {
+    tool_name: "Read",
+    tool_input: { file_path: "/tmp/test.js" },
+    _git: { branch: "test-branch", tracking: true }
+  },
+  expectBlock: false
+});
+
+// 12. Test files always allowed
+test("allows test file edits", {
+  env: { hasRoadmap: false, hasTodo: false },
+  input: {
+    tool_name: "Write",
+    tool_input: { file_path: "/tmp/project/scripts/test/test-foo.js", content: "test" },
+    _git: { branch: "test-branch", tracking: true }
+  },
+  expectBlock: false
+});
+
+// === Summary ===
+console.log("\n" + passed + " passed, " + failed + " failed");
+process.exit(failed > 0 ? 1 : 0);

--- a/setup.js
+++ b/setup.js
@@ -767,6 +767,10 @@ function cmdHelp() {
   console.log("  --integrity     Full integrity scan (file drift + workflow compliance)");
   console.log("  --preflight     Enforcement status: active rules, never-fired gates, pipeline health");
   console.log("  --manifest      Generate ENFORCEMENT.md from live modules + hook log");
+  console.log("  --snapshot         Create SHA256 snapshot of current state");
+  console.log("  --snapshot drift   Detect drift from last snapshot (--json for machine output)");
+  console.log("  --snapshot backup  Copy files to git repo, commit, push");
+  console.log("  --snapshot restore Clone repo and copy files back into place");
   console.log("  --help, -h      Show this help");
   console.log("");
   console.log("Options:");
@@ -1728,6 +1732,13 @@ function main() {
         args.indexOf("--json") !== -1 ? ["--json"] : []
       ), { stdio: "inherit", windowsHide: true });
     process.exit(mfResult.status || 0);
+  }
+  if (args.indexOf("--snapshot") !== -1) {
+    var snapArgs = args.slice(args.indexOf("--snapshot") + 1).filter(function(a) { return a.indexOf("--snapshot") === -1; });
+    var snapResult = require("child_process").spawnSync(process.execPath,
+      [path.join(__dirname, "snapshot.js")].concat(snapArgs.length ? snapArgs : ["create"]),
+      { stdio: "inherit", windowsHide: true });
+    process.exit(snapResult.status || 0);
   }
   if (args.indexOf("--health") !== -1) return cmdHealth();
   if (args.indexOf("--sync") !== -1) return cmdSync(dryRun);

--- a/snapshot.js
+++ b/snapshot.js
@@ -1,0 +1,372 @@
+#!/usr/bin/env node
+"use strict";
+// snapshot.js — Snapshot, drift detection, and git-backed backup/restore.
+//
+// Usage:
+//   node snapshot.js create                # SHA256 manifest of current state
+//   node snapshot.js drift [--json]        # detect changes since last snapshot
+//   node snapshot.js backup [--repo URL]   # copy files to git repo, commit, push
+//   node snapshot.js restore <repo|dir>    # clone repo, copy files into place
+
+var fs = require("fs");
+var path = require("path");
+var os = require("os");
+var crypto = require("crypto");
+var cp = require("child_process");
+
+var HOME = os.homedir();
+var CLAUDE_DIR = path.join(HOME, ".claude");
+var HOOKS_DIR = path.join(CLAUDE_DIR, "hooks");
+var MODULES_DIR = path.join(HOOKS_DIR, "run-modules");
+var WORKFLOWS_DIR = path.join(HOOKS_DIR, "workflows");
+var SKILLS_DIR = path.join(CLAUDE_DIR, "skills");
+var SNAPSHOTS_DIR = path.join(CLAUDE_DIR, "snapshots");
+var VERSION = require(path.join(__dirname, "package.json")).version;
+var EVENTS = ["PreToolUse", "PostToolUse", "SessionStart", "Stop", "UserPromptSubmit"];
+
+// ── Helpers ──
+
+function sha256(p) {
+  try { return crypto.createHash("sha256").update(fs.readFileSync(p)).digest("hex"); }
+  catch (e) { return null; }
+}
+
+function fsize(p) { try { return fs.statSync(p).size; } catch (e) { return 0; } }
+
+function ensureDir(d) { if (!fs.existsSync(d)) fs.mkdirSync(d, { recursive: true }); }
+
+function walkDir(dir, prefix) {
+  prefix = prefix || "";
+  var out = [];
+  var ents;
+  try { ents = fs.readdirSync(dir, { withFileTypes: true }); } catch (e) { return out; }
+  for (var i = 0; i < ents.length; i++) {
+    var n = ents[i].name;
+    if (n === ".git" || n === "archive" || n === "node_modules") continue;
+    if (n.endsWith(".jsonl") || n.endsWith(".log")) continue;
+    var rel = prefix ? prefix + "/" + n : n;
+    if (ents[i].isDirectory()) out = out.concat(walkDir(path.join(dir, n), rel));
+    else if (ents[i].isFile()) out.push(rel);
+  }
+  return out;
+}
+
+function findMcpDir() {
+  var mcpJson = path.join(CLAUDE_DIR, ".mcp.json");
+  if (fs.existsSync(mcpJson)) {
+    try {
+      var cfg = JSON.parse(fs.readFileSync(mcpJson, "utf-8"));
+      var mgr = cfg.mcpServers && cfg.mcpServers["mcp-manager"];
+      if (mgr && mgr.args && mgr.args[0]) {
+        var d = path.dirname(path.dirname(mgr.args[0]));
+        if (fs.existsSync(d)) return d;
+      }
+    } catch (e) {}
+  }
+  var od = path.join(HOME, "OneDrive - TrendMicro", "Documents", "ProjectsCL", "MCP", "mcp-manager");
+  return fs.existsSync(od) ? od : null;
+}
+
+// ── Collect all files to snapshot ──
+
+function collectFiles() {
+  var files = {};
+  function add(cat, absPath, label) {
+    var h = sha256(absPath);
+    if (h) files[label] = { category: cat, sha256: h, size: fsize(absPath), absPath: absPath.replace(/\\/g, "/") };
+  }
+
+  // Config
+  ["settings.json", "CLAUDE.md", ".mcp.json"].forEach(function(f) {
+    var p = path.join(CLAUDE_DIR, f);
+    if (fs.existsSync(p)) add("config", p, "config/" + f);
+  });
+
+  // Runners
+  var RUNNERS = require(path.join(__dirname, "constants.js")).RUNNER_FILES;
+  RUNNERS.forEach(function(f) {
+    var p = path.join(HOOKS_DIR, f);
+    if (fs.existsSync(p)) add("runner", p, "runners/" + f);
+  });
+
+  // GSD + standalone hooks
+  try {
+    fs.readdirSync(HOOKS_DIR).forEach(function(f) {
+      if (f.startsWith("gsd-") && (f.endsWith(".js") || f.endsWith(".sh")))
+        add("gsd-hook", path.join(HOOKS_DIR, f), "gsd-hooks/" + f);
+    });
+  } catch (e) {}
+  ["report.js", "setup.js", "run-hidden.js", "run-stop-bg.js", "watchdog.js",
+   "reflection-score.js", "generate-manifest.js"].forEach(function(f) {
+    var p = path.join(HOOKS_DIR, f);
+    if (fs.existsSync(p)) add("standalone", p, "standalone/" + f);
+  });
+
+  // Modules
+  EVENTS.forEach(function(evt) {
+    walkDir(path.join(MODULES_DIR, evt)).forEach(function(f) {
+      add("module", path.join(MODULES_DIR, evt, f), "modules/" + evt + "/" + f);
+    });
+  });
+
+  // Workflows
+  if (fs.existsSync(WORKFLOWS_DIR)) {
+    fs.readdirSync(WORKFLOWS_DIR).filter(function(f) { return f.endsWith(".yml"); }).forEach(function(f) {
+      add("workflow", path.join(WORKFLOWS_DIR, f), "workflows/" + f);
+    });
+  }
+
+  // State files
+  ["workflow-config.json", "reflection-score.json"].forEach(function(f) {
+    var p = path.join(HOOKS_DIR, f);
+    if (fs.existsSync(p)) add("state", p, "state/" + f);
+  });
+
+  // Skills (SKILL.md + entry scripts only)
+  if (fs.existsSync(SKILLS_DIR)) {
+    try {
+      fs.readdirSync(SKILLS_DIR).forEach(function(sk) {
+        var skDir = path.join(SKILLS_DIR, sk);
+        try { if (!fs.statSync(skDir).isDirectory()) return; } catch (e) { return; }
+        try {
+          fs.readdirSync(skDir).forEach(function(f) {
+            if (f === "SKILL.md" || f.endsWith(".js") || f.endsWith(".sh") || f.endsWith(".ps1") || f.endsWith(".py"))
+              add("skill", path.join(skDir, f), "skills/" + sk + "/" + f);
+          });
+        } catch (e) {}
+      });
+    } catch (e) {}
+  }
+
+  // MCP config
+  var mcpDir = findMcpDir();
+  if (mcpDir) {
+    ["servers.yaml", "capabilities-cache.yaml", "default-servers.json", "metadata.yaml"].forEach(function(f) {
+      var p = path.join(mcpDir, f);
+      if (fs.existsSync(p)) add("mcp", p, "mcp/" + f);
+    });
+  }
+
+  return files;
+}
+
+// ── Create snapshot ──
+
+function createSnapshot() {
+  var files = collectFiles();
+  var manifest = {
+    version: "1.0.0",
+    hookRunnerVersion: VERSION,
+    timestamp: new Date().toISOString(),
+    platform: process.platform,
+    files: files
+  };
+
+  ensureDir(SNAPSHOTS_DIR);
+  var name = manifest.timestamp.replace(/[:.]/g, "-").replace("T", "_").slice(0, 19);
+  var snapPath = path.join(SNAPSHOTS_DIR, name + ".json");
+  fs.writeFileSync(snapPath, JSON.stringify(manifest, null, 2));
+  fs.writeFileSync(path.join(SNAPSHOTS_DIR, "latest.json"), JSON.stringify(manifest, null, 2));
+
+  var n = Object.keys(files).length;
+  console.log("[snapshot] " + n + " files captured -> " + name);
+  return { path: snapPath, manifest: manifest };
+}
+
+// ── Drift detection ──
+
+function detectDrift(jsonMode) {
+  var latestPath = path.join(SNAPSHOTS_DIR, "latest.json");
+  if (!fs.existsSync(latestPath)) {
+    console.error("[drift] No snapshot. Run: node snapshot.js create");
+    process.exit(1);
+  }
+
+  var snap = JSON.parse(fs.readFileSync(latestPath, "utf-8"));
+  var results = { timestamp: snap.timestamp, modified: [], removed: [], added: [], unchanged: 0 };
+  var ageH = Math.round((Date.now() - new Date(snap.timestamp).getTime()) / 3600000);
+
+  // Check tracked files
+  var labels = Object.keys(snap.files);
+  for (var i = 0; i < labels.length; i++) {
+    var e = snap.files[labels[i]];
+    var h = sha256(e.absPath.replace(/\//g, path.sep));
+    if (!h) results.removed.push(labels[i]);
+    else if (h !== e.sha256) results.modified.push(labels[i]);
+    else results.unchanged++;
+  }
+
+  // Check for new files
+  var live = collectFiles();
+  Object.keys(live).forEach(function(l) { if (!snap.files[l]) results.added.push(l); });
+
+  if (jsonMode) { console.log(JSON.stringify(results, null, 2)); return results; }
+
+  var total = results.modified.length + results.removed.length + results.added.length;
+  if (total === 0) {
+    console.log("[drift] OK — " + results.unchanged + " files unchanged (snapshot " + ageH + "h old)");
+    return results;
+  }
+
+  console.log("[drift] " + total + " change(s) detected (snapshot " + ageH + "h old):");
+  results.modified.forEach(function(f) { console.log("  [MOD] " + f); });
+  results.removed.forEach(function(f) { console.log("  [DEL] " + f); });
+  results.added.forEach(function(f) { console.log("  [NEW] " + f); });
+  return results;
+}
+
+// ── Backup to git repo ──
+
+function backup(repoUrl) {
+  // Find or create backup dir
+  var backupDir = path.join(CLAUDE_DIR, "backup-repo");
+  var isNew = false;
+
+  if (!fs.existsSync(backupDir)) {
+    if (repoUrl) {
+      console.log("[backup] Cloning " + repoUrl + "...");
+      cp.execSync('git clone "' + repoUrl + '" "' + backupDir.replace(/\\/g, "/") + '"', { stdio: "pipe", windowsHide: true });
+    } else {
+      ensureDir(backupDir);
+      cp.execSync("git init", { cwd: backupDir, stdio: "pipe", windowsHide: true });
+      isNew = true;
+    }
+  }
+
+  // Create snapshot first
+  var snap = createSnapshot();
+  var files = snap.manifest.files;
+
+  // Copy all files into backup repo
+  var labels = Object.keys(files);
+  var copied = 0;
+  for (var i = 0; i < labels.length; i++) {
+    var src = files[labels[i]].absPath.replace(/\//g, path.sep);
+    var dest = path.join(backupDir, labels[i].replace(/\//g, path.sep));
+    ensureDir(path.dirname(dest));
+    try { fs.copyFileSync(src, dest); copied++; } catch (e) {}
+  }
+
+  // Copy manifest
+  fs.copyFileSync(snap.path, path.join(backupDir, "snapshot.json"));
+
+  // Commit
+  cp.execSync("git add -A", { cwd: backupDir, stdio: "pipe", windowsHide: true });
+  var status = cp.execSync("git status --porcelain", { cwd: backupDir, encoding: "utf-8", windowsHide: true }).trim();
+  if (!status) {
+    console.log("[backup] No changes since last backup.");
+    return;
+  }
+
+  var msg = "backup " + new Date().toISOString().slice(0, 19).replace("T", " ") + " (" + copied + " files)";
+  cp.execSync('git commit -m "' + msg + '"', { cwd: backupDir, stdio: "pipe", windowsHide: true });
+
+  // Push if remote exists
+  try {
+    var remote = cp.execSync("git remote get-url origin", { cwd: backupDir, encoding: "utf-8", windowsHide: true }).trim();
+    if (remote) {
+      console.log("[backup] Pushing to " + remote + "...");
+      cp.execSync("git push -u origin main 2>/dev/null || git push -u origin master", { cwd: backupDir, stdio: "pipe", windowsHide: true });
+    }
+  } catch (e) {
+    // No remote — local-only backup is fine
+  }
+
+  console.log("[backup] " + copied + " files committed to " + backupDir);
+  if (isNew) console.log("  Add remote: cd " + backupDir + " && git remote add origin <url> && git push -u origin main");
+}
+
+// ── Restore from git repo or directory ──
+
+function restore(source, dryRun) {
+  if (!source) {
+    // Default: use existing backup-repo
+    source = path.join(CLAUDE_DIR, "backup-repo");
+    if (!fs.existsSync(source)) {
+      console.error("[restore] Usage: node snapshot.js restore <repo-url|directory>");
+      process.exit(1);
+    }
+  }
+
+  var restoreDir = source;
+
+  // If it looks like a URL, clone it
+  if (source.includes("github.com") || source.startsWith("git@")) {
+    restoreDir = path.join(os.tmpdir(), "hook-runner-restore-" + Date.now());
+    console.log("[restore] Cloning " + source + "...");
+    cp.execSync('git clone "' + source + '" "' + restoreDir.replace(/\\/g, "/") + '"', { stdio: "pipe", windowsHide: true });
+  }
+
+  var snapFile = path.join(restoreDir, "snapshot.json");
+  if (!fs.existsSync(snapFile)) {
+    console.error("[restore] No snapshot.json found in " + restoreDir);
+    process.exit(1);
+  }
+
+  var manifest = JSON.parse(fs.readFileSync(snapFile, "utf-8"));
+  var labels = Object.keys(manifest.files);
+  var restored = 0;
+
+  for (var i = 0; i < labels.length; i++) {
+    var label = labels[i];
+    var src = path.join(restoreDir, label.replace(/\//g, path.sep));
+    if (!fs.existsSync(src)) continue;
+
+    // Map label to target path
+    var target;
+    if (label.startsWith("config/")) target = path.join(CLAUDE_DIR, label.slice(7));
+    else if (label.startsWith("runners/")) target = path.join(HOOKS_DIR, label.slice(8));
+    else if (label.startsWith("modules/")) target = path.join(HOOKS_DIR, "run-modules", label.slice(8));
+    else if (label.startsWith("workflows/")) target = path.join(HOOKS_DIR, label);
+    else if (label.startsWith("gsd-hooks/")) target = path.join(HOOKS_DIR, label.slice(10));
+    else if (label.startsWith("standalone/")) target = path.join(HOOKS_DIR, label.slice(11));
+    else if (label.startsWith("state/")) target = path.join(HOOKS_DIR, label.slice(6));
+    else if (label.startsWith("skills/")) target = path.join(CLAUDE_DIR, label);
+    else if (label.startsWith("mcp/")) { continue; } // MCP paths are device-specific
+    else target = path.join(HOOKS_DIR, label);
+
+    if (dryRun) { console.log("  [WOULD] " + label + " -> " + target); }
+    else { ensureDir(path.dirname(target)); fs.copyFileSync(src, target); }
+    restored++;
+  }
+
+  console.log("[restore] " + restored + " files " + (dryRun ? "would be " : "") + "restored.");
+  if (!dryRun) console.log("  Restart Claude Code to pick up changes.");
+}
+
+// ── Main ──
+
+function main() {
+  var args = process.argv.slice(2);
+  var cmd = args[0] || "help";
+
+  switch (cmd) {
+    case "create":
+      createSnapshot();
+      break;
+    case "drift":
+    case "check":
+      detectDrift(args.indexOf("--json") !== -1);
+      break;
+    case "backup":
+      var repoIdx = args.indexOf("--repo");
+      backup(repoIdx !== -1 ? args[repoIdx + 1] : null);
+      break;
+    case "restore":
+      var restoreSrc = args[1] && !args[1].startsWith("--") ? args[1] : null;
+      restore(restoreSrc, args.indexOf("--dry-run") !== -1);
+      break;
+    default:
+      console.log("Usage: node snapshot.js <create|drift|backup|restore>");
+      console.log("");
+      console.log("  create              SHA256 snapshot of current state");
+      console.log("  drift [--json]      Detect changes since last snapshot");
+      console.log("  backup [--repo URL] Copy files to git repo, commit, push");
+      console.log("  restore [repo|dir]  Clone/copy files back into place");
+      break;
+  }
+}
+
+module.exports = { createSnapshot: createSnapshot, detectDrift: detectDrift };
+
+if (require.main === module) main();

--- a/snapshot.js
+++ b/snapshot.js
@@ -261,12 +261,22 @@ function backup(repoUrl) {
   var msg = "backup " + new Date().toISOString().slice(0, 19).replace("T", " ") + " (" + copied + " files)";
   cp.execSync('git commit -m "' + msg + '"', { cwd: backupDir, stdio: "pipe", windowsHide: true });
 
-  // Push if remote exists
+  // Push if remote exists — use gh auth token for correct account
   try {
     var remote = cp.execSync("git remote get-url origin", { cwd: backupDir, encoding: "utf-8", windowsHide: true }).trim();
     if (remote) {
       console.log("[backup] Pushing to " + remote + "...");
-      cp.execSync("git push -u origin main 2>/dev/null || git push -u origin master", { cwd: backupDir, stdio: "pipe", windowsHide: true });
+      var account = remote.indexOf("grobomo") !== -1 ? "grobomo" : null;
+      var pushEnv = Object.assign({}, process.env);
+      if (account) {
+        try {
+          var token = cp.execSync("gh auth token --user " + account, { encoding: "utf-8", windowsHide: true }).trim();
+          if (token) pushEnv.GH_TOKEN = token;
+        } catch (e2) {}
+      }
+      cp.execSync("git push -u origin main 2>/dev/null || git push -u origin master", {
+        cwd: backupDir, stdio: "pipe", windowsHide: true, env: pushEnv
+      });
     }
   } catch (e) {
     // No remote — local-only backup is fine

--- a/workflows/gsd.yml
+++ b/workflows/gsd.yml
@@ -1,0 +1,139 @@
+name: gsd
+description: GSD-driven development discipline. Enforces .planning/ → ROADMAP.md → phase plan → branch → execute → PR pipeline. Replaces shtd's spec-based flow with GSD's phase-based flow while keeping all safety, quality, and session lifecycle modules.
+version: 1
+steps:
+  - id: plan
+    name: Discuss and plan the phase (PLAN.md exists)
+    gate:
+      require_files: []
+    completion:
+      require_files: [".planning/ROADMAP.md"]
+  - id: branch
+    name: Create feature branch for the phase
+    gate:
+      require_step: plan
+    completion:
+      require_files: []
+  - id: execute
+    name: Execute the plan tasks
+    gate:
+      require_step: branch
+    completion:
+      require_files: []
+  - id: verify
+    name: Verify implementation passes tests
+    gate:
+      require_step: execute
+    completion:
+      require_files: []
+  - id: pr
+    name: Create PR for the phase work
+    gate:
+      require_step: verify
+    completion:
+      require_files: []
+
+modules:
+  # GSD pipeline enforcement (replaces spec-gate, spec-before-code-gate)
+  - gsd-plan-gate
+  # Development pipeline (kept from shtd)
+  - branch-pr-gate
+  - commit-msg-check
+  - continuous-claude-gate
+  - drift-review
+  - hook-editing-gate
+  - hook-integrity-monitor
+  - workflow-compliance-gate
+  - pr-per-task-gate
+  - push-unpushed
+  - remote-tracking-gate
+  - commit-counter-gate
+  - commit-quality-gate
+  - unresolved-issues-gate
+  - victory-declaration-gate
+  - deploy-gate
+  - deploy-history-reminder
+  - secret-scan-gate
+  - task-completion-gate
+  - test-before-done
+  - test-checkpoint-gate
+  - unresolved-issues-check
+  - why-reminder
+  - workflow-gate
+  - blueprint-no-sleep
+  - gh-auto-gate
+  - no-hook-bypass
+  - no-nested-claude
+  - publish-json-guard
+  # Code quality
+  - archive-not-delete
+  - claude-p-pattern
+  - git-destructive-guard
+  - git-rebase-safety
+  - no-fragile-heuristics
+  - no-hardcoded-paths
+  - preserve-iterated-content
+  - root-cause-gate
+  - no-rules-gate
+  - rule-hygiene
+  - test-coverage-check
+  - empty-output-detector
+  - result-review-gate
+  - update-stale-docs
+  - hook-health-monitor
+  - hook-self-test
+  - windowless-spawn-gate
+  - worktree-gate
+  - pr-first-gate
+  # Infrastructure safety
+  - aws-tagging-gate
+  - crlf-detector
+  - crlf-ssh-key-check
+  - disk-space-guard
+  - disk-space-detect
+  - force-push-gate
+  - env-var-check
+  - session-cleanup
+  - hook-autocommit
+  - no-adhoc-commands
+  - cross-project-todo-gate
+  - cwd-drift-detector
+  - no-focus-steal
+  - settings-audit-log
+  - settings-change-gate
+  - settings-hooks-gate
+  # Messaging safety
+  - messaging-safety-gate
+  - share-is-generic
+  # Project-scoped (ddei-email-security)
+  - rdp-testbox-gate
+  # System reminders
+  - hook-system-reminder
+  # Self-improvement
+  - instruction-to-hook-gate
+  - instruction-detector
+  - interrupt-detector
+  - troubleshoot-detector
+  - no-passive-rules
+  - prompt-logger
+  # Self-reflection
+  - self-reflection
+  - reflection-gate
+  - reflection-score
+  - reflection-score-inject
+  - session-brain-analysis
+  - lesson-effectiveness
+  # Session lifecycle
+  - auto-continue
+  - backup-check
+  - chat-export
+  - config-sync
+  - load-instructions
+  - load-lessons
+  - log-gotchas
+  - mark-turn-complete
+  - never-give-up
+  - project-health
+  - session-collision-detector
+  - terminal-title
+  - workflow-summary

--- a/workflows/gsd.yml
+++ b/workflows/gsd.yml
@@ -1,6 +1,7 @@
 name: gsd
 description: GSD-driven development discipline. Enforces .planning/ → ROADMAP.md → phase plan → branch → execute → PR pipeline. Replaces shtd's spec-based flow with GSD's phase-based flow while keeping all safety, quality, and session lifecycle modules.
-version: 1
+version: 2
+extends: starter
 steps:
   - id: plan
     name: Discuss and plan the phase (PLAN.md exists)
@@ -34,9 +35,10 @@ steps:
       require_files: []
 
 modules:
-  # GSD pipeline enforcement (replaces spec-gate, spec-before-code-gate)
+  # === GSD-EXCLUSIVE: phase-based methodology ===
   - gsd-plan-gate
-  # Development pipeline (kept from shtd)
+  # === DEV DISCIPLINE: shared with shtd (tagged: shtd, gsd) ===
+  # Development pipeline
   - branch-pr-gate
   - commit-msg-check
   - continuous-claude-gate

--- a/workflows/shtd.yml
+++ b/workflows/shtd.yml
@@ -1,6 +1,7 @@
 name: shtd
 description: Spec-Hook-Test-Driven — all development discipline in one workflow. Enforces spec → branch → test → implement → PR pipeline, code quality, infrastructure safety, messaging guards, session lifecycle, and self-improvement.
-version: 2
+version: 3
+extends: starter
 steps:
   - id: spec
     name: Write spec describing the feature or rule
@@ -46,12 +47,16 @@ steps:
       require_files: []
 
 modules:
-  # Development pipeline (was: shtd)
+  # === SHTD-EXCLUSIVE: spec-based methodology ===
+  - spec-gate
+  - spec-before-code-gate
+  - enforcement-gate
+  # === DEV DISCIPLINE: shared with gsd (tagged: shtd, gsd) ===
+  # Development pipeline
   - branch-pr-gate
   - commit-msg-check
   - continuous-claude-gate
   - drift-review
-  - enforcement-gate
   - hook-editing-gate
   - hook-integrity-monitor
   - workflow-compliance-gate
@@ -65,8 +70,6 @@ modules:
   - deploy-gate
   - deploy-history-reminder
   - secret-scan-gate
-  - spec-before-code-gate
-  - spec-gate
   - task-completion-gate
   - test-before-done
   - test-checkpoint-gate
@@ -78,7 +81,7 @@ modules:
   - no-hook-bypass
   - no-nested-claude
   - publish-json-guard
-  # Code quality (was: code-quality)
+  # Code quality
   - archive-not-delete
   - claude-p-pattern
   - git-destructive-guard
@@ -98,7 +101,7 @@ modules:
   - windowless-spawn-gate
   - worktree-gate
   - pr-first-gate
-  # Infrastructure safety (was: infra-safety)
+  # Infrastructure safety
   - aws-tagging-gate
   - crlf-detector
   - crlf-ssh-key-check
@@ -115,14 +118,14 @@ modules:
   - settings-audit-log
   - settings-change-gate
   - settings-hooks-gate
-  # Messaging safety (was: messaging-safety)
+  # Messaging safety
   - messaging-safety-gate
   - share-is-generic
   # Project-scoped (ddei-email-security)
   - rdp-testbox-gate
   # System reminders
   - hook-system-reminder
-  # Self-improvement (was: self-improvement)
+  # Self-improvement
   - instruction-to-hook-gate
   - instruction-detector
   - interrupt-detector
@@ -136,7 +139,7 @@ modules:
   - reflection-score-inject
   - session-brain-analysis
   - lesson-effectiveness
-  # Session lifecycle (was: session-management)
+  # Session lifecycle
   - auto-continue
   - backup-check
   - chat-export

--- a/workflows/starter.yml
+++ b/workflows/starter.yml
@@ -1,6 +1,6 @@
 name: starter
 description: Safe defaults for any Claude Code user. Blocks common mistakes (force push, destructive git, rm -rf, secret commits) and adds helpful guardrails (commit quality, test reminders). Start here, then enable shtd when you want full development discipline.
-version: 1
+version: 2
 steps:
   - id: ready
     name: Ready to work
@@ -22,7 +22,39 @@ modules:
   - no-hardcoded-paths
   - test-coverage-check
   - preserve-iterated-content
-  # Session lifecycle — helpful context
+  # Hook system protection — prevent self-sabotage
+  - hook-editing-gate
+  - no-hook-bypass
+  - no-rules-gate
+  - hook-autocommit
+  - hook-health-monitor
+  - hook-integrity-monitor
+  # Account/platform safety — correct identity and environment
+  - gh-auto-gate
+  - publish-json-guard
+  - settings-change-gate
+  - settings-hooks-gate
+  - messaging-safety-gate
+  - no-nested-claude
+  - no-focus-steal
+  - windowless-spawn-gate
+  # Infrastructure — disk, CRLF, SSH
+  - disk-space-guard
+  - disk-space-detect
+  - crlf-ssh-key-check
+  - crlf-detector
+  # Session lifecycle — context and continuity
+  - auto-continue
+  - never-give-up
+  - backup-check
+  - drift-check
+  - hook-self-test
+  - load-instructions
   - project-health
-  - workflow-summary
+  - session-cleanup
+  - session-collision-detector
   - terminal-title
+  - workflow-summary
+  # User prompt monitoring
+  - interrupt-detector
+  - prompt-logger


### PR DESCRIPTION
## Summary
- **Bug fix**: 52 modules listed in `gsd.yml` were tagged `// WORKFLOW: shtd` only. When a project disabled shtd and enabled gsd, these modules silently stopped firing — losing commit counters, PR gates, test enforcement, self-reflection, and session lifecycle.
- **Root cause**: When gsd workflow was created, it copied shtd's module list but didn't update the code-level `// WORKFLOW:` tags that control actual loading.
- **Fix**: Dual-tag all 52 shared discipline modules as `// WORKFLOW: shtd, gsd`

## Workflow tiers (after this PR)
| Tier | Modules | Purpose |
|------|---------|---------|
| **starter** | 40 | Universal safety, session lifecycle, platform guards — always fires |
| **shtd** | 3 exclusive + 52 shared | Spec-based methodology (spec-gate, enforcement-gate, spec-before-code-gate) |
| **gsd** | 1 exclusive + 52 shared | Phase-based methodology (gsd-plan-gate) |

## Test plan
- [x] gsd-plan-gate: 12/12 tests passing
- [x] Tag parsing verified: branch-pr-gate=[shtd,gsd], spec-gate=[shtd], gsd-plan-gate=[gsd], force-push-gate=[shtd,starter]
- [x] Modules synced to live `~/.claude/hooks/run-modules/`