### PR TITLE
T495: Add missing setup.js commands to spec-gate allowlist

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1294,6 +1294,9 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T493: Convert test-modules.sh to JS — eliminates ~218 node spawns, fixes 60s timeout (436 tests, <5s)
 - [x] T494: --audit-project command — per-project hook audit from hook-log.jsonl (fired modules, blocks, coverage gaps, timing)
 
+**Session 15:**
+- [x] T495: spec-gate allowlist — add --audit-project, --manifest, --analyze, --workflow to read-only Bash command allowlist (was blocking operational commands on main)
+
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006
 - [ ] Port remaining OpenClaw modules (configurable/niche: aws-tagging, deploy-gate, messaging-safety, etc.)

--- a/modules/PreToolUse/spec-gate.js
+++ b/modules/PreToolUse/spec-gate.js
@@ -216,7 +216,7 @@ var BASH_ALLOW_PATTERNS = [
   /^\s*bash\s+scripts\/test\//, // running existing test scripts
   /^\s*node\s+scripts\/test\//, // running JS test scripts
   /^\s*node\s+setup\.js\s+--test/, // hook-runner tests
-  /^\s*node\s+setup\.js\s+--(perf|stats|health|list|version|help|report|export|snapshot|xref|sync|upgrade)/, // T477+T486+T488: hook-runner operational commands
+  /^\s*node\s+setup\.js\s+--(perf|stats|health|list|version|help|report|export|snapshot|xref|sync|upgrade|audit-project|manifest|analyze|workflow)/, // T477+T486+T488+T495: hook-runner operational commands
   /python\s+.*new.session\.py/, // T384: session management (launch new Claude tab)
   /python\s+.*context.reset\.py/, // T384: session management (backward-compat alias)
   /^\s*curl\s/, // HTTP requests (read-only, no local state change)

--- a/scripts/test/test-T338-spec-gate-bash.sh
+++ b/scripts/test/test-T338-spec-gate-bash.sh
@@ -232,6 +232,43 @@ else
   fail "node setup.js --upgrade should be allowed: $OUTPUT"
 fi
 
+# --- T495: audit-project, manifest, analyze, workflow commands always allowed ---
+
+OUTPUT=$(run_bash_gate "$PROJ" "node setup.js --audit-project dd-lab")
+if [ "$OUTPUT" = "PASSED" ]; then
+  pass "node setup.js --audit-project allowed (read-only)"
+else
+  fail "node setup.js --audit-project should be allowed: $OUTPUT"
+fi
+
+OUTPUT=$(run_bash_gate "$PROJ" "node setup.js --manifest")
+if [ "$OUTPUT" = "PASSED" ]; then
+  pass "node setup.js --manifest allowed (read-only)"
+else
+  fail "node setup.js --manifest should be allowed: $OUTPUT"
+fi
+
+OUTPUT=$(run_bash_gate "$PROJ" "node setup.js --analyze")
+if [ "$OUTPUT" = "PASSED" ]; then
+  pass "node setup.js --analyze allowed (read-only)"
+else
+  fail "node setup.js --analyze should be allowed: $OUTPUT"
+fi
+
+OUTPUT=$(run_bash_gate "$PROJ" "node setup.js --workflow list")
+if [ "$OUTPUT" = "PASSED" ]; then
+  pass "node setup.js --workflow allowed (operational)"
+else
+  fail "node setup.js --workflow should be allowed: $OUTPUT"
+fi
+
+OUTPUT=$(run_bash_gate "$PROJ" "cd /some/project && node setup.js --audit-project myproj")
+if [ "$OUTPUT" = "PASSED" ]; then
+  pass "cd + audit-project allowed (read-only after cd)"
+else
+  fail "cd + audit-project should be allowed: $OUTPUT"
+fi
+
 # --- Piped commands check the first command ---
 
 OUTPUT=$(run_bash_gate "$PROJ" "jq '.name' package.json | head -1")


### PR DESCRIPTION
## Summary
- Adds `--audit-project`, `--manifest`, `--analyze`, `--workflow` to spec-gate's Bash allowlist
- These read-only/operational `setup.js` commands were blocked on main branch because they weren't in `BASH_ALLOW_PATTERNS`
- Root cause: T494 added `--audit-project` but didn't update spec-gate's allowlist

## Test plan
- [x] 5 new test cases in test-T338 (30 total, all pass)
- [x] All 5 spec-gate test suites pass (57 total tests)
- [x] Synced to live hooks