### PR TITLE
T499: SessionStart perf — 670ms faster via process.kill(0) and accessSync

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1300,6 +1300,9 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T497: commit-counter-gate false positive — metadata dirs (.claude, .coconut, etc.) excluded from branch-file mismatch detection
 - [x] T498: Version bump to v2.37.0 — CHANGELOG for T490-T497 (1 feature, 5 fixes, 1 improvement)
 
+**Session 16:**
+- [x] T499: SessionStart perf — replace tasklist with process.kill(0) in _is-pid-running (374ms→14ms), replace require() with accessSync in project-health (358ms→45ms). Net ~670ms saved per session.
+
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006
 - [ ] Port remaining OpenClaw modules (configurable/niche: aws-tagging, deploy-gate, messaging-safety, etc.)

--- a/modules/SessionStart/_is-pid-running.js
+++ b/modules/SessionStart/_is-pid-running.js
@@ -1,25 +1,17 @@
 // Shared helper: check if a process ID is still running
 // Used by session-cleanup.js and session-collision-detector.js
+// T499: Replaced Windows tasklist (~200ms/call) with process.kill(pid, 0) (<1ms).
+// Signal 0 doesn't kill — just checks existence. EPERM = exists but no permission.
 "use strict";
-var cp = require("child_process");
 
 module.exports = function isPidRunning(pid) {
   pid = Number(pid);
   if (isNaN(pid) || pid <= 0 || pid !== Math.floor(pid)) return false;
   try {
-    if (process.platform === "win32") {
-      var out = cp.execFileSync("tasklist", ["/FI", "PID eq " + pid, "/NH"], {
-        encoding: "utf-8",
-        timeout: 3000,
-        stdio: ["pipe", "pipe", "pipe"],
-        windowsHide: true
-      });
-      return out.indexOf("" + pid) !== -1;
-    } else {
-      process.kill(pid, 0);
-      return true;
-    }
+    process.kill(pid, 0);
+    return true;
   } catch (e) {
-    return false;
+    // EPERM = process exists but we lack permission (e.g. system process) — still running
+    return e.code === "EPERM";
   }
 };

--- a/modules/SessionStart/project-health.js
+++ b/modules/SessionStart/project-health.js
@@ -28,12 +28,18 @@ module.exports = function(input) {
     warnings.push("Missing runners: " + missingRunners.join(", ") + ". Run `node setup.js` to reinstall.");
   }
 
-  // 2. Check module directories exist and modules load
+  // 2. Check module directories exist and modules are readable
+  // T499: replaced require() with fs.accessSync() — loading 60+ modules cost ~350ms.
+  // Syntax/dep errors surface when modules actually run and get logged by the runner.
   var events = ["PreToolUse", "PostToolUse", "Stop", "SessionStart", "UserPromptSubmit"];
-  var loadErrors = [];
+  var missingDirs = [];
+  var unreadable = [];
   for (var ei = 0; ei < events.length; ei++) {
     var modDir = path.join(hooksDir, "run-modules", events[ei]);
-    if (!fs.existsSync(modDir)) continue;
+    if (!fs.existsSync(modDir)) {
+      missingDirs.push(events[ei]);
+      continue;
+    }
     var files;
     try { files = fs.readdirSync(modDir); } catch(e) { continue; }
     for (var fi = 0; fi < files.length; fi++) {
@@ -41,30 +47,31 @@ module.exports = function(input) {
       var stat;
       try { stat = fs.statSync(fPath); } catch(e) { continue; }
       if (stat.isDirectory()) {
-        // skip archive directories — contain superseded modules with stale deps
         if (files[fi] === "archive") continue;
-        // project-scoped modules
         var subFiles;
         try { subFiles = fs.readdirSync(fPath); } catch(e) { continue; }
         for (var si = 0; si < subFiles.length; si++) {
           if (subFiles[si].indexOf(".js", subFiles[si].length - 3) === -1) continue;
           try {
-            require(path.join(fPath, subFiles[si]));
+            fs.accessSync(path.join(fPath, subFiles[si]), fs.constants.R_OK);
           } catch(e) {
-            loadErrors.push(events[ei] + "/" + files[fi] + "/" + subFiles[si] + ": " + e.message);
+            unreadable.push(events[ei] + "/" + files[fi] + "/" + subFiles[si]);
           }
         }
       } else if (files[fi].indexOf(".js", files[fi].length - 3) !== -1) {
         try {
-          require(fPath);
+          fs.accessSync(fPath, fs.constants.R_OK);
         } catch(e) {
-          loadErrors.push(events[ei] + "/" + files[fi] + ": " + e.message);
+          unreadable.push(events[ei] + "/" + files[fi]);
         }
       }
     }
   }
-  if (loadErrors.length > 0) {
-    warnings.push("Module load errors:\n  " + loadErrors.join("\n  "));
+  if (missingDirs.length > 0) {
+    warnings.push("Missing module dirs: " + missingDirs.join(", ") + ". Run `node setup.js --sync`.");
+  }
+  if (unreadable.length > 0) {
+    warnings.push("Unreadable modules:\n  " + unreadable.join("\n  "));
   }
 
   // 3. Check settings.json has hooks


### PR DESCRIPTION
## Summary
- **_is-pid-running**: Replace Windows `tasklist` (~200ms/call) with `process.kill(pid, 0)` (<1ms). Signal 0 checks existence without killing. EPERM = exists but no permission.
- **project-health**: Replace `require()` module validation with `fs.accessSync()`. Loading 60+ modules cost ~350ms at startup. Syntax errors surface when modules actually run.

## Results
| Module | Before (avg) | After | Speedup |
|--------|-------------|-------|---------|
| session-cleanup | 374ms | 14ms | 96% |
| project-health | 358ms | 45ms | 87% |

## Test plan
- [x] 8/8 session-collision tests pass
- [x] 436/436 module tests pass
- [x] Benchmarked on Windows 11