### PR TITLE
T458: Fix env var subshell stripping in spec-gate

### DIFF
--- a/modules/PreToolUse/spec-gate.js
+++ b/modules/PreToolUse/spec-gate.js
@@ -227,8 +227,9 @@ module.exports = function(input) {
 
     // Strip leading cd ... && or cd ... ; to get the real command
     var realCmd = cmd.replace(/^(\s*cd\s+[^;&|]+\s*&&\s*)+/, "").trim();
-    // Strip leading env var assignments (e.g. GH_TOKEN=... git pull)
-    realCmd = realCmd.replace(/^(\s*\w+=\S*\s+)+/, "").trim();
+    // Strip leading env var assignments (e.g. GH_TOKEN=$(cmd) git pull)
+    // Handles subshells $(), quoted values, and simple KEY=val
+    realCmd = realCmd.replace(/^(\s*\w+=(?:\$\([^)]*\)|"[^"]*"|'[^']*'|\S)*\s+)+/, "").trim();
     // Also handle piped commands — check the first command in the pipeline
     var firstCmd = realCmd.split("|")[0].trim();
 


### PR DESCRIPTION
Follow-up to PR #344. The initial regex `\S*` didn't handle `$()` subshells
with spaces (e.g. `GH_TOKEN=$(gh auth token --user grobomo 2>/dev/null)`).
New regex handles `$()`, quoted values, and simple `KEY=val`. 38/38 tests pass.