### PR TITLE
T458: Fix spec-gate blocking git/gh with env var prefixes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1197,6 +1197,10 @@ Status:
 - [ ] T445: Fix --test to discover .js test files — 15 JS test suites (145+ tests) silently skipped because cmdTest() only discovers .sh files
 - [ ] T446: Performance audit — PreToolUse ~281ms overhead. Document top offenders, add perf baseline to CI
 
+## Spec Gate Bugfix (2026-04-16)
+
+- [ ] T458: Fix spec-gate blocking git commands with env var prefixes (GH_TOKEN=... git pull) and node test scripts on main
+
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog
 - `modules/` has all available modules organized by event type

--- a/docs/hook-runner-hooks-template.json
+++ b/docs/hook-runner-hooks-template.json
@@ -1,0 +1,89 @@
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"C:/Users/joelg/.claude/hooks/run-hidden.js\" run-sessionstart.js",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"C:/Users/joelg/.claude/hooks/run-hidden.js\" run-stop.js",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"C:/Users/joelg/.claude/hooks/run-hidden.js\" run-pretooluse.js",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"C:/Users/joelg/.claude/hooks/run-hidden.js\" run-pretooluse.js",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"C:/Users/joelg/.claude/hooks/run-hidden.js\" run-pretooluse.js",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"C:/Users/joelg/.claude/hooks/run-hidden.js\" run-posttooluse.js",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"C:/Users/joelg/.claude/hooks/run-hidden.js\" run-posttooluse.js",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"C:/Users/joelg/.claude/hooks/run-hidden.js\" run-userpromptsubmit.js",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  },

--- a/modules/PreToolUse/spec-gate.js
+++ b/modules/PreToolUse/spec-gate.js
@@ -202,6 +202,7 @@ var BASH_ALLOW_PATTERNS = [
   /^\s*node\s+-e\b/, /^\s*node\s+--eval\b/, // quick evals (not running files)
   /^\s*python\s+-c\b/, // quick evals
   /^\s*bash\s+scripts\/test\//, // running existing test scripts
+  /^\s*node\s+scripts\/test\//, // running JS test scripts
   /^\s*node\s+setup\.js\s+--test/, // hook-runner tests
   /python\s+.*new.session\.py/, // T384: session management (launch new Claude tab)
   /python\s+.*context.reset\.py/, // T384: session management (backward-compat alias)
@@ -226,6 +227,8 @@ module.exports = function(input) {
 
     // Strip leading cd ... && or cd ... ; to get the real command
     var realCmd = cmd.replace(/^(\s*cd\s+[^;&|]+\s*&&\s*)+/, "").trim();
+    // Strip leading env var assignments (e.g. GH_TOKEN=... git pull)
+    realCmd = realCmd.replace(/^(\s*\w+=\S*\s+)+/, "").trim();
     // Also handle piped commands — check the first command in the pipeline
     var firstCmd = realCmd.split("|")[0].trim();
 


### PR DESCRIPTION
## Summary
- **Bug**: `GH_TOKEN=... git pull` was blocked by spec-gate because env var prefix wasn't stripped before matching the Bash allowlist
- **Fix**: Strip leading env var assignments (`VAR=val `) from commands before allowlist check (line 229)
- **Also**: Added `node scripts/test/` to the allowlist (only `bash scripts/test/` was there)

## Test plan
- [x] test-T338-spec-gate-bash.sh: 19/19 passing
- [x] test-T321-spec-gate-task-id.sh: 12/12 passing
- [x] test-T106-spec-gate-relaxed.sh: 7/7 passing
- [x] Verified: `GH_TOKEN=... git fetch origin main` now passes through