### PR TITLE
T478: Performance cache for preserve-iterated-content (1122ms to 7ms)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1232,7 +1232,8 @@ Replace: spec-gate, spec-before-code-gate, gsd-gate → new gsd-plan-gate.
 
 - [x] T460: Clean up stale branches — 17 remote + 3 local worktree branches deleted, 5 unmerged remote kept
 - [ ] T462: Marketplace sync for T458-T469+ changes — delegated to claude-code-skills T004
-- [x] T477: Fix runner worktree branch detection — readBranchFromDir prefers CWD worktree over CLAUDE_PROJECT_DIR. Spec-gate allowlist expanded with 9 read-only setup.js flags. 28/28 tests pass (23 bash + 5 worktree).
+- [x] T477: Fix runner worktree branch detection — readBranchFromDir prefers CWD worktree over CLAUDE_PROJECT_DIR. Spec-gate allowlist expanded with 9 read-only setup.js flags. 28/28 tests pass (23 bash + 5 worktree). (PR #362)
+- [x] T478: Performance — preserve-iterated-content file-based cache (1122ms→7ms on cache hit). Fixed worktree HEAD resolution via commondir.
 
 ## OpenClaw Hook Integration (T470-T476, complete)
 
@@ -1247,13 +1248,17 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T475: E2E test — 30/30, 3 phases (PR #359)
 - [x] T476: Test profile + plugin SDK rewrite (PR #358)
 
-## Session Handoff (2026-04-17, session 6)
+## Session Handoff (2026-04-17, session 7)
 
-**Session 6:** TODO cleanup — consolidated stale sections, removed duplicate task entries.
+**Session 7:**
+- T460: Cleaned 17 remote + 3 local stale branches
+- T477: Fixed worktree branch detection in runner + spec-gate allowlist (PR #362)
+- T478: Performance cache for preserve-iterated-content (1122ms→7ms)
+- Synced runner + spec-gate to live hooks
 
 **Remaining:**
-1. T460: Clean up stale local branches (user must approve `git branch -D`)
-2. T462: Marketplace sync (delegated to claude-code-skills T004)
+1. T462: Marketplace sync (delegated to claude-code-skills T004)
+2. Consider: enforcement-gate max spike 1787ms (avg 29ms — may be first-call overhead only)
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog

--- a/modules/PreToolUse/preserve-iterated-content.js
+++ b/modules/PreToolUse/preserve-iterated-content.js
@@ -5,12 +5,75 @@
 // "my code" instead of a carefully evolved artifact. This gate catches
 // full-file rewrites (Write tool) on files with significant git history
 // and suggests using Edit instead.
+// T478: Added file-based cache — git rev-list was 882ms avg on Windows.
+// Cache keyed by repo HEAD + file path, persists across hook invocations.
 "use strict";
 var cp = require("child_process");
 var path = require("path");
+var fs = require("fs");
+var os = require("os");
 
 // Commit count threshold — files with this many+ commits are "iterated"
 var ITERATION_THRESHOLD = 5;
+
+// T478: File-based cache to avoid repeated git rev-list calls (~800ms each on Windows).
+// Cache file persists across hook invocations within the same session.
+var CACHE_FILE = path.join(os.tmpdir(), "hook-runner-iterated-cache.json");
+var CACHE_MAX_AGE = 3600000; // 1 hour
+
+function loadCache() {
+  try {
+    var stat = fs.statSync(CACHE_FILE);
+    if (Date.now() - stat.mtimeMs > CACHE_MAX_AGE) return {};
+    return JSON.parse(fs.readFileSync(CACHE_FILE, "utf-8"));
+  } catch (e) { return {}; }
+}
+
+function saveCache(cache) {
+  try { fs.writeFileSync(CACHE_FILE, JSON.stringify(cache)); } catch (e) { /* best effort */ }
+}
+
+function getHeadSha(dir) {
+  try {
+    var dotGit = path.join(dir, ".git");
+    var headPath;
+    var stat = fs.statSync(dotGit);
+    if (stat.isFile()) {
+      var gitdir = fs.readFileSync(dotGit, "utf-8").trim().replace(/^gitdir:\s*/, "");
+      if (!path.isAbsolute(gitdir)) gitdir = path.join(dir, gitdir);
+      headPath = path.join(gitdir, "HEAD");
+    } else {
+      headPath = path.join(dotGit, "HEAD");
+    }
+    var head = fs.readFileSync(headPath, "utf-8").trim();
+    if (head.indexOf("ref: ") === 0) {
+      // Try loose ref first, then commondir (worktrees store refs in main repo)
+      var gitBase = path.dirname(headPath);
+      var refPath = path.join(gitBase, head.slice(5));
+      try { return fs.readFileSync(refPath, "utf-8").trim().slice(0, 12); } catch (e) {}
+      // Worktree: follow commondir to main repo's refs
+      try {
+        var commondir = fs.readFileSync(path.join(gitBase, "commondir"), "utf-8").trim();
+        if (!path.isAbsolute(commondir)) commondir = path.join(gitBase, commondir);
+        refPath = path.join(commondir, head.slice(5));
+        return fs.readFileSync(refPath, "utf-8").trim().slice(0, 12);
+      } catch (e) {}
+      return "";
+    }
+    return head.slice(0, 12);
+  } catch (e) { return ""; }
+}
+
+function findGitRoot(startDir) {
+  var dir = startDir;
+  for (var d = 0; d < 20; d++) {
+    if (fs.existsSync(path.join(dir, ".git"))) return dir;
+    var parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return "";
+}
 
 module.exports = function(input) {
   if (input.tool_name !== "Write") return null;
@@ -27,15 +90,42 @@ module.exports = function(input) {
   }
   if (!isWatched) return null;
 
-  // Check git history — rev-list --count is faster than log --oneline + line counting
+  // T478: Check cache before spawning git
   var dir = path.dirname(filePath);
+  var gitRoot = findGitRoot(dir);
+  var headSha = gitRoot ? getHeadSha(gitRoot) : "";
+  var cacheKey = headSha + ":" + norm;
+
+  if (headSha) {
+    var cache = loadCache();
+    if (cache[cacheKey] !== undefined) {
+      var commitCount = cache[cacheKey];
+      if (commitCount < ITERATION_THRESHOLD) return null;
+      return {
+        decision: "block",
+        reason: "CAUTION: Write (full rewrite) on a file with " + commitCount +
+          " commits of history. This file has been iterated — a rewrite may " +
+          "discard carefully refined content. Use Edit for surgical changes instead. " +
+          "If a full rewrite is truly needed, the user must explicitly approve it. " +
+          "File: " + path.basename(filePath)
+      };
+    }
+  }
+
+  // Cache miss — run git rev-list
   try {
     var countStr = cp.execFileSync("git", ["rev-list", "--count", "HEAD", "--", path.basename(filePath)],
       { cwd: dir, encoding: "utf-8", timeout: 1500, stdio: ["pipe", "pipe", "pipe"], windowsHide: true }
     ).trim();
 
-    var commitCount = parseInt(countStr, 10);
-    if (!commitCount || commitCount < ITERATION_THRESHOLD) return null;
+    var commitCount = parseInt(countStr, 10) || 0;
+
+    // Save to cache
+    if (headSha) {
+      var cache = loadCache();
+      cache[cacheKey] = commitCount;
+      saveCache(cache);
+    }
 
     if (commitCount >= ITERATION_THRESHOLD) {
       return {


### PR DESCRIPTION
## Summary
- **T478**: Added file-based cache to `preserve-iterated-content` module
  - `git rev-list --count` was 882ms avg (1122ms measured) on Windows per Write call
  - Cache keyed by HEAD SHA + file path, stored in `$TEMP/hook-runner-iterated-cache.json`
  - Cache hit: 7ms (160x faster)
  - Fixed worktree HEAD resolution: follows `commondir` to find refs in main repo
- **TODO**: Updated T460, T477, T478 status + session 7 handoff

## Root cause
`git rev-list --count HEAD -- <file>` spawns a git process (~800ms on Windows). Same file gets checked repeatedly in a session since Write calls to hooks/ are common. The cache persists across hook invocations (1hr TTL) and invalidates when HEAD changes.

## Test plan
- [x] Verified: first call 1122ms, cache hit 7ms
- [x] Worktree HEAD resolution: returns correct SHA via commondir
- [x] Non-watched dirs (modules/) return null instantly
- [x] Full suite: 76 suites, 1041 passed (pre-existing)