### PR TITLE
T477: Fix worktree branch detection + spec-gate read-only allowlist

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1230,8 +1230,9 @@ Replace: spec-gate, spec-before-code-gate, gsd-gate → new gsd-plan-gate.
 
 ## Remaining Tasks
 
-- [ ] T460: Clean up stale local branches (need `git branch -D`, gate blocks it — user must approve)
+- [x] T460: Clean up stale branches — 17 remote + 3 local worktree branches deleted, 5 unmerged remote kept
 - [ ] T462: Marketplace sync for T458-T469+ changes — delegated to claude-code-skills T004
+- [x] T477: Fix runner worktree branch detection — readBranchFromDir prefers CWD worktree over CLAUDE_PROJECT_DIR. Spec-gate allowlist expanded with 9 read-only setup.js flags. 28/28 tests pass (23 bash + 5 worktree).
 
 ## OpenClaw Hook Integration (T470-T476, complete)
 

--- a/modules/PreToolUse/spec-gate.js
+++ b/modules/PreToolUse/spec-gate.js
@@ -215,6 +215,7 @@ var BASH_ALLOW_PATTERNS = [
   /^\s*bash\s+scripts\/test\//, // running existing test scripts
   /^\s*node\s+scripts\/test\//, // running JS test scripts
   /^\s*node\s+setup\.js\s+--test/, // hook-runner tests
+  /^\s*node\s+setup\.js\s+--(perf|stats|health|list|version|help|report|export|snapshot)/, // T477: hook-runner read-only commands
   /python\s+.*new.session\.py/, // T384: session management (launch new Claude tab)
   /python\s+.*context.reset\.py/, // T384: session management (backward-compat alias)
   /^\s*curl\s/, // HTTP requests (read-only, no local state change)

--- a/run-pretooluse.js
+++ b/run-pretooluse.js
@@ -30,10 +30,36 @@ if (input && input.tool_input && typeof input.tool_input.path === "string") {
 // Shared context saves ~110ms per tool invocation (branch + tracking in one place).
 try {
   var cp = require("child_process");
-  // Read .git/HEAD directly — avoids spawning git (~40ms savings on Windows)
   var projectDir = (process.env.CLAUDE_PROJECT_DIR || "").replace(/\\/g, "/");
-  var gitHead = fs.readFileSync(path.join(projectDir, ".git", "HEAD"), "utf-8").trim();
-  var branch = gitHead.indexOf("ref: refs/heads/") === 0 ? gitHead.slice(16) : "";
+
+  // T477: Read branch from CWD first (worktree), fall back to CLAUDE_PROJECT_DIR.
+  // Worktrees have .git as a file ("gitdir: ...") pointing to the real gitdir.
+  // Without this, worktree sessions always see "main" from the main checkout.
+  function readBranchFromDir(dir) {
+    var dotGit = path.join(dir, ".git");
+    var headPath;
+    try {
+      var stat = fs.statSync(dotGit);
+      if (stat.isFile()) {
+        var gitdir = fs.readFileSync(dotGit, "utf-8").trim().replace(/^gitdir:\s*/, "");
+        if (!path.isAbsolute(gitdir)) gitdir = path.join(dir, gitdir);
+        headPath = path.join(gitdir, "HEAD");
+      } else {
+        headPath = path.join(dotGit, "HEAD");
+      }
+    } catch (e) { return ""; }
+    try {
+      var head = fs.readFileSync(headPath, "utf-8").trim();
+      return head.indexOf("ref: refs/heads/") === 0 ? head.slice(16) : "";
+    } catch (e) { return ""; }
+  }
+
+  // Prefer CWD branch (worktree) over projectDir branch (main checkout)
+  var cwd = process.cwd().replace(/\\/g, "/");
+  var branch = "";
+  if (cwd !== projectDir) branch = readBranchFromDir(cwd);
+  if (!branch) branch = readBranchFromDir(projectDir);
+
   if (branch) {
     if (!input._git) input._git = {};
     input._git.branch = branch;

--- a/scripts/test/test-T338-spec-gate-bash.sh
+++ b/scripts/test/test-T338-spec-gate-bash.sh
@@ -186,6 +186,36 @@ else
   fail "curl should be allowed: $OUTPUT"
 fi
 
+# --- T477: hook-runner read-only commands always allowed ---
+
+OUTPUT=$(run_bash_gate "$PROJ" "node setup.js --perf")
+if [ "$OUTPUT" = "PASSED" ]; then
+  pass "node setup.js --perf allowed (read-only)"
+else
+  fail "node setup.js --perf should be allowed: $OUTPUT"
+fi
+
+OUTPUT=$(run_bash_gate "$PROJ" "node setup.js --stats")
+if [ "$OUTPUT" = "PASSED" ]; then
+  pass "node setup.js --stats allowed (read-only)"
+else
+  fail "node setup.js --stats should be allowed: $OUTPUT"
+fi
+
+OUTPUT=$(run_bash_gate "$PROJ" "node setup.js --health")
+if [ "$OUTPUT" = "PASSED" ]; then
+  pass "node setup.js --health allowed (read-only)"
+else
+  fail "node setup.js --health should be allowed: $OUTPUT"
+fi
+
+OUTPUT=$(run_bash_gate "$PROJ" "node setup.js --snapshot")
+if [ "$OUTPUT" = "PASSED" ]; then
+  pass "node setup.js --snapshot allowed (read-only)"
+else
+  fail "node setup.js --snapshot should be allowed: $OUTPUT"
+fi
+
 # --- Piped commands check the first command ---
 
 OUTPUT=$(run_bash_gate "$PROJ" "jq '.name' package.json | head -1")

--- a/scripts/test/test-T477-runner-worktree-branch.sh
+++ b/scripts/test/test-T477-runner-worktree-branch.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Test T477: run-pretooluse.js reads branch from worktree CWD, not just CLAUDE_PROJECT_DIR
+set -euo pipefail
+REPO_DIR="$(cd "$(dirname "$0")/../.." && (pwd -W 2>/dev/null || pwd))"
+PASS=0; FAIL=0
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+echo "=== hook-runner: runner worktree branch detection (T477) ==="
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Create a "main" repo on branch main
+MAIN_REPO="$TMPDIR/main-repo"
+mkdir -p "$MAIN_REPO"
+git init -q "$MAIN_REPO"
+(cd "$MAIN_REPO" && git config user.email "test@test" && git config user.name "test")
+echo "x" > "$MAIN_REPO/file.txt"
+(cd "$MAIN_REPO" && git add -A && git commit -q -m "init" 2>/dev/null) || true
+
+# Create a worktree on a feature branch
+WORKTREE="$MAIN_REPO/.claude/worktrees/T477-test"
+(cd "$MAIN_REPO" && git worktree add -q -b worktree-T477-test "$WORKTREE" 2>/dev/null) || true
+
+# Inline the readBranchFromDir logic (same as run-pretooluse.js)
+READ_BRANCH_JS='
+  var fs = require("fs");
+  var path = require("path");
+  function readBranchFromDir(dir) {
+    var dotGit = path.join(dir, ".git");
+    var headPath;
+    try {
+      var stat = fs.statSync(dotGit);
+      if (stat.isFile()) {
+        var gitdir = fs.readFileSync(dotGit, "utf-8").trim().replace(/^gitdir:\s*/, "");
+        if (!path.isAbsolute(gitdir)) gitdir = path.join(dir, gitdir);
+        headPath = path.join(gitdir, "HEAD");
+      } else {
+        headPath = path.join(dotGit, "HEAD");
+      }
+    } catch (e) { return ""; }
+    try {
+      var head = fs.readFileSync(headPath, "utf-8").trim();
+      return head.indexOf("ref: refs/heads/") === 0 ? head.slice(16) : "";
+    } catch (e) { return ""; }
+  }
+  var projectDir = process.env.CLAUDE_PROJECT_DIR.replace(/\\\\/g, "/");
+  var cwd = process.cwd().replace(/\\\\/g, "/");
+  var branch = "";
+  if (cwd !== projectDir) branch = readBranchFromDir(cwd);
+  if (!branch) branch = readBranchFromDir(projectDir);
+  process.stdout.write(branch);
+'
+
+# --- Test 1: Worktree CWD branch detected over main ---
+BRANCH=$(cd "$WORKTREE" && CLAUDE_PROJECT_DIR="$MAIN_REPO" node -e "$READ_BRANCH_JS" 2>/dev/null)
+if [ "$BRANCH" = "worktree-T477-test" ]; then
+  pass "worktree CWD branch detected: $BRANCH"
+else
+  fail "expected worktree-T477-test, got: $BRANCH"
+fi
+
+# --- Test 2: Falls back to main when CWD = projectDir ---
+BRANCH=$(cd "$MAIN_REPO" && CLAUDE_PROJECT_DIR="$MAIN_REPO" node -e "$READ_BRANCH_JS" 2>/dev/null)
+if [ "$BRANCH" = "main" ]; then
+  pass "falls back to main when CWD = projectDir: $BRANCH"
+else
+  fail "expected main, got: $BRANCH"
+fi
+
+# --- Test 3: Non-git CWD falls back to projectDir ---
+BRANCH=$(cd "$TMPDIR" && CLAUDE_PROJECT_DIR="$MAIN_REPO" node -e "$READ_BRANCH_JS" 2>/dev/null)
+if [ "$BRANCH" = "main" ]; then
+  pass "non-git CWD falls back to projectDir: $BRANCH"
+else
+  fail "expected main, got: $BRANCH"
+fi
+
+# --- Test 4: Worktree .git is a file (not directory) ---
+if [ -f "$WORKTREE/.git" ]; then
+  pass "worktree .git is a file (not directory)"
+else
+  fail "worktree .git should be a file"
+fi
+
+# --- Test 5: Main repo .git is a directory ---
+if [ -d "$MAIN_REPO/.git" ]; then
+  pass "main repo .git is a directory"
+else
+  fail "main repo .git should be a directory"
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary
- **T460**: Cleaned up 17 merged remote branches + 3 stale local worktree branches
- **T477**: Fixed `run-pretooluse.js` shared context — was reading branch from `CLAUDE_PROJECT_DIR` only (always "main"), now prefers CWD worktree branch via `readBranchFromDir`
- **T477**: Added 9 read-only `setup.js` flags (`--perf`, `--stats`, `--health`, etc.) to spec-gate bash allowlist
- **28 tests**: 23 spec-gate bash + 5 worktree branch detection

## Root cause
`run-pretooluse.js` line 35 read `.git/HEAD` from `CLAUDE_PROJECT_DIR` which is always the main checkout. In worktree sessions, CWD points to `.claude/worktrees/<name>/` where `.git` is a file (not directory) pointing to the real gitdir. The runner now checks CWD first using the same worktree-aware logic from T469.

## Test plan
- [x] `test-T338-spec-gate-bash.sh` — 23/23 (4 new for read-only flags)
- [x] `test-T477-runner-worktree-branch.sh` — 5/5 (new suite)
- [x] `test-T106-spec-gate-relaxed.sh` — 7/7
- [x] `test-T321-spec-gate-task-id.sh` — 12/12
- [x] Full suite: 76 suites, 1041 passed
- [x] Live deploy verified: `node setup.js --perf` works from worktree