### PR TITLE
T498: Version bump to v2.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.37.0] — 2026-04-18
+
+### Added
+- **`--audit-project` CLI** (T494) — Per-project hook audit from hook-log.jsonl. Shows fired modules, blocks with samples, coverage gaps, timing analysis with spike detection, and a verdict. Usage: `node setup.js --audit-project <name>`
+
+### Fixed
+- **spec-gate allowlist** (T495) — Added `--audit-project`, `--manifest`, `--analyze`, `--workflow` to Bash allowlist. These read-only/operational commands were blocked on main branch.
+- **preserve-iterated-content cache** (T496) — Cache was keyed by `headSha:filePath`, invalidating all entries on every commit. Switched to path-only keys with 5-minute TTL. Cache hit: 663ms → 4ms. Removed unused `getHeadSha`/`findGitRoot` functions.
+- **commit-counter-gate metadata dirs** (T497) — Metadata directories (`.claude`, `.coconut`, `.github`, `.planning`, `.vscode`, `specs`, `node_modules`) excluded from branch-file mismatch detection. Prevents false "WRONG BRANCH" blocks in worktrees.
+- **2 pre-existing test failures** (T492) — T112 why-gate WORKFLOW tag check, T094 module-docs missing 3 T486 modules in README.
+- **no-nested-claude false positive** (T490) — Chained `cd && git commit` with "claude" in heredoc was blocked.
+
+### Improved
+- **test-modules.sh → JS** (T493) — Converted shell-based module tests to pure JS. Eliminates ~218 node process spawns, fixes 60s timeout. 436 tests in <5s (was 45s+).
+
 ## [2.36.0] — 2026-04-18
 
 ### Improved

--- a/TODO.md
+++ b/TODO.md
@@ -1298,6 +1298,7 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T495: spec-gate allowlist — add --audit-project, --manifest, --analyze, --workflow to read-only Bash command allowlist (PR #389)
 - [x] T496: preserve-iterated-content perf — switch cache from headSha:path to path-only with 5min TTL (663ms→4ms cache hit)
 - [x] T497: commit-counter-gate false positive — metadata dirs (.claude, .coconut, etc.) excluded from branch-file mismatch detection
+- [x] T498: Version bump to v2.37.0 — CHANGELOG for T490-T497 (1 feature, 5 fixes, 1 improvement)
 
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.36.0",
+  "version": "2.37.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Version bump from v2.36.0 to v2.37.0
- CHANGELOG covers T490-T497: 1 new feature, 5 bug fixes, 1 improvement

## Changes since v2.36.0
- **T494**: `--audit-project` CLI for per-project hook monitoring
- **T495**: spec-gate allowlist for read-only CLI commands
- **T496**: preserve-iterated-content cache fix (663ms→4ms)
- **T497**: commit-counter-gate metadata dir false positive fix
- **T493**: test-modules.sh→JS conversion (436 tests, <5s)
- **T492**: Fix 2 pre-existing test failures
- **T490**: Fix no-nested-claude false positive on chained git commands