### PR TITLE
T503: Version bump to v2.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.39.0] — 2026-04-18
+
+### Added
+- **OpenClaw plugin — auto-continue + session-start-reminder** (T502) — Ported two modules to the OpenClaw plugin: `auto-continue` injects a stop message forcing Claude to continue working instead of stopping, `session-start-reminder` injects session instructions at plugin startup. Includes `stop-message.txt` for customizable stop prompt.
+
 ## [2.38.0] — 2026-04-18
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -1303,8 +1303,11 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 **Session 16:**
 - [x] T499: SessionStart perf — replace tasklist with process.kill(0) in _is-pid-running (374ms→14ms), replace require() with accessSync in project-health (358ms→45ms). Net ~670ms saved per session (PR #393)
 - [x] T500: --audit-project --json — machine-readable JSON output for programmatic consumption (PR #394)
-- [x] T501: Version bump to v2.38.0 — CHANGELOG for T499-T500
-- [ ] T502: OpenClaw plugin — port auto-continue and session-start-reminder (prior session work)
+- [x] T501: Version bump to v2.38.0 — CHANGELOG for T499-T500 (PR #395)
+- [x] T502: OpenClaw plugin — port auto-continue and session-start-reminder (PR #396)
+
+**Session 17:**
+- [ ] T503: Version bump to v2.39.0 — CHANGELOG for T502
 
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.38.0",
+  "version": "2.39.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Bump version to v2.39.0
- CHANGELOG entry for T502 (OpenClaw plugin — auto-continue + session-start-reminder port)
- Fix T501/T502 PR references in TODO.md