### PR TITLE
T491: TOOLS tag optimization batch 2 — 6 PreToolUse modules tagged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.36.0] — 2026-04-18
+
+### Improved
+- **TOOLS tag optimization batch 2** (T491) — Added `// TOOLS:` tags to 6 untagged PreToolUse modules, reducing overhead on Read/Grep/Glob calls:
+  - `spec-gate` → `Bash, Edit, Write` (12ms avg saved per non-matching call)
+  - `gsd-plan-gate` → `Bash, Edit, Write` (8ms avg saved)
+  - `env-var-check` → `Bash, Edit, Write`
+  - `no-nested-claude` → `Bash`
+  - `publish-json-guard` → `Bash, Edit, Write`
+  - `pr-first-gate` → `Bash, Edit, Write`
+- Combined with T488 (batch 1), 56 of 61 PreToolUse modules now have TOOLS tags
+
 ## [2.35.0] — 2026-04-18
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -1285,6 +1285,11 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 
 **Session 13:**
 - [x] T489: OpenClaw batch port #2 — 7 universal modules, plugin v0.3.0, 25 total (17 before_tool_call + 8 after_tool_call), 116 tests (PR #382, v2.35.0)
+- [x] T489: Update openclaw.plugin.json + README.md for v0.3.0 (PR #383)
+- [x] T490: Fix no-nested-claude false positive on chained git commands — `cd && git commit` with "claude" in heredoc was blocked (PR #384)
+
+**Session 14:**
+- [x] T491: TOOLS tag optimization batch 2 — add TOOLS tags to 6 untagged PreToolUse modules (spec-gate, gsd-plan-gate, env-var-check, no-nested-claude, publish-json-guard, pr-first-gate) — 56/61 PreToolUse modules now tagged
 
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006

--- a/modules/PreToolUse/env-var-check.js
+++ b/modules/PreToolUse/env-var-check.js
@@ -1,3 +1,4 @@
+// TOOLS: Bash, Edit, Write
 // WORKFLOW: shtd, gsd
 // WHY: Missing env vars caused silent failures deep in workflows.
 "use strict";

--- a/modules/PreToolUse/gsd-plan-gate.js
+++ b/modules/PreToolUse/gsd-plan-gate.js
@@ -1,3 +1,4 @@
+// TOOLS: Bash, Edit, Write
 // WORKFLOW: gsd
 // WHY: Claude dived into coding without a GSD plan, producing untracked work
 // that couldn't be reviewed via PRs or traced to any roadmap phase.

--- a/modules/PreToolUse/no-nested-claude.js
+++ b/modules/PreToolUse/no-nested-claude.js
@@ -1,3 +1,4 @@
+// TOOLS: Bash
 // WORKFLOW: shtd, starter
 // WHY: Nested `claude -p` calls inside a session don't work reliably.
 // Cross-project work must use context_reset.py which opens a proper new terminal session.

--- a/modules/PreToolUse/pr-first-gate.js
+++ b/modules/PreToolUse/pr-first-gate.js
@@ -1,3 +1,4 @@
+// TOOLS: Bash, Edit, Write
 // WORKFLOW: shtd, gsd
 // WHY: Claude created specs and wrote code on branches without opening a PR first.
 // The dev team monitors progress via GitHub Mobile notifications — without a PR,

--- a/modules/PreToolUse/publish-json-guard.js
+++ b/modules/PreToolUse/publish-json-guard.js
@@ -1,3 +1,4 @@
+// TOOLS: Bash, Edit, Write
 // WORKFLOW: shtd, starter
 // WHY: ep-incident-response (private customer data) was published to grobomo (public).
 // Root cause: nothing prevented Claude from editing publish.json or git remotes,

--- a/modules/PreToolUse/spec-gate.js
+++ b/modules/PreToolUse/spec-gate.js
@@ -1,3 +1,4 @@
+// TOOLS: Bash, Edit, Write
 // WORKFLOW: shtd
 // WHY: Claude implemented features that nobody asked for, wasting hours.
 // T321: Strengthened — if branch has TXXX, that specific task must be unchecked.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.35.0",
+  "version": "2.36.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Add `// TOOLS:` tags to 6 untagged PreToolUse modules so they skip loading on non-matching tool calls
- Biggest win: `spec-gate` (12ms avg) and `gsd-plan-gate` (8ms avg) no longer load on Read/Grep/Glob calls
- 56 of 61 PreToolUse modules now have TOOLS tags (remaining 5 intentionally check all tools)

## Modules tagged
| Module | Tag | Avg savings |
|--------|-----|-------------|
| spec-gate | Bash, Edit, Write | 12ms |
| gsd-plan-gate | Bash, Edit, Write | 8ms |
| env-var-check | Bash, Edit, Write | — |
| no-nested-claude | Bash | — |
| publish-json-guard | Bash, Edit, Write | — |
| pr-first-gate | Bash, Edit, Write | — |

## Test plan
- [x] All spec-gate tests pass (58 tests across 5 suites)
- [x] gsd-plan-gate tests pass (12 tests)
- [x] publish-json-guard tests pass (18 tests)
- [x] pr-first-gate tests pass (7 tests)
- [x] Full suite: 692 passed, 0 new failures