### PR TITLE
T481: v2.29.0 — E2E harness fix + CHANGELOG corrections

### DIFF
--- a/.coconut/STATUS_REPORT.md
+++ b/.coconut/STATUS_REPORT.md
@@ -1,16 +1,20 @@
-# Status Report
+# Coconut Status Report
 
-**Generated:** 2026-04-17 21:15 CDT
-**Task:** T472-T473 (OpenClaw Hook Integration)
+**Updated:** 2026-04-18 session 10
 
-## Currently Working On
-T474: Build install script for openclaw-plugin
+## Current Task
+- T481: v2.29.0 release — version bump, CHANGELOG, sync to live, PR + GitHub release
 
-## Completed Since Last Report
-- **T472** (PR #355): Mapped all 94 modules to OpenClaw equivalents — 70% transferable
-- **T473** (PR #356): Ported 3 pilot modules to OpenClaw Plugin SDK with 24 tests
-- Full suite: 74 suites, 1028 passed, 0 failed
+## Recent Completions (session 9)
+- T475: Fixed OpenClaw e2e tsx harness — 31/31 tests, 3 phases (PR #368)
+- T479: CHANGELOG accuracy fixes for v2.27.0 and v2.28.0 (PR #370)
+- T480: Cleaned 6 stale remote branches
+- T462: Delegated marketplace sync to claude-code-skills T006
+
+## Blockers
+- None
 
 ## Next Steps
-1. T474: Install script for plugin deployment
-2. T475-T476: E2E test with live OpenClaw instance
+1. Version bump to v2.29.0, update CHANGELOG
+2. Sync modules to live hooks
+3. Create PR + GitHub release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.29.0] — 2026-04-18
+
+### Fixed
+- **OpenClaw E2E tsx harness** (T475) — Rewrote harness to use real OpenClaw Plugin SDK `register(api)` + `api.on("before_tool_call")` pattern instead of incorrect `plugin.hooks.before_tool_call()`. Uses `NODE_PATH` to resolve SDK from WSL global install. 16/16 gate tests via tsx.
+- **CHANGELOG accuracy** (T479) — v2.27.0 T475 test count corrected 30→31. v2.28.0 added missing commit-counter-gate optimization and TOOLS tag entries.
+
+### Maintenance
+- **Stale branch cleanup** (T480) — Deleted 6 merged remote branches (237-bookkeeping, 253-T001, 253-T009, 350-T460, feat/event/T001, worktree-T462).
+
 ## [2.28.0] — 2026-04-17
 
 ### Fixed

--- a/TODO.md
+++ b/TODO.md
@@ -1268,10 +1268,13 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 2. T479: CHANGELOG accuracy — v2.27.0 T475 count corrected (30→31), v2.28.0 added commit-counter + TOOLS tag entries
 3. T480: Stale branch cleanup — deleted 6 merged remote branches (237-bookkeeping, 253-T001, 253-T009, 350-T460, feat/event/T001, worktree-T462)
 
+**Session 10:**
+- [ ] T481: v2.29.0 release — T475 e2e fix + T479 CHANGELOG corrections + T480 branch cleanup
+
 ## Future (backlog)
+- [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006
 - [ ] Port more OpenClaw modules beyond 3 pilot gates (42 directly portable per T472 mapping)
 - [ ] Test suite parallelization — bash tests hang when run sequentially due to WSL latency; add per-test timeouts
-- [ ] v2.29.0 — bundle T475 e2e fix + CHANGELOG corrections
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.28.0",
+  "version": "2.29.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- **T475**: Rewrote OpenClaw e2e tsx harness to use real Plugin SDK `register(api)` + `api.on("before_tool_call")` pattern
- **T479**: Fixed CHANGELOG accuracy — v2.27.0 T475 count 30→31, v2.28.0 added missing entries
- **T480**: Cleaned 6 merged remote branches
- **T481**: Version bump to v2.29.0

## Test plan
- [x] 262 JS tests across 23 suites — 0 failures
- [x] `node setup.js --version` → `hook-runner v2.29.0`