### PR TITLE
T457: Version bump v2.26.0 + marketplace sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.26.0] — 2026-04-16
+
+### Added
+- **Snapshot system** (T453) — `snapshot.js` with SHA256 manifest creation, drift detection, and git-backed backup/restore to private repo. `drift-check.js` SessionStart module for daily drift detection.
+- **TOOLS: tag filtering** (T446) — New `// TOOLS: Bash, Edit, Write` module header. `load-modules.js` skips modules that don't match the current tool. Read calls skip 21/54 modules (39%), Edit skips 17 (31%). ~300ms savings on Read calls.
+- **gsd-branch-gate** (T450) — Enforces GSD branch naming `<seq>-phase-<N>-<slug>` matching active ROADMAP.md phases. Allows shtd-style branches for compatibility. 9/9 tests.
+- **gsd-pr-gate** (T451) — Enforces phase/task reference in PR titles. Phase branches must map to active phases. 9/9 tests.
+- **Testing step in stop-message** (T456) — Step 3: "TEST what you built" before hardening. New 5-step stop order.
+
+### Fixed
+- **Workflow tier bug** (T455) — 52 shared modules were tagged `// WORKFLOW: shtd` only, silently stopping when shtd disabled and gsd enabled. Now dual-tagged `shtd, gsd`.
+- **Starter workflow expansion** (T454) — `starter.yml` expanded from 12 to 40 modules (system protection, account safety, session lifecycle, platform guards).
+
 ## [2.25.0] — 2026-04-14
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -1220,6 +1220,10 @@ Replace: spec-gate, spec-before-code-gate, gsd-gate → new gsd-plan-gate.
 
 - [x] T456: Update stop-message.txt to add step 3: "TEST what you built" before hardening. New 5-step order verified via stop hook test. (PR #339)
 
+## Merge & Release (2026-04-16)
+
+- [ ] T457: Merge PRs #337-#342, version bump, marketplace sync, sync modules to live
+
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog
 - `modules/` has all available modules organized by event type

--- a/TODO.md
+++ b/TODO.md
@@ -1213,7 +1213,7 @@ Replace: spec-gate, spec-before-code-gate, gsd-gate → new gsd-plan-gate.
 - [x] T453: Snapshot system — SHA256 manifest, drift detection, git-backed backup/restore (snapshot.js + drift-check SessionStart module) (PR #337)
 - [x] T454: Promote universal modules to starter — 27 modules that protect system/account/platform should fire regardless of dev workflow (PR #337)
 - [x] T455: Simplify workflow tiers — dual-tag 52 shared modules shtd+gsd, expand starter.yml 12→40 modules, clear tier structure (PR #338)
-- [ ] T451: Write `gsd-pr-gate.js` PreToolUse module — one PR per plan/task in a phase. Branch must map to a single phase.
+- [x] T451: Write `gsd-pr-gate.js` PreToolUse module — enforces phase/task reference in PRs, validates active ROADMAP.md phases. 9/9 tests. (PR #342)
 - [x] T452: E2E tests for gsd-plan-gate — 12 tests covering all scenarios. Merged into T448.
 
 ## Stop Hook: Add Testing Step (T456)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.25.0",
+  "version": "2.26.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Version bump 2.25.0 → 2.26.0
- CHANGELOG updated with T446, T450-T456 changes
- Marketplace synced to grobomo/claude-code-skills

## Included in v2.26.0
- T453: Snapshot system (create/drift/backup/restore)
- T454: Starter expanded 12→40 modules
- T455: Workflow tier fix (52 modules dual-tagged shtd+gsd)
- T456: Testing step in stop-message
- T446: TOOLS: tag filtering (39% module reduction on Read)
- T450: gsd-branch-gate (9/9 tests)
- T451: gsd-pr-gate (9/9 tests)