### PR TITLE
T501: Version bump to v2.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.38.0] — 2026-04-18
+
+### Added
+- **`--audit-project --json`** (T500) — Machine-readable JSON output for `--audit-project`. Includes events, blocks with samples, coverage gaps, timing, and summary. Enables programmatic consumption by scripts and dashboards.
+
+### Improved
+- **SessionStart perf** (T499) — Replaced Windows `tasklist` (~200ms/call) with `process.kill(pid, 0)` (<1ms) in `_is-pid-running`. Replaced `require()` module validation with `fs.accessSync()` in `project-health`. Net: session-cleanup 374ms→14ms, project-health 358ms→45ms (~670ms saved per session start).
+
 ## [2.37.0] — 2026-04-18
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -1302,7 +1302,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 
 **Session 16:**
 - [x] T499: SessionStart perf — replace tasklist with process.kill(0) in _is-pid-running (374ms→14ms), replace require() with accessSync in project-health (358ms→45ms). Net ~670ms saved per session (PR #393)
-- [x] T500: --audit-project --json — machine-readable JSON output for programmatic consumption
+- [x] T500: --audit-project --json — machine-readable JSON output for programmatic consumption (PR #394)
+- [x] T501: Version bump to v2.38.0 — CHANGELOG for T499-T500
 
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.37.0",
+  "version": "2.38.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Version bump to v2.38.0
- CHANGELOG covers T499 (SessionStart perf) and T500 (--audit-project --json)