### PR TITLE
T487: v2.33.0 — OpenClaw plugin batch port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.33.0] — 2026-04-18
+
+### Added
+- **OpenClaw plugin v0.2.0** (T487) — Batch-ported 15 modules beyond the 3 T473 pilots. Total: 18 modules.
+  - **before_tool_call (10 new)**: `git-destructive-guard`, `archive-not-delete`, `git-rebase-safety`, `no-hardcoded-paths`, `victory-declaration-gate`, `root-cause-gate`, `no-fragile-heuristics`, `no-focus-steal`, `crlf-ssh-key-check`, `unresolved-issues-gate`
+  - **after_tool_call (5 new)**: `commit-msg-check`, `crlf-detector`, `test-coverage-check`, `result-review-gate`, `rule-hygiene`
+- All modules individually configurable via `openclaw.plugin.json` modules map
+- 49-test suite for T487. Updated T472 mapping doc with ported status.
+
 ## [2.32.0] — 2026-04-18
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -1280,7 +1280,7 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T486: Inter-project TODO priority system — audit logger, SessionStart P0 injection, PreToolUse priority gate, CLI dashboard (PR #377, v2.32.0)
 
 **Session 12:**
-- [ ] T487: Batch port 15 universally-useful modules to OpenClaw plugin (beyond 3 pilots)
+- [x] T487: Batch port 15 modules to OpenClaw plugin v0.2.0 — 18 total (13 before_tool_call + 5 after_tool_call), 49/49 tests (PR #379)
 
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.32.0",
+  "version": "2.33.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Version bump v2.33.0 for T487 OpenClaw batch port
- Mark T487 complete in TODO.md
- CHANGELOG entry for 15 new modules (18 total)