### PR TITLE
T479: Fix CHANGELOG accuracy + stale branch cleanup + backlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to hook-runner are documented here.
 
 ### Performance
 - **preserve-iterated-content cache** (T478) — File-based cache for `git rev-list --count` results. First call: 1122ms, cache hit: 7ms (160x faster). Cache keyed by HEAD SHA + file path with 1hr TTL. Worktree HEAD resolution via `commondir`.
+- **commit-counter-gate optimization** (T478) — Replaced 4 git subprocess spawns with single `git status --porcelain`. 12/12 tests.
+- **TOOLS tags on 7 modules** (T478) — Added tool-specific `// TOOLS:` tags to 7 modules that already checked `tool_name` internally. Read/Grep/Glob calls now load 28 modules instead of 35.
 
 ### Maintenance
 - **Stale branch cleanup** (T460) — Deleted 17 merged remote branches + 3 stale local worktree branches.
@@ -19,7 +21,7 @@ All notable changes to hook-runner are documented here.
 ### Added
 - **OpenClaw Plugin SDK integration** (T470-T476) — Ported 3 pilot gate modules (force-push, secret-scan, commit-quality) to OpenClaw's Plugin SDK as `openclaw-plugin/`. Install script, `definePluginEntry` + `before_tool_call` hook, configurable per-module enable/disable.
 - **OpenClaw module mapping** (T472) — Mapped all 94 hook-runner modules to OpenClaw equivalents. 42 directly portable, 24 adaptable, 28 Claude Code-specific. See `docs/T472-openclaw-mapping.md`.
-- **OpenClaw E2E test suite** (T475) — 30-test suite across 3 phases: plugin load verification, tsx gate tests, cross-validation with hook-runner originals.
+- **OpenClaw E2E test suite** (T475) — 31-test suite across 3 phases: plugin load verification (3), tsx gate tests with real SDK (16), cross-validation with hook-runner originals (11). Harness uses `register(api)` + `api.on("before_tool_call")` pattern matching OpenClaw runtime.
 - **openclaw-tmemu-guard** (T468) — Project-scoped PreToolUse module preventing modification of production OpenClaw instance. Allows test profiles. 13/13 tests.
 - **Worktree-aware gates** (T469) — spec-gate, branch-pr-gate, and worktree-gate now detect git worktrees via `.git` file gitdir reference. 8 new tests.
 - **Commit counter branch awareness** (T466) — Branch-file mismatch detection + worktree enforcement. 12-test suite.

--- a/TODO.md
+++ b/TODO.md
@@ -1264,7 +1264,14 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - T475: Fixed e2e tsx harness — rewrote to use real OpenClaw Plugin SDK register(api)/api.on("before_tool_call") pattern instead of broken plugin.hooks.before_tool_call(). 31/31 tests pass across 3 phases.
 
 **Remaining:**
-1. T462: Marketplace sync (delegated to claude-code-skills T004) — only open task
+1. T462: Marketplace sync for v2.28.0 (delegated to claude-code-skills T006)
+2. T479: CHANGELOG accuracy — v2.27.0 T475 count corrected (30→31), v2.28.0 added commit-counter + TOOLS tag entries
+3. T480: Stale branch cleanup — deleted 6 merged remote branches (237-bookkeeping, 253-T001, 253-T009, 350-T460, feat/event/T001, worktree-T462)
+
+## Future (backlog)
+- [ ] Port more OpenClaw modules beyond 3 pilot gates (42 directly portable per T472 mapping)
+- [ ] Test suite parallelization — bash tests hang when run sequentially due to WSL latency; add per-test timeouts
+- [ ] v2.29.0 — bundle T475 e2e fix + CHANGELOG corrections
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog

--- a/TODO.md
+++ b/TODO.md
@@ -1231,7 +1231,7 @@ Replace: spec-gate, spec-before-code-gate, gsd-gate → new gsd-plan-gate.
 ## Remaining Tasks
 
 - [x] T460: Clean up stale branches — 17 remote + 3 local worktree branches deleted, 5 unmerged remote kept
