### PR TITLE
T485: Block git commit bypass of worktree enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.31.0] — 2026-04-18
+
+### Fixed
+- **spec-gate TODO.md bypass** (T484) — When task ID exists in TODO.md AND a fuzzy-matching spec dir has `spec.md` but no `tasks.md`, gate now blocks. Prevents bypassing SHTD pipeline by adding tasks to TODO.md when an incomplete spec exists. Completed specs unaffected. 6-test suite.
+- **commit-counter-gate worktree bypass** (T485) — Wrong-branch and not-in-worktree blocks now set a `worktreeRequired` flag that also blocks `git commit` until session enters a worktree. Previously Claude could bypass by committing on the wrong branch. 5 new tests (17 total).
+
 ## [2.30.0] — 2026-04-18
 
 ### Improved

--- a/TODO.md
+++ b/TODO.md
@@ -1272,6 +1272,11 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T481: v2.29.0 release — T475 e2e fix + T479 CHANGELOG corrections + T480 branch cleanup (PR #371, GitHub release)
 - [x] T482: Test suite per-test timeouts — 60s per-test timeouts, TIMEOUT vs FAIL distinction, --js-only/--sh-only/--skip-wsl/--timeout flags (PR #373, v2.30.0)
 
+**Session 11:**
+- [x] T482: (continued from session 10) — committed, PR #373 merged, v2.30.0 released
+- [x] T484: RCA — spec-gate TODO.md bypass when matching spec has incomplete chain (PR #375)
+- [x] T485: RCA — commit-counter-gate worktreeRequired flag blocks git commit bypass (PR #375)
+
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006
 - [ ] Port more OpenClaw modules beyond 3 pilot gates (42 directly portable per T472 mapping)

--- a/modules/PreToolUse/commit-counter-gate.js
+++ b/modules/PreToolUse/commit-counter-gate.js
@@ -25,13 +25,17 @@ var FILE_MODIFY_PATTERNS = require("./_file-modify-patterns");
 function readCounter() {
   try {
     var data = JSON.parse(fs.readFileSync(COUNTER_FILE, "utf-8"));
-    return data.count || 0;
-  } catch(e) { return 0; }
+    return { count: data.count || 0, worktreeRequired: !!data.worktreeRequired };
+  } catch(e) { return { count: 0, worktreeRequired: false }; }
 }
 
-function writeCounter(count) {
+function writeCounter(count, worktreeRequired) {
   try {
-    fs.writeFileSync(COUNTER_FILE, JSON.stringify({ count: count, ts: new Date().toISOString() }));
+    fs.writeFileSync(COUNTER_FILE, JSON.stringify({
+      count: count,
+      ts: new Date().toISOString(),
+      worktreeRequired: !!worktreeRequired
+    }));
   } catch(e) {}
 }
 
@@ -155,9 +159,21 @@ module.exports = function(input) {
     } catch(e) { cmd = (input.tool_input || {}).command || ""; }
   }
 
-  // Reset counter on git commit
+  // Reset counter on git commit — but block if worktree was required
+  // T485: Previously, Claude bypassed the worktree enforcement by just committing
+  // on the wrong branch. Now: if the gate flagged "worktree required", block commits too.
   if (input.tool_name === "Bash" && /git\s+commit/.test(cmd)) {
-    writeCounter(0);
+    var state = readCounter();
+    if (state.worktreeRequired && !isInWorktree()) {
+      return {
+        decision: "block",
+        reason: "COMMIT COUNTER — WORKTREE REQUIRED: Cannot commit on the main checkout.\n" +
+          "A previous check found files that need an isolated worktree.\n" +
+          "REQUIRED: Call EnterWorktree first, then commit in the worktree.\n" +
+          "This flag clears automatically once you're in a worktree."
+      };
+    }
+    writeCounter(0, false);
     return null;
   }
 
@@ -176,8 +192,9 @@ module.exports = function(input) {
 
   if (!isFileModify) return null;
 
-  var count = readCounter() + 1;
-  writeCounter(count);
+  var counterState = readCounter();
+  var count = counterState.count + 1;
+  writeCounter(count, counterState.worktreeRequired);
 
   if (count >= MAX_EDITS) {
     // T478: Single git call replaces 4 separate spawns
@@ -198,6 +215,8 @@ module.exports = function(input) {
 
     if (mismatch) {
       // WRONG BRANCH — changed files don't relate to this branch at all
+      // T485: Set worktreeRequired flag so git commit is also blocked
+      writeCounter(count, true);
       var topDirs = [];
       var seen = {};
       files.forEach(function(f) {
@@ -217,6 +236,8 @@ module.exports = function(input) {
 
     // Branch looks right (or we can't tell) but not in a worktree — enforce worktree
     if (!inWorktree) {
+      // T485: Set worktreeRequired flag so git commit is also blocked
+      writeCounter(count, true);
       return {
         decision: "block",
         reason: "COMMIT COUNTER: " + count + " file modifications since last commit (" + gitCount + " files changed in git).\n" +

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.30.0",
+  "version": "2.31.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"

--- a/scripts/test/test-commit-counter-gate.js
+++ b/scripts/test/test-commit-counter-gate.js
@@ -271,6 +271,93 @@ test("substring matching: branch 'deploy' matches dir 'deployment'", function() 
   cleanupRepo(dir);
 });
 
+// --- T485: worktreeRequired flag blocks git commit bypass ---
+
+test("T485: git commit blocked when worktreeRequired flag is set (not in worktree)", function() {
+  // Simulate: counter has worktreeRequired=true, session tries git commit
+  var dir = createTempRepo("main", ["src/app.js"]);
+  process.env.CLAUDE_PROJECT_DIR = dir;
+  // Write counter with worktreeRequired flag
+  fs.writeFileSync(COUNTER_FILE, JSON.stringify({ count: 15, ts: new Date().toISOString(), worktreeRequired: true }));
+
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: { command: "git commit -m 'sneaky commit'" } });
+  assert(r !== null, "should block git commit");
+  assert(r.decision === "block", "should be block decision");
+  assert(r.reason.indexOf("WORKTREE REQUIRED") !== -1, "should mention WORKTREE REQUIRED");
+
+  cleanupRepo(dir);
+});
+
+test("T485: git commit allowed when worktreeRequired is false", function() {
+  var dir = createTempRepo("main", []);
+  process.env.CLAUDE_PROJECT_DIR = dir;
+  fs.writeFileSync(COUNTER_FILE, JSON.stringify({ count: 10, ts: new Date().toISOString(), worktreeRequired: false }));
+
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: { command: "git commit -m 'normal commit'" } });
+  assert(r === null, "should allow commit when worktreeRequired is false");
+  var data = JSON.parse(fs.readFileSync(COUNTER_FILE, "utf-8"));
+  assert(data.count === 0, "counter should reset to 0");
+
+  cleanupRepo(dir);
+});
+
+test("T485: WRONG BRANCH sets worktreeRequired flag", function() {
+  var dir = createTempRepo("001-T001-deploy-nfs-datasec", [
+    "labs/dd-lab/terraform/main.tf",
+    "labs/dd-lab/scripts/setup.sh"
+  ]);
+  process.env.CLAUDE_PROJECT_DIR = dir;
+  setCounter(14);
+
+  var gate = loadGate();
+  var r = gate({ tool_name: "Edit", tool_input: { file_path: path.join(dir, "labs/dd-lab/terraform/main.tf"), old_string: "a", new_string: "b" } });
+  assert(r !== null && r.reason.indexOf("WRONG BRANCH") !== -1, "should detect wrong branch");
+  var data = JSON.parse(fs.readFileSync(COUNTER_FILE, "utf-8"));
+  assert(data.worktreeRequired === true, "worktreeRequired flag should be set");
+
+  cleanupRepo(dir);
+});
+
+test("T485: not-in-worktree block sets worktreeRequired flag", function() {
+  var dir = createTempRepo("build-src-utils", ["src/utils.js"]);
+  process.env.CLAUDE_PROJECT_DIR = dir;
+  setCounter(14);
+
+  var gate = loadGate();
+  var r = gate({ tool_name: "Edit", tool_input: { file_path: path.join(dir, "src/utils.js"), old_string: "a", new_string: "b" } });
+  assert(r !== null && r.reason.indexOf("main checkout") !== -1, "should enforce worktree");
+  var data = JSON.parse(fs.readFileSync(COUNTER_FILE, "utf-8"));
+  assert(data.worktreeRequired === true, "worktreeRequired flag should be set");
+
+  cleanupRepo(dir);
+});
+
+test("T485: worktreeRequired cleared on commit inside worktree", function() {
+  // Simulate being in a worktree: .git is a file
+  var dir = createTempRepo("worktree-T485-test", []);
+  process.env.CLAUDE_PROJECT_DIR = dir;
+  var gitDir = path.join(dir, ".git");
+  var realGitDir = path.join(os.tmpdir(), "fake-git-t485-" + Date.now());
+  fs.mkdirSync(realGitDir, { recursive: true });
+  fs.cpSync(path.join(gitDir, "HEAD"), path.join(realGitDir, "HEAD"));
+  fs.rmSync(gitDir, { recursive: true, force: true });
+  fs.writeFileSync(gitDir, "gitdir: " + realGitDir);
+
+  fs.writeFileSync(COUNTER_FILE, JSON.stringify({ count: 15, ts: new Date().toISOString(), worktreeRequired: true }));
+
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: { command: "git commit -m 'commit in worktree'" } });
+  // In worktree, commit should be allowed (worktreeRequired only blocks non-worktree)
+  assert(r === null, "should allow commit inside worktree even with worktreeRequired");
+  var data = JSON.parse(fs.readFileSync(COUNTER_FILE, "utf-8"));
+  assert(data.worktreeRequired === false, "worktreeRequired should be cleared");
+
+  fs.rmSync(realGitDir, { recursive: true, force: true });
+  cleanupRepo(dir);
+});
+
 // --- Cleanup ---
 process.env.CLAUDE_PROJECT_DIR = origProjectDir || "";
 process.env.HOOK_RUNNER_TEST = origTestEnv || "";


### PR DESCRIPTION
## Summary
- commit-counter-gate now sets `worktreeRequired` flag when wrong-branch or not-in-worktree block fires
- `git commit` is also blocked when flag is set (not in worktree), preventing bypass
- Flag clears when session enters a worktree and commits there
- v2.31.0 with CHANGELOG

## Test plan
- [x] 5 new T485 tests (17 total commit-counter-gate tests, 0 failures)
- [x] 12 existing tests pass unchanged
- [x] T484 spec-gate fix already merged in PR #375