### PR TITLE
T496: Fix preserve-iterated-content cache — 663ms to 4ms

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1295,7 +1295,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T494: --audit-project command — per-project hook audit from hook-log.jsonl (fired modules, blocks, coverage gaps, timing)
 
 **Session 15:**
-- [x] T495: spec-gate allowlist — add --audit-project, --manifest, --analyze, --workflow to read-only Bash command allowlist (was blocking operational commands on main)
+- [x] T495: spec-gate allowlist — add --audit-project, --manifest, --analyze, --workflow to read-only Bash command allowlist (PR #389)
+- [x] T496: preserve-iterated-content perf — switch cache from headSha:path to path-only with 5min TTL (663ms→4ms cache hit)
 
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006

--- a/modules/PreToolUse/preserve-iterated-content.js
+++ b/modules/PreToolUse/preserve-iterated-content.js
@@ -6,7 +6,9 @@
 // full-file rewrites (Write tool) on files with significant git history
 // and suggests using Edit instead.
 // T478: Added file-based cache — git rev-list was 882ms avg on Windows.
-// Cache keyed by repo HEAD + file path, persists across hook invocations.
+// T496: Switched cache key from headSha:path to path-only with 5min TTL.
+// headSha-based keys invalidated on every commit, causing constant cache misses
+// (663ms avg, 1556ms spikes). Commit counts change rarely — TTL is sufficient.
 "use strict";
 var cp = require("child_process");
 var path = require("path");
@@ -16,10 +18,11 @@ var os = require("os");
 // Commit count threshold — files with this many+ commits are "iterated"
 var ITERATION_THRESHOLD = 5;
 
-// T478: File-based cache to avoid repeated git rev-list calls (~800ms each on Windows).
-// Cache file persists across hook invocations within the same session.
+// T496: File-based cache keyed by normalized file path with per-entry TTL.
+// Avoids git rev-list spawns (~800ms each on Windows). Persists across invocations.
 var CACHE_FILE = path.join(os.tmpdir(), "hook-runner-iterated-cache.json");
-var CACHE_MAX_AGE = 3600000; // 1 hour
+var CACHE_MAX_AGE = 3600000; // 1 hour — evict entire cache file
+var ENTRY_TTL = 300000;      // 5 minutes — per-entry staleness
 
 function loadCache() {
   try {
@@ -31,48 +34,6 @@ function loadCache() {
 
 function saveCache(cache) {
   try { fs.writeFileSync(CACHE_FILE, JSON.stringify(cache)); } catch (e) { /* best effort */ }
-}
-
-function getHeadSha(dir) {
-  try {
-    var dotGit = path.join(dir, ".git");
-    var headPath;
-    var stat = fs.statSync(dotGit);
-    if (stat.isFile()) {
-      var gitdir = fs.readFileSync(dotGit, "utf-8").trim().replace(/^gitdir:\s*/, "");
-      if (!path.isAbsolute(gitdir)) gitdir = path.join(dir, gitdir);
-      headPath = path.join(gitdir, "HEAD");
-    } else {
-      headPath = path.join(dotGit, "HEAD");
-    }
-    var head = fs.readFileSync(headPath, "utf-8").trim();
-    if (head.indexOf("ref: ") === 0) {
-      // Try loose ref first, then commondir (worktrees store refs in main repo)
-      var gitBase = path.dirname(headPath);
-      var refPath = path.join(gitBase, head.slice(5));
-      try { return fs.readFileSync(refPath, "utf-8").trim().slice(0, 12); } catch (e) {}
-      // Worktree: follow commondir to main repo's refs
-      try {
-        var commondir = fs.readFileSync(path.join(gitBase, "commondir"), "utf-8").trim();
-        if (!path.isAbsolute(commondir)) commondir = path.join(gitBase, commondir);
-        refPath = path.join(commondir, head.slice(5));
-        return fs.readFileSync(refPath, "utf-8").trim().slice(0, 12);
-      } catch (e) {}
-      return "";
-    }
-    return head.slice(0, 12);
-  } catch (e) { return ""; }
-}
-
-function findGitRoot(startDir) {
-  var dir = startDir;
-  for (var d = 0; d < 20; d++) {
-    if (fs.existsSync(path.join(dir, ".git"))) return dir;
-    var parent = path.dirname(dir);
-    if (parent === dir) break;
-    dir = parent;
-  }
-  return "";
 }
 
 module.exports = function(input) {
@@ -90,29 +51,26 @@ module.exports = function(input) {
   }
   if (!isWatched) return null;
 
-  // T478: Check cache before spawning git
+  // T496: Check cache by normalized path with TTL (no headSha dependency)
   var dir = path.dirname(filePath);
-  var gitRoot = findGitRoot(dir);
-  var headSha = gitRoot ? getHeadSha(gitRoot) : "";
-  var cacheKey = headSha + ":" + norm;
+  var now = Date.now();
+  var cache = loadCache();
+  var cached = cache[norm];
 
-  if (headSha) {
-    var cache = loadCache();
-    if (cache[cacheKey] !== undefined) {
-      var commitCount = cache[cacheKey];
-      if (commitCount < ITERATION_THRESHOLD) return null;
-      return {
-        decision: "block",
-        reason: "CAUTION: Write (full rewrite) on a file with " + commitCount +
-          " commits of history. This file has been iterated — a rewrite may " +
-          "discard carefully refined content. Use Edit for surgical changes instead. " +
-          "If a full rewrite is truly needed, the user must explicitly approve it. " +
-          "File: " + path.basename(filePath)
-      };
-    }
+  if (cached && (now - cached.ts) < ENTRY_TTL) {
+    // Cache hit — use stored count (no git spawn needed)
+    if (cached.count < ITERATION_THRESHOLD) return null;
+    return {
+      decision: "block",
+      reason: "CAUTION: Write (full rewrite) on a file with " + cached.count +
+        " commits of history. This file has been iterated — a rewrite may " +
+        "discard carefully refined content. Use Edit for surgical changes instead. " +
+        "If a full rewrite is truly needed, the user must explicitly approve it. " +
+        "File: " + path.basename(filePath)
+    };
   }
 
-  // Cache miss — run git rev-list
+  // Cache miss or stale — run git rev-list
   try {
     var countStr = cp.execFileSync("git", ["rev-list", "--count", "HEAD", "--", path.basename(filePath)],
       { cwd: dir, encoding: "utf-8", timeout: 1500, stdio: ["pipe", "pipe", "pipe"], windowsHide: true }
@@ -120,12 +78,9 @@ module.exports = function(input) {
 
     var commitCount = parseInt(countStr, 10) || 0;
 
-    // Save to cache
-    if (headSha) {
-      var cache = loadCache();
-      cache[cacheKey] = commitCount;
-      saveCache(cache);
-    }
+    // Save to cache with timestamp
+    cache[norm] = { count: commitCount, ts: now };
+    saveCache(cache);
 
     if (commitCount >= ITERATION_THRESHOLD) {
       return {


### PR DESCRIPTION
## Summary
- Cache was keyed by `headSha:filePath` — every commit invalidated all entries, causing constant git rev-list spawns (~800ms each on Windows)
- Switched to path-only keys with 5-minute per-entry TTL
- Cache hit drops from 663ms avg (1556ms spikes) to 4ms
- Removed unused `getHeadSha` and `findGitRoot` functions (29 additions, 73 deletions)

## Test plan
- [x] Module loads and blocks files with 5+ commits
- [x] Cache hit confirmed at 4ms (vs 663ms before)
- [x] Non-Write, non-watched, and no-git paths all pass through
- [x] 436/436 module tests pass
- [x] Synced to live hooks