### PR TITLE
T504: Alias modules for stale sync entries

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1307,7 +1307,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T502: OpenClaw plugin — port auto-continue and session-start-reminder (PR #396)
 
 **Session 17:**
-- [ ] T503: Version bump to v2.39.0 — CHANGELOG for T502
+- [x] T503: Version bump to v2.39.0 — CHANGELOG for T502 (PR #397)
+- [ ] T504: Remove stale module aliases — gsd-gate and e2e-self-report-gate renamed to test-checkpoint-gate
 
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006

--- a/modules/PreToolUse/e2e-self-report-gate.js
+++ b/modules/PreToolUse/e2e-self-report-gate.js
@@ -1,0 +1,8 @@
+// TOOLS: Bash
+// WORKFLOW: shtd, gsd
+// WHY: Renamed to test-checkpoint-gate (T504). Alias kept for modules.yaml backwards compat.
+"use strict";
+// Alias: delegates to test-checkpoint-gate.js
+var path = require("path");
+var real = require(path.join(__dirname, "test-checkpoint-gate.js"));
+module.exports = function(input) { return real(input); };

--- a/modules/PreToolUse/gsd-gate.js
+++ b/modules/PreToolUse/gsd-gate.js
@@ -1,0 +1,8 @@
+// TOOLS: Edit, Write
+// WORKFLOW: shtd, gsd
+// WHY: Renamed to test-checkpoint-gate (T504). Alias kept for modules.yaml backwards compat.
+"use strict";
+// Alias: delegates to test-checkpoint-gate.js
+var path = require("path");
+var real = require(path.join(__dirname, "test-checkpoint-gate.js"));
+module.exports = function(input) { return real(input); };


### PR DESCRIPTION
## Summary
- `gsd-gate.js` and `e2e-self-report-gate.js` were renamed to `test-checkpoint-gate.js` but still referenced in `modules.yaml`
- Creates thin alias modules that delegate to `test-checkpoint-gate.js`
- Fixes 2 x 404 errors during `--sync`