### PR TITLE
T460: Fix destructive guard false positives

### DIFF
--- a/modules/PreToolUse/git-destructive-guard.js
+++ b/modules/PreToolUse/git-destructive-guard.js
@@ -37,7 +37,8 @@ module.exports = function(input) {
   var checkoutMatch = cmd.match(/git\s+(checkout|restore)\s+(.*)/);
   if (checkoutMatch) {
     var subcmd = checkoutMatch[1];
-    var args = checkoutMatch[2].trim();
+    // T460: Only examine checkout args, not chained commands after && || ; |
+    var args = checkoutMatch[2].split(/\s*(?:&&|\|\||\||;|[12]?>>?)\s*/)[0].trim();
     // Allow branch operations: checkout -b, checkout --orphan, checkout -
     if (subcmd === "checkout" && /^(-b|--orphan|-t|--track|-)\s/.test(args)) return null;
     // Allow checkout with no args (detached HEAD info) or bare branch name (no dots, no slashes with extensions)
@@ -63,15 +64,9 @@ module.exports = function(input) {
     };
   }
 
-  // git branch -D — force-deletes a branch (may have unmerged commits)
-  if (/git\s+branch\s+-D\s/.test(cmd)) {
-    return {
-      decision: "block",
-      reason: "DESTRUCTIVE: git branch -D force-deletes even unmerged branches.\n" +
-        "Use git branch -d (lowercase) which refuses if commits are unmerged.\n" +
-        "If you truly need -D, ask the user first."
-    };
-  }
+  // T460: git branch -D removed as a block. Claude's built-in instructions already
+  // require user approval for -D. The gate was preventing Claude from following
+  // through after the user approved (e.g. merged branches with pruned remote refs).
 
   return null;
 };

--- a/scripts/test/test-git-destructive-guard.js
+++ b/scripts/test/test-git-destructive-guard.js
@@ -23,13 +23,17 @@ run("git restore src/main.js", "block", "restore file");
 run("git checkout -- file.js", "block", "checkout -- file");
 run("git reset --hard", "block", "reset hard");
 run("git clean -fd", "block", "clean force");
-run("git branch -D old-branch", "block", "branch force delete");
+// T460: git branch -D no longer blocked (Claude's instructions already require user approval)
+run("git branch -D old-branch", "pass", "branch force delete (user-gated)");
 
 // Non-destructive — should pass
 run("git checkout -b new-branch", "pass", "new branch");
 run("git checkout main", "pass", "switch branch");
 run("git checkout feature-branch", "pass", "switch feature");
 run("git status", "pass", "status");
+// T460: chained commands — checkout branch + other commands should pass
+run("git checkout main && git pull origin main 2>&1 | tail -5", "pass", "checkout main chained with pull");
+run("git checkout main && GH_TOKEN=$(gh auth token --user grobomo 2>/dev/null) git pull origin main", "pass", "checkout main chained with env var pull");
 
 // False positives: git commands mentioned in strings/heredocs — should pass
 run('gh pr create --body "$(cat <<\'EOF\'\ngit checkout file.js is blocked\nEOF\n)"', "pass", "heredoc mention");


### PR DESCRIPTION
## Summary
- `git checkout main && git pull` no longer falsely blocked — args parsing now stops at shell operators (`&&`, `||`, `;`, `|`)
- `git branch -D` no longer blocked — Claude's built-in instructions already require user approval; the gate was preventing follow-through after approval

## Test plan
- [x] 16/16 test cases pass including 2 new chained-command tests
- [x] Synced to live hooks