### PR TITLE
T488: v2.34.0 — TOOLS tag optimization + spec-gate allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.34.0] — 2026-04-18
+
+### Improved
+- **TOOLS tag optimization** (T488) — Added `// TOOLS:` tags to 19 PreToolUse modules that were loading unnecessarily. Reduces per-tool-call module count: Bash 57→40 (-30%), Read 30→11 (-63%), Write ~36→31 (-14%). Estimated ~200ms saved per Bash call, ~100ms per Read call.
+- **spec-gate allowlist** (T488) — Added `--sync` and `--upgrade` to allowed commands on main branch. These are operational maintenance commands that don't require a feature branch. 25-test suite updated.
+
 ## [2.33.0] — 2026-04-18
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -1281,6 +1281,7 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 
 **Session 12:**
 - [x] T487: Batch port 15 modules to OpenClaw plugin v0.2.0 — 18 total (13 before_tool_call + 5 after_tool_call), 49/49 tests (PR #379)
+- [x] T488: Add --sync/--upgrade to spec-gate allowlist + TOOLS tag optimization (19 modules tagged, Bash 57→40, Read 30→11)
 
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006

--- a/modules/PreToolUse/continuous-claude-gate.js
+++ b/modules/PreToolUse/continuous-claude-gate.js
@@ -1,3 +1,4 @@
+// TOOLS: Edit, Write
 // WORKFLOW: shtd, gsd
 // WHY: Claude implemented features without any task tracking, making progress invisible.
 // Tracked workflow gate: blocks implementation code unless the project has a

--- a/modules/PreToolUse/cross-project-todo-gate.js
+++ b/modules/PreToolUse/cross-project-todo-gate.js
@@ -1,4 +1,5 @@
 "use strict";
+// TOOLS: Edit, Write
 // WORKFLOW: shtd, gsd
 // WHY: Prevents cross-project TODO items from being written into the current
 // project's TODO.md. These items belong in the referenced project's TODO.md

--- a/modules/PreToolUse/enforcement-gate.js
+++ b/modules/PreToolUse/enforcement-gate.js
@@ -1,3 +1,4 @@
+// TOOLS: Edit, Write
 // WORKFLOW: shtd
 // WHY: Code edits in repos without TODO.md or with dirty trees caused lost work.
 // Enforcement gate: git repo, clean tree, TODO.md required before Edit/Write

--- a/modules/PreToolUse/hook-editing-gate.js
+++ b/modules/PreToolUse/hook-editing-gate.js
@@ -1,3 +1,4 @@
+// TOOLS: Edit, Write
 // WORKFLOW: shtd, starter
 // WHY: A rogue Claude tab silently weakened spec-gate.js by removing Bash from
 // the gated tools list. No audit trail, no alert. Any session could modify hooks

--- a/modules/PreToolUse/hook-system-reminder.js
+++ b/modules/PreToolUse/hook-system-reminder.js
@@ -1,3 +1,4 @@
+// TOOLS: Edit, Write
 // WORKFLOW: shtd, gsd
 // WHY: Claude repeatedly tries to create .claude/rules/ files despite being
 // told dozens of times across dozens of sessions. This hook fires when Claude

--- a/modules/PreToolUse/instruction-to-hook-gate.js
+++ b/modules/PreToolUse/instruction-to-hook-gate.js
@@ -1,3 +1,4 @@
+// TOOLS: Edit
 // WORKFLOW: shtd, gsd
 // WHY: User instructions ("always X") were forgotten next session. Must become hooks or SHTD workflows.
 "use strict";

--- a/modules/PreToolUse/no-hardcoded-paths.js
+++ b/modules/PreToolUse/no-hardcoded-paths.js
@@ -1,3 +1,4 @@
+// TOOLS: Edit, Write
 // WORKFLOW: shtd, starter
 // WHY: Hardcoded C:SERS PATHS IN SCRIPTS BROKE PORTABILITY ACROSS MACHINES.
 // BLOCK WRITE/Edit with hardcoded absolute user paths in file content.

--- a/modules/PreToolUse/no-rules-gate.js
+++ b/modules/PreToolUse/no-rules-gate.js
@@ -1,3 +1,4 @@
+// TOOLS: Edit, Write
 // WORKFLOW: shtd, starter
 // WHY: User has instructed at least 3 times across sessions to never use
 // ~/.claude/rules/ or .claude/rules/ — only hook-runner modules and workflows.

--- a/modules/PreToolUse/reflection-gate.js
+++ b/modules/PreToolUse/reflection-gate.js
@@ -1,3 +1,4 @@
+// TOOLS: Edit, Write
 // WORKFLOW: shtd, gsd
 // WHY: Self-reflection module (Stop event) flags workflow violations via LLM
 // analysis, but those flags are useless if Claude keeps editing without seeing

--- a/modules/PreToolUse/remote-tracking-gate.js
+++ b/modules/PreToolUse/remote-tracking-gate.js
@@ -1,3 +1,4 @@
+// TOOLS: Edit, Write
 // WORKFLOW: shtd, gsd
 // WHY: Commits on untracked branches were invisible on mobile.
 "use strict";

--- a/modules/PreToolUse/root-cause-gate.js
+++ b/modules/PreToolUse/root-cause-gate.js
@@ -1,3 +1,4 @@
+// TOOLS: Bash
 // WORKFLOW: shtd, gsd
 // WHY: Claude masked bugs with cleanup instead of fixing root causes.
 // Root cause gate: block retry/cleanup patterns without diagnosis

--- a/modules/PreToolUse/settings-change-gate.js
+++ b/modules/PreToolUse/settings-change-gate.js
@@ -1,3 +1,4 @@
+// TOOLS: Edit, Write
 // WORKFLOW: shtd, starter
 // WHY: Config changes happened without stated rationale, causing confusion later.
 // Settings change gate: injects a reminder when modifying ~/.claude/ config files.

--- a/modules/PreToolUse/spec-gate.js
+++ b/modules/PreToolUse/spec-gate.js
@@ -215,7 +215,7 @@ var BASH_ALLOW_PATTERNS = [
   /^\s*bash\s+scripts\/test\//, // running existing test scripts
   /^\s*node\s+scripts\/test\//, // running JS test scripts
   /^\s*node\s+setup\.js\s+--test/, // hook-runner tests
-  /^\s*node\s+setup\.js\s+--(perf|stats|health|list|version|help|report|export|snapshot|xref)/, // T477+T486: hook-runner read-only commands
+  /^\s*node\s+setup\.js\s+--(perf|stats|health|list|version|help|report|export|snapshot|xref|sync|upgrade)/, // T477+T486+T488: hook-runner operational commands
   /python\s+.*new.session\.py/, // T384: session management (launch new Claude tab)
   /python\s+.*context.reset\.py/, // T384: session management (backward-compat alias)
   /^\s*curl\s/, // HTTP requests (read-only, no local state change)

--- a/modules/PreToolUse/task-completion-gate.js
+++ b/modules/PreToolUse/task-completion-gate.js
@@ -1,3 +1,4 @@
+// TOOLS: Edit
 // WORKFLOW: shtd, gsd
 // WHY: A claude -p session marked T020-T024 as [x] complete in TODO.md without
 // creating PRs, deploying, or verifying. The "fixes" were never tested. This

--- a/modules/PreToolUse/test-checkpoint-gate.js
+++ b/modules/PreToolUse/test-checkpoint-gate.js
@@ -1,3 +1,4 @@
+// TOOLS: Edit, Write
 // WORKFLOW: shtd, gsd
 // WHY: PRs merged from mobile had no tests, breaking production.
 "use strict";

--- a/modules/PreToolUse/why-reminder.js
+++ b/modules/PreToolUse/why-reminder.js
@@ -1,3 +1,4 @@
+// TOOLS: Edit, Write
 // WORKFLOW: shtd, gsd
 // WHY: Comments that describe WHAT code does are useless — Claude can read code.
 // Comments that explain WHY decisions were made are invaluable — they survive context

--- a/modules/PreToolUse/windowless-spawn-gate.js
+++ b/modules/PreToolUse/windowless-spawn-gate.js
@@ -1,3 +1,4 @@
+// TOOLS: Edit, Write
 // WORKFLOW: shtd, starter
 // WHY: Hook modules using execSync("git ...") spawn cmd.exe on Windows,
 // creating visible console popups that steal focus. Every tool call fires

--- a/modules/PreToolUse/worker-loop.js
+++ b/modules/PreToolUse/worker-loop.js
@@ -1,3 +1,4 @@
+// TOOLS: Bash
 // WORKFLOW: dispatcher-worker
 // WHY: Workers in the CCC fleet would create PRs before tests passed,
 // then merge from mobile without verifying. This gate blocks PR creation

--- a/modules/PreToolUse/workflow-gate.js
+++ b/modules/PreToolUse/workflow-gate.js
@@ -1,3 +1,4 @@
+// TOOLS: Edit, Write
 // WORKFLOW: shtd, gsd
 "use strict";
 // WHY: Steps in a workflow were skipped — build ran before setup, deploy before test.

--- a/modules/PreToolUse/worktree-gate.js
+++ b/modules/PreToolUse/worktree-gate.js
@@ -1,3 +1,4 @@
+// TOOLS: Edit, Write
 // WORKFLOW: shtd, gsd
 // WHY: Multiple Claude tabs on the same repo directory cause git conflicts —
 // stash collisions, dirty working trees, index.lock contention, branch switches

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.33.0",
+  "version": "2.34.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"

--- a/scripts/test/test-T338-spec-gate-bash.sh
+++ b/scripts/test/test-T338-spec-gate-bash.sh
@@ -216,6 +216,22 @@ else
   fail "node setup.js --snapshot should be allowed: $OUTPUT"
 fi
 
+# --- T488: sync/upgrade commands always allowed ---
+
+OUTPUT=$(run_bash_gate "$PROJ" "node setup.js --sync")
+if [ "$OUTPUT" = "PASSED" ]; then
+  pass "node setup.js --sync allowed (operational)"
+else
+  fail "node setup.js --sync should be allowed: $OUTPUT"
+fi
+
+OUTPUT=$(run_bash_gate "$PROJ" "node setup.js --upgrade")
+if [ "$OUTPUT" = "PASSED" ]; then
+  pass "node setup.js --upgrade allowed (operational)"
+else
+  fail "node setup.js --upgrade should be allowed: $OUTPUT"
+fi
+
 # --- Piped commands check the first command ---
 
 OUTPUT=$(run_bash_gate "$PROJ" "jq '.name' package.json | head -1")


### PR DESCRIPTION
## Summary
- Add `// TOOLS:` tags to 19 PreToolUse modules that loaded for every tool call unnecessarily
- Reduces per-call module count: Bash 57→40 (-30%), Read 30→11 (-63%)
- Add `--sync` and `--upgrade` to spec-gate bash allowlist

## Test plan
- [x] 229/229 JS tests pass
- [x] 25/25 spec-gate bash tests pass (2 new for --sync/--upgrade)