### PR TITLE
T489: Update OpenClaw plugin docs for v0.3.0

### DIFF
--- a/openclaw-plugin/README.md
+++ b/openclaw-plugin/README.md
@@ -4,7 +4,7 @@ Ported [hook-runner](https://github.com/grobomo/hook-runner) gate modules for Op
 
 ## Modules
 
-### before_tool_call (13 gates)
+### before_tool_call (17 gates)
 
 | Module | What it does |
 |---|---|
@@ -21,8 +21,12 @@ Ported [hook-runner](https://github.com/grobomo/hook-runner) gate modules for Op
 | `no-focus-steal` | Blocks background processes that flash console windows (Windows) |
 | `crlf-ssh-key-check` | Warns about CRLF corruption when copying SSH keys |
 | `unresolved-issues-gate` | Blocks commit when TODO.md has unresolved FAIL/WARN entries |
+| `no-nested-claude` | Blocks running Claude Code as a subprocess |
+| `disk-space-guard` | Blocks destructive commands during disk space emergencies |
+| `no-unnecessary-sleep` | Blocks `sleep` > 1s between actions (wastes time) |
+| `claude-p-pattern` | Enforces correct `claude -p` invocation patterns |
 
-### after_tool_call (5 gates)
+### after_tool_call (8 gates)
 
 | Module | What it does |
 |---|---|
@@ -31,6 +35,9 @@ Ported [hook-runner](https://github.com/grobomo/hook-runner) gate modules for Op
 | `test-coverage-check` | Reminds to run tests when source files with matching test files are modified |
 | `result-review-gate` | Injects review checklist when reading report/results files |
 | `rule-hygiene` | Validates rule files are granular and properly scoped |
+| `empty-output-detector` | Flags commands that silently produce no output |
+| `disk-space-detect` | Detects disk space errors and activates disk-space-guard |
+| `troubleshoot-detector` | Detects fail-fail-succeed cycles, prompts to codify the lesson |
 
 ## Install
 

--- a/openclaw-plugin/openclaw.plugin.json
+++ b/openclaw-plugin/openclaw.plugin.json
@@ -1,8 +1,8 @@
 {
   "id": "hook-runner-gates",
   "name": "Hook Runner Gates",
-  "description": "18 ported hook-runner gate modules for OpenClaw. Git safety, secret scanning, code quality, commit hygiene, test coverage, and AI behavioral guardrails.",
-  "version": "0.2.0",
+  "description": "25 ported hook-runner gate modules for OpenClaw. Git safety, secret scanning, code quality, commit hygiene, test coverage, disk safety, and AI behavioral guardrails.",
+  "version": "0.3.0",
   "author": "grobomo",
   "license": "MIT",
   "openclaw": {
@@ -29,11 +29,18 @@
           "no-focus-steal": { "type": "boolean", "default": true },
           "crlf-ssh-key-check": { "type": "boolean", "default": true },
           "unresolved-issues-gate": { "type": "boolean", "default": true },
+          "no-nested-claude": { "type": "boolean", "default": true },
+          "disk-space-guard": { "type": "boolean", "default": true },
+          "no-unnecessary-sleep": { "type": "boolean", "default": true },
+          "claude-p-pattern": { "type": "boolean", "default": true },
           "commit-msg-check": { "type": "boolean", "default": true },
           "crlf-detector": { "type": "boolean", "default": true },
           "test-coverage-check": { "type": "boolean", "default": true },
           "result-review-gate": { "type": "boolean", "default": true },
-          "rule-hygiene": { "type": "boolean", "default": true }
+          "rule-hygiene": { "type": "boolean", "default": true },
+          "empty-output-detector": { "type": "boolean", "default": true },
+          "disk-space-detect": { "type": "boolean", "default": true },
+          "troubleshoot-detector": { "type": "boolean", "default": true }
         }
       }
     }
@@ -53,11 +60,18 @@
       "no-focus-steal": true,
       "crlf-ssh-key-check": true,
       "unresolved-issues-gate": true,
+      "no-nested-claude": true,
+      "disk-space-guard": true,
+      "no-unnecessary-sleep": true,
+      "claude-p-pattern": true,
       "commit-msg-check": true,
       "crlf-detector": true,
       "test-coverage-check": true,
       "result-review-gate": true,
-      "rule-hygiene": true
+      "rule-hygiene": true,
+      "empty-output-detector": true,
+      "disk-space-detect": true,
+      "troubleshoot-detector": true
     }
   }
 }


### PR DESCRIPTION
## Summary
- Update openclaw.plugin.json: version 0.3.0, add 7 new module config entries
- Update README.md: 17 before_tool_call + 8 after_tool_call module tables

Companion to PR #382 which added the code.