-- [ ] T462: Marketplace sync for T458-T469+ changes — delegated to claude-code-skills T004
+- [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006 (T004 covered v2.26.0, T006 covers v2.28.0)
 - [x] T477: Fix runner worktree branch detection — readBranchFromDir prefers CWD worktree over CLAUDE_PROJECT_DIR. Spec-gate allowlist expanded with 9 read-only setup.js flags. 28/28 tests pass (23 bash + 5 worktree). (PR #362)
 - [x] T478: Performance — preserve-iterated-content cache (1122ms→7ms), commit-counter-gate 4→1 git spawns, TOOLS tags on 7 modules (Read loads 35→28). PRs #363, #365, #366.
 

--- a/TODO.md
+++ b/TODO.md
@@ -1245,7 +1245,7 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T472: Map 94 modules — 42 portable, 24 adaptable, 28 not portable (PR #355)
 - [x] T473: Port 3 pilot gates to Plugin SDK (PR #356)
 - [x] T474: Install script + 11-test suite (PR #357)
-- [x] T475: E2E test — 30/30, 3 phases (PR #359)
+- [x] T475: E2E test — 31/31 across 3 phases: plugin load (3), tsx gates with real SDK (16), cross-validation (11) + install (11). Rewrote tsx harness to use register(api)/api.on pattern.
 - [x] T476: Test profile + plugin SDK rewrite (PR #358)
 
 ## Session Handoff (2026-04-17, session 7+8)
@@ -1259,6 +1259,9 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
   - TOOLS tags on 7 modules: Read/Grep/Glob loads 35→28 modules
 - v2.28.0 released (PR #364, GitHub release)
 - All fixes synced to live hooks
+
+**Session 9:**
+- T475: Fixed e2e tsx harness — rewrote to use real OpenClaw Plugin SDK register(api)/api.on("before_tool_call") pattern instead of broken plugin.hooks.before_tool_call(). 31/31 tests pass across 3 phases.
 
 **Remaining:**
 1. T462: Marketplace sync (delegated to claude-code-skills T004) — only open task

--- a/scripts/test/e2e-tsx-harness.ts
+++ b/scripts/test/e2e-tsx-harness.ts
@@ -1,178 +1,232 @@
-// T475: E2E test harness — loads the actual OpenClaw plugin and calls before_tool_call
-// Run: PLUGIN_PATH=<path-to-index.ts> npx tsx scripts/test/e2e-tsx-harness.ts
+// T475: E2E test harness — loads the actual OpenClaw plugin via its real SDK
+// and exercises before_tool_call through the register(api) → api.on() pattern.
+// Run in WSL: NODE_PATH=/usr/lib/node_modules npx tsx scripts/test/e2e-tsx-harness.ts
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const pluginMod = require(process.env.PLUGIN_PATH!);
-const plugin = pluginMod.default || pluginMod;
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+// Verify SDK import works
+if (typeof definePluginEntry !== "function") {
+  console.log("FAIL: definePluginEntry not a function — SDK import broken");
+  process.exit(1);
+}
+
+// ── Load plugin ──────────────────────────────────────────────────────────
+// Import the plugin source — definePluginEntry returns { id, register, ... }
+import pluginExport from "../../openclaw-plugin/index.ts";
+const plugin = pluginExport;
+
+if (!plugin || typeof plugin.register !== "function") {
+  console.log("FAIL: plugin.register is not a function");
+  console.log("  got:", Object.keys(plugin || {}));
+  process.exit(1);
+}
+
+// ── Mock the plugin API to capture the before_tool_call handler ──────────
+type Handler = (event: any, ctx: any) => Promise<any>;
+let capturedHandler: Handler | null = null;
+let currentConfig: Record<string, any> = {};
+
+const mockApi = {
+  on(eventName: string, handler: Handler) {
+    if (eventName === "before_tool_call") {
+      capturedHandler = handler;
+    }
+  },
+  get pluginConfig() {
+    return currentConfig;
+  },
+};
+
+plugin.register(mockApi as any);
+
+if (!capturedHandler) {
+  console.log("FAIL: plugin did not register a before_tool_call handler");
+  process.exit(1);
+}
+
+console.log("OK: plugin loaded and before_tool_call handler captured");
+
+// ── Test cases ───────────────────────────────────────────────────────────
 
 interface TC {
   name: string;
-  tool: string;
-  args: Record<string, unknown>;
-  expectAction: string;
+  toolName: string;
+  params: Record<string, unknown>;
+  expectBlock: boolean;
   reasonContains?: string;
-  config?: Record<string, boolean>;
+  modules?: Record<string, boolean>;
 }
 
 const cases: TC[] = [
   // ── force-push-gate ──
   {
     name: "force-push to main: blocked",
-    tool: "Bash",
-    args: { command: "git push --force origin main" },
-    expectAction: "deny",
+    toolName: "Bash",
+    params: { command: "git push --force origin main" },
+    expectBlock: true,
     reasonContains: "Force-push to main",
   },
   {
     name: "force-push to master: blocked",
-    tool: "Bash",
-    args: { command: "git push -f origin master" },
-    expectAction: "deny",
+    toolName: "Bash",
+    params: { command: "git push -f origin master" },
+    expectBlock: true,
     reasonContains: "Force-push to master",
   },
   {
     name: "force-push to feature: allowed",
-    tool: "Bash",
-    args: { command: "git push --force origin feature-xyz" },
-    expectAction: "allow",
+    toolName: "Bash",
+    params: { command: "git push --force origin feature-xyz" },
+    expectBlock: false,
   },
   {
     name: "regular push to main: allowed",
-    tool: "Bash",
-    args: { command: "git push origin main" },
-    expectAction: "allow",
+    toolName: "Bash",
+    params: { command: "git push origin main" },
+    expectBlock: false,
   },
   {
     name: "force-with-lease to main: blocked",
-    tool: "Bash",
-    args: { command: "git push --force-with-lease origin main" },
-    expectAction: "deny",
+    toolName: "Bash",
+    params: { command: "git push --force-with-lease origin main" },
+    expectBlock: true,
     reasonContains: "Force-push to main",
   },
 
   // ── commit-quality-gate ──
   {
     name: "short commit msg (2 words): blocked",
-    tool: "Bash",
-    args: { command: "git commit -m 'fix bug'" },
-    expectAction: "deny",
+    toolName: "Bash",
+    params: { command: "git commit -m 'fix bug'" },
+    expectBlock: true,
     reasonContains: "TOO SHORT",
   },
   {
     name: "generic commit msg (6 words): blocked",
-    tool: "Bash",
-    args: { command: "git commit -m 'update the config file for deploy setup'" },
-    expectAction: "deny",
+    toolName: "Bash",
+    params: { command: "git commit -m 'update the config file for deploy setup'" },
+    expectBlock: true,
     reasonContains: "TOO GENERIC",
   },
   {
     name: "good commit msg: allowed",
-    tool: "Bash",
-    args: {
+    toolName: "Bash",
+    params: {
       command:
         "git commit -m 'Fix spec-gate cache invalidation when tasks.md is edited externally'",
     },
-    expectAction: "allow",
+    expectBlock: false,
   },
   {
     name: "amend commit: allowed",
-    tool: "Bash",
-    args: { command: "git commit --amend -m 'wip'" },
-    expectAction: "allow",
+    toolName: "Bash",
+    params: { command: "git commit --amend -m 'wip'" },
+    expectBlock: false,
   },
 
   // ── secret-scan-gate (no staged changes, should allow) ──
   {
     name: "git commit (no staged diff): allowed",
-    tool: "Bash",
-    args: { command: "git commit -m 'T475: Test commit with enough words for quality gate'" },
-    expectAction: "allow",
+    toolName: "Bash",
+    params: { command: "git commit -m 'T475: Test commit with enough words for quality gate'" },
+    expectBlock: false,
   },
 
   // ── non-Bash tools: always allowed ──
   {
     name: "non-commit Bash: allowed",
-    tool: "Bash",
-    args: { command: "ls -la" },
-    expectAction: "allow",
+    toolName: "Bash",
+    params: { command: "ls -la" },
+    expectBlock: false,
   },
   {
     name: "Read tool: allowed",
-    tool: "Read",
-    args: { file_path: "/etc/passwd" },
-    expectAction: "allow",
+    toolName: "Read",
+    params: { file_path: "/etc/passwd" },
+    expectBlock: false,
   },
   {
     name: "Write tool: allowed",
-    tool: "Write",
-    args: { file_path: "/tmp/t.txt", content: "hi" },
-    expectAction: "allow",
+    toolName: "Write",
+    params: { file_path: "/tmp/t.txt", content: "hi" },
+    expectBlock: false,
   },
   {
     name: "Edit tool: allowed",
-    tool: "Edit",
-    args: { file_path: "/tmp/t.txt", old_string: "a", new_string: "b" },
-    expectAction: "allow",
+    toolName: "Edit",
+    params: { file_path: "/tmp/t.txt", old_string: "a", new_string: "b" },
+    expectBlock: false,
   },
 
   // ── config: disable a gate ──
   {
     name: "disabled force-push-gate: allowed",
-    tool: "Bash",
-    args: { command: "git push --force origin main" },
-    expectAction: "allow",
-    config: { "force-push-gate": false },
+    toolName: "Bash",
+    params: { command: "git push --force origin main" },
+    expectBlock: false,
+    modules: { "force-push-gate": false },
   },
   {
     name: "disabled commit-quality-gate: allowed",
-    tool: "Bash",
-    args: { command: "git commit -m 'wip'" },
-    expectAction: "allow",
-    config: { "commit-quality-gate": false },
+    toolName: "Bash",
+    params: { command: "git commit -m 'wip'" },
+    expectBlock: false,
+    modules: { "commit-quality-gate": false },
   },
 ];
+
+// ── Run tests ────────────────────────────────────────────────────────────
 
 let pass = 0;
 let fail = 0;
 
-for (const tc of cases) {
-  const modules = tc.config || {};
-  const input = {
-    tool: tc.tool,
-    args: tc.args,
-    context: { session: {}, channel: {}, config: { modules } },
-  };
+async function runTests() {
+  for (const tc of cases) {
+    // Set config for this test case
+    currentConfig = tc.modules ? { modules: tc.modules } : {};
 
-  const result = plugin.hooks.before_tool_call(input);
-  const action = result?.action || "allow";
+    const event = { toolName: tc.toolName, params: tc.params };
+    const ctx = {};
 
-  if (action !== tc.expectAction) {
-    console.log(
-      `FAIL: ${tc.name} — expected ${tc.expectAction}, got ${action}`
-    );
-    if (result?.reason)
-      console.log(`  reason: ${result.reason.split("\n")[0]}`);
-    fail++;
-    continue;
+    let result: any;
+    try {
+      result = await capturedHandler!(event, ctx);
+    } catch (err: any) {
+      console.log(`FAIL: ${tc.name} — handler threw: ${err.message}`);
+      fail++;
+      continue;
+    }
+
+    const blocked = result?.block === true;
+
+    if (blocked !== tc.expectBlock) {
+      console.log(
+        `FAIL: ${tc.name} — expected ${tc.expectBlock ? "block" : "allow"}, got ${blocked ? "block" : "allow"}`
+      );
+      if (result?.blockReason)
+        console.log(`  reason: ${result.blockReason.split("\n")[0]}`);
+      fail++;
+      continue;
+    }
+
+    if (tc.reasonContains && blocked && result?.blockReason) {
+      if (!result.blockReason.includes(tc.reasonContains)) {
+        console.log(
+          `FAIL: ${tc.name} — reason missing "${tc.reasonContains}"`
+        );
+        console.log(`  got: ${result.blockReason.split("\n")[0]}`);
+        fail++;
+        continue;
+      }
+    }
+
+    console.log(`OK: ${tc.name}`);
+    pass++;
   }
 
-  if (
-    tc.reasonContains &&
-    result?.reason &&
-    !result.reason.includes(tc.reasonContains)
-  ) {
-    console.log(
-      `FAIL: ${tc.name} — reason missing "${tc.reasonContains}"`
-    );
-    console.log(`  got: ${result.reason.split("\n")[0]}`);
-    fail++;
-    continue;
-  }
-
-  console.log(`OK: ${tc.name}`);
-  pass++;
+  console.log("");
+  console.log(`--- tsx gate tests: ${pass}/${pass + fail} passed ---`);
+  if (fail > 0) process.exit(1);
 }
 
-console.log("");
-console.log(`--- tsx gate tests: ${pass}/${pass + fail} passed ---`);
-if (fail > 0) process.exit(1);
+runTests();

--- a/scripts/test/test-openclaw-e2e.sh
+++ b/scripts/test/test-openclaw-e2e.sh
@@ -48,10 +48,9 @@ echo ""
 echo "=== Phase 2: Gate functions via tsx ==="
 echo "Running gate tests via tsx in WSL..."
 
-WSL_PLUGIN="${WSL_REPO}/openclaw-plugin/index.ts"
 WSL_HARNESS="${WSL_REPO}/scripts/test/e2e-tsx-harness.ts"
 
-TSX_OUTPUT=$(wsl -e bash -c "PLUGIN_PATH='${WSL_PLUGIN}' npx tsx '${WSL_HARNESS}' 2>&1" 2>/dev/null | tr -d '\000')
+TSX_OUTPUT=$(wsl -e bash -c "cd '${WSL_REPO}' && NODE_PATH=/usr/lib/node_modules npx tsx '${WSL_HARNESS}' 2>&1" 2>/dev/null | tr -d '\000')
 echo "$TSX_OUTPUT"
 
 TSX_PASS=$(echo "$TSX_OUTPUT" | grep -c "^OK:" || true)


### PR DESCRIPTION
## Summary
- Fix v2.27.0 CHANGELOG: T475 test count 30→31, add harness details
- Fix v2.28.0 CHANGELOG: add commit-counter-gate optimization and TOOLS tag entries
- Document stale branch cleanup (6 remote branches deleted)
- Add backlog items: OpenClaw module expansion, test parallelization, v2.29.0