### PR TITLE
T482: Per-test timeouts + test filtering flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.30.0] — 2026-04-18
+
+### Improved
+- **Test suite timeouts** (T482) — Per-test timeouts (60s JS, 60s bash) replace single 360s global timeout. Timeouts reported as `TIMEOUT` (not `FAIL`) and don't cause exit(1). New flags: `--js-only`, `--sh-only`, `--skip-wsl`, `--timeout <sec>`. Per-suite and total elapsed times shown. 17-test suite.
+
 ## [2.29.0] — 2026-04-18
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.29.0",
+  "version": "2.30.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"

--- a/scripts/test/test-T482-test-timeouts.js
+++ b/scripts/test/test-T482-test-timeouts.js
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+"use strict";
+// T482: Test --test flag enhancements (timeouts, filters, skip-wsl)
+// Tests parse the cmdTest function logic without running the full suite
+var path = require("path");
+var fs = require("fs");
+
+var REPO_DIR = path.resolve(__dirname, "../..");
+var passed = 0;
+var failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log("OK: " + name);
+    passed++;
+  } catch (e) {
+    console.log("FAIL: " + name + " — " + e.message);
+    failed++;
+  }
+}
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg || "assertion failed");
+}
+
+// Load setup.js source to verify changes
+var setupSrc = fs.readFileSync(path.join(REPO_DIR, "setup.js"), "utf-8");
+
+// Test 1: cmdTest accepts args parameter
+test("cmdTest function accepts args parameter", function() {
+  assert(setupSrc.indexOf("function cmdTest(args)") !== -1, "cmdTest should accept args");
+});
+
+// Test 2: --timeout flag parsing
+test("--timeout flag parsed from args", function() {
+  assert(setupSrc.indexOf('args.indexOf("--timeout")') !== -1, "should parse --timeout");
+});
+
+// Test 3: --skip-wsl flag parsing
+test("--skip-wsl flag parsed from args", function() {
+  assert(setupSrc.indexOf('args.indexOf("--skip-wsl")') !== -1, "should parse --skip-wsl");
+});
+
+// Test 4: --js-only flag parsing
+test("--js-only flag parsed from args", function() {
+  assert(setupSrc.indexOf('args.indexOf("--js-only")') !== -1, "should parse --js-only");
+});
+
+// Test 5: --sh-only flag parsing
+test("--sh-only flag parsed from args", function() {
+  assert(setupSrc.indexOf('args.indexOf("--sh-only")') !== -1, "should parse --sh-only");
+});
+
+// Test 6: default JS timeout is 60s
+test("default JS timeout is 60000ms", function() {
+  assert(setupSrc.indexOf("customTimeout || 60000") !== -1, "JS default should be 60000");
+});
+
+// Test 7: timeout detection uses killed, signal, and elapsed heuristic
+test("timeout detection uses multiple signals", function() {
+  assert(setupSrc.indexOf("e.killed") !== -1, "should check e.killed");
+  assert(setupSrc.indexOf('e.signal === "SIGTERM"') !== -1, "should check e.signal");
+  assert(setupSrc.indexOf("testTimeout - 500") !== -1, "should use elapsed heuristic");
+});
+
+// Test 8: TIMEOUT is reported distinctly from FAIL
+test("TIMEOUT reported distinctly from FAIL", function() {
+  var timeoutMsg = setupSrc.indexOf('"    TIMEOUT: killed after "');
+  var failMsg = setupSrc.indexOf('"    FAIL: suite crashed');
+  assert(timeoutMsg !== -1, "should have TIMEOUT message");
+  assert(failMsg !== -1, "should have FAIL message");
+  assert(timeoutMsg !== failMsg, "TIMEOUT and FAIL should be different code paths");
+});
+
+// Test 9: timed-out suites tracked separately
+test("timed-out suites tracked in separate array", function() {
+  assert(setupSrc.indexOf("timedOutSuites") !== -1, "should track timedOutSuites");
+  assert(setupSrc.indexOf("suiteTimeout++") !== -1, "should increment suiteTimeout counter");
+});
+
+// Test 10: timeouts don't cause exit(1)
+test("timeouts alone do not trigger exit(1)", function() {
+  // The exit condition should only check suiteFail, not suiteTimeout
+  var exitLine = setupSrc.match(/if \(suiteFail > 0\) process\.exit\(1\)/);
+  assert(exitLine, "exit(1) should only trigger on suiteFail > 0");
+});
+
+// Test 11: total elapsed time tracked
+test("total elapsed time tracked", function() {
+  assert(setupSrc.indexOf("var startTime = Date.now()") !== -1, "should track startTime");
+  assert(setupSrc.indexOf("totalElapsed") !== -1, "should compute totalElapsed");
+});
+
+// Test 12: per-suite elapsed time shown
+test("per-suite elapsed time shown", function() {
+  assert(setupSrc.indexOf("var suiteStart = Date.now()") !== -1, "should track suiteStart");
+  assert(setupSrc.indexOf("elapsed") !== -1, "should compute elapsed");
+});
+
+// Test 13: WSL tests list exists
+test("WSL_TESTS list defined", function() {
+  assert(setupSrc.indexOf("WSL_TESTS") !== -1, "should define WSL_TESTS");
+  assert(setupSrc.indexOf("test-openclaw-e2e.sh") !== -1, "should include openclaw-e2e.sh");
+});
+
+// Test 14: dynamic WSL detection scans file content
+test("dynamic WSL detection reads file head", function() {
+  assert(setupSrc.indexOf("slice(0, 2000)") !== -1, "should read first 2000 chars");
+  assert(setupSrc.indexOf("/\\bwsl\\b/i") !== -1, "should check for wsl keyword");
+});
+
+// Test 15: cmdTest dispatch passes args
+test("cmdTest dispatch passes args", function() {
+  assert(setupSrc.indexOf("cmdTest(args)") !== -1, "dispatch should pass args to cmdTest");
+});
+
+// Test 16: help text updated
+test("help text mentions new flags", function() {
+  assert(setupSrc.indexOf("--timeout") !== -1, "help should mention --timeout");
+  assert(setupSrc.indexOf("--skip-wsl") !== -1, "help should mention --skip-wsl");
+  assert(setupSrc.indexOf("--js-only") !== -1, "help should mention --js-only");
+  assert(setupSrc.indexOf("--sh-only") !== -1, "help should mention --sh-only");
+});
+
+// Test 17: verify test directory has both .js and .sh files (for filter logic to matter)
+test("test directory has both JS and bash tests", function() {
+  var testDir = path.join(REPO_DIR, "scripts", "test");
+  var files = fs.readdirSync(testDir).filter(function(f) { return f.indexOf("test-") === 0; });
+  var jsCount = files.filter(function(f) { return f.slice(-3) === ".js"; }).length;
+  var shCount = files.filter(function(f) { return f.slice(-3) === ".sh"; }).length;
+  assert(jsCount > 10, "should have >10 JS tests, got " + jsCount);
+  assert(shCount > 10, "should have >10 bash tests, got " + shCount);
+});
+
+console.log("\n" + passed + " passed, " + failed + " failed");
+process.exit(failed > 0 ? 1 : 0);

--- a/setup.js
+++ b/setup.js
@@ -759,7 +759,7 @@ function cmdHelp() {
   console.log("  --export [file] Export installed modules as shareable YAML (default: modules-export.yaml)");
   console.log("  --perf          Analyze module timing data and identify bottlenecks");
   console.log("  --test-module   Test a single module with sample inputs");
-  console.log("  --test          Run all test suites");
+  console.log("  --test          Run all test suites (--timeout <sec>, --skip-wsl, --js-only, --sh-only)");
   console.log("  --upgrade       Fetch latest runners from GitHub and update local copies");
   console.log("  --uninstall     Remove hook-runner from settings.json and hooks dir");
   console.log("  --prune [N]     Prune log entries older than N days (default 7)");
@@ -1160,14 +1160,36 @@ function cmdList() {
   console.log("[hook-runner] " + installedCount + " installed, " + catalogCount + " in catalog");
 }
 
-function cmdTest() {
+function cmdTest(args) {
+  // Parse test-specific flags
+  var timeoutIdx = args ? args.indexOf("--timeout") : -1;
+  var customTimeout = timeoutIdx !== -1 && args[timeoutIdx + 1] ? parseInt(args[timeoutIdx + 1], 10) * 1000 : 0;
+  var skipWsl = args && args.indexOf("--skip-wsl") !== -1;
+  var jsOnly = args && args.indexOf("--js-only") !== -1;
+  var shOnly = args && args.indexOf("--sh-only") !== -1;
+  var JS_TIMEOUT = customTimeout || 60000;   // 60s default for JS (some create git repos)
+  var SH_TIMEOUT = customTimeout || 60000;   // 60s default for bash
+  // Tests that call WSL — detected by grep at startup or known list
+  var WSL_TESTS = ["test-openclaw-e2e.sh"];
+
   console.log("[hook-runner] Test Suite");
   console.log("========================");
+  if (skipWsl) console.log("  (skipping WSL-dependent tests)");
+  if (jsOnly) console.log("  (JS tests only)");
+  if (shOnly) console.log("  (bash tests only)");
+  console.log("  Timeouts: JS=" + (JS_TIMEOUT / 1000) + "s, bash=" + (SH_TIMEOUT / 1000) + "s");
   var testDir = path.join(REPO_DIR, "scripts", "test");
   var testFiles;
   try {
     testFiles = fs.readdirSync(testDir).filter(function(f) {
-      return f.indexOf("test-") === 0 && (f.slice(-3) === ".sh" || f.slice(-3) === ".js");
+      if (f.indexOf("test-") !== 0) return false;
+      var isSh = f.slice(-3) === ".sh";
+      var isJs = f.slice(-3) === ".js";
+      if (!isSh && !isJs) return false;
+      if (jsOnly && !isJs) return false;
+      if (shOnly && !isSh) return false;
+      if (skipWsl && WSL_TESTS.indexOf(f) !== -1) return false;
+      return true;
     }).sort();
   } catch(e) {
     console.log("  ERROR: test directory not found: " + testDir);
@@ -1176,6 +1198,16 @@ function cmdTest() {
   if (testFiles.length === 0) {
     console.log("  No test scripts found in " + testDir);
     process.exit(1);
+  }
+  // Also detect WSL tests dynamically: scan first line for wsl/openclaw
+  if (skipWsl) {
+    testFiles = testFiles.filter(function(f) {
+      if (f.slice(-3) !== ".sh") return true;
+      try {
+        var head = fs.readFileSync(path.join(testDir, f), "utf-8").slice(0, 2000);
+        return !/\bwsl\b/i.test(head) && !/\bopenclaw\b/i.test(head);
+      } catch(e) { return true; }
+    });
   }
   // Pre-test cleanup: remove any leftover test-tmp-mod-* artifacts from previous runs
   var preCleanDirs = [path.join(REPO_DIR, "modules", "PreToolUse"), path.join(REPO_DIR, "modules", "PostToolUse")];
@@ -1192,21 +1224,26 @@ function cmdTest() {
   // Restore workflow YAML in case previous test left it dirty
   try { cp.execSync("git checkout -- workflows/no-local-docker.yml", { cwd: REPO_DIR, stdio: "pipe" }); } catch(e) {}
 
-  var totalPass = 0, totalFail = 0, suiteFail = 0, failedSuites = [];
+  var totalPass = 0, totalFail = 0, suiteFail = 0, suiteTimeout = 0;
+  var failedSuites = [], timedOutSuites = [], skippedCount = 0;
+  var startTime = Date.now();
   for (var ti = 0; ti < testFiles.length; ti++) {
     var testPath = path.join(testDir, testFiles[ti]);
     var isJs = testFiles[ti].slice(-3) === ".js";
     var suiteName = testFiles[ti].replace("test-", "").replace(/\.(sh|js)$/, "");
+    var suiteStart = Date.now();
+    var testTimeout = isJs ? JS_TIMEOUT : SH_TIMEOUT;
     console.log("");
-    console.log("  [" + suiteName + "] " + testFiles[ti]);
+    console.log("  [" + suiteName + "] " + testFiles[ti] + " (timeout: " + (testTimeout / 1000) + "s)");
     try {
       var execCmd = isJs ? "node " + JSON.stringify(testPath) : "bash " + JSON.stringify(testPath);
       var result = cp.execSync(execCmd, {
         cwd: REPO_DIR,
         encoding: "utf-8",
         stdio: ["pipe", "pipe", "pipe"],
-        timeout: 360000
+        timeout: testTimeout
       });
+      var elapsed = ((Date.now() - suiteStart) / 1000).toFixed(1);
       var match = result.match(/(\d+) passed, (\d+) failed/);
       if (match) {
         totalPass += parseInt(match[1], 10);
@@ -1218,29 +1255,52 @@ function cmdTest() {
       for (var sl = 0; sl < summaryLines.length; sl++) {
         console.log("    " + summaryLines[sl]);
       }
+      console.log("    (" + elapsed + "s)");
     } catch(e) {
-      suiteFail++;
-      failedSuites.push(suiteName);
-      console.log("    FAIL: suite crashed (exit code " + (e.status || "unknown") + ")");
-      var errOut = (e.stdout || "") + (e.stderr || "");
-      var errLines = errOut.trim().split("\n").slice(-5);
-      for (var el = 0; el < errLines.length; el++) {
-        console.log("    " + errLines[el]);
-      }
-      var partMatch = errOut.match(/(\d+) passed, (\d+) failed/);
-      if (partMatch) {
-        totalPass += parseInt(partMatch[1], 10);
-        totalFail += parseInt(partMatch[2], 10);
+      var elapsed2 = ((Date.now() - suiteStart) / 1000).toFixed(1);
+      var isTimeout = e.killed || e.signal === "SIGTERM" || (Date.now() - suiteStart) >= testTimeout - 500;
+      if (isTimeout) {
+        // Timeout — distinct from failure
+        suiteTimeout++;
+        timedOutSuites.push(suiteName);
+        console.log("    TIMEOUT: killed after " + (testTimeout / 1000) + "s (" + elapsed2 + "s elapsed)");
+        // Still count any partial results
+        var timeoutOut = (e.stdout || "") + (e.stderr || "");
+        var timeoutMatch = timeoutOut.match(/(\d+) passed, (\d+) failed/);
+        if (timeoutMatch) {
+          totalPass += parseInt(timeoutMatch[1], 10);
+          totalFail += parseInt(timeoutMatch[2], 10);
+        }
+      } else {
+        suiteFail++;
+        failedSuites.push(suiteName);
+        console.log("    FAIL: suite crashed (exit code " + (e.status || "unknown") + ") (" + elapsed2 + "s)");
+        var errOut = (e.stdout || "") + (e.stderr || "");
+        var errLines = errOut.trim().split("\n").slice(-5);
+        for (var el = 0; el < errLines.length; el++) {
+          console.log("    " + errLines[el]);
+        }
+        var partMatch = errOut.match(/(\d+) passed, (\d+) failed/);
+        if (partMatch) {
+          totalPass += parseInt(partMatch[1], 10);
+          totalFail += parseInt(partMatch[2], 10);
+        }
       }
     }
   }
+  var totalElapsed = ((Date.now() - startTime) / 1000).toFixed(1);
   console.log("");
   console.log("========================");
-  console.log("[hook-runner] " + testFiles.length + " suites, " + totalPass + " passed, " + totalFail + " failed");
+  console.log("[hook-runner] " + testFiles.length + " suites, " + totalPass + " passed, " + totalFail + " failed" +
+    (suiteTimeout > 0 ? ", " + suiteTimeout + " timed out" : "") +
+    " (" + totalElapsed + "s)");
   if (suiteFail > 0) {
     console.log("[hook-runner] " + suiteFail + " suite(s) had failures: " + failedSuites.join(", "));
-    process.exit(1);
   }
+  if (suiteTimeout > 0) {
+    console.log("[hook-runner] " + suiteTimeout + " suite(s) timed out: " + timedOutSuites.join(", "));
+  }
+  if (suiteFail > 0) process.exit(1);
 }
 
 function cmdHealth() {
@@ -1715,7 +1775,7 @@ function main() {
   if (args.indexOf("--perf") !== -1) return cmdPerf();
   if (args.indexOf("--list") !== -1) return cmdList();
   if (args.indexOf("--test-module") !== -1) return cmdTestModule(args);
-  if (args.indexOf("--test") !== -1) return cmdTest();
+  if (args.indexOf("--test") !== -1) return cmdTest(args);
   if (args.indexOf("--integrity") !== -1) return cmdIntegrity(args);
   if (args.indexOf("--preflight") !== -1) {
     var pfArgs = [path.join(__dirname, "preflight.js")];


### PR DESCRIPTION
## Summary
- Replace single 360s global timeout with per-test timeouts (60s JS, 60s bash)
- Timeouts reported as `TIMEOUT` (not `FAIL`) and don't trigger `exit(1)`
- New flags: `--js-only`, `--sh-only`, `--skip-wsl`, `--timeout <sec>`
- Per-suite and total elapsed times shown in output

## Test plan
- [x] 24 JS suites pass (209 tests, 0 failed, 0 timeouts)
- [x] 17-test verification suite for new flags (`test-T482-test-timeouts.js`)
- [x] Timeout detection verified: commit-counter-gate correctly reports TIMEOUT
- [x] `--js-only` filter correctly excludes bash tests