### PR TITLE
T505: Add alias modules to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,10 +348,12 @@ Full catalog in `modules/` directory:
 | `deploy-gate` | Blocks deploy commands when git tree is dirty |
 | `deploy-history-reminder` | Shows last 5 commits before deploy — prevents repeating failed approaches |
 | `disk-space-guard` | Blocks destructive commands after disk space errors |
+| `e2e-self-report-gate` | Alias → `test-checkpoint-gate` (legacy name) |
 | `enforcement-gate` | Requires git repo + TODO.md before edits |
 | `env-var-check` | Blocks edits if required env vars missing |
 | `force-push-gate` | Blocks git push --force to main/master |
 | `gh-auto-gate` | Forces gh_auto wrapper for all gh/git push commands (EMU account safety) |
+| `gsd-gate` | Alias → `test-checkpoint-gate` (legacy name) |
 | `gsd-branch-gate` | Enforces GSD branch naming (seq-phase-N-slug) for new branches |
 | `gsd-plan-gate` | Blocks code edits without a phase plan in GSD workflow |
 | `gsd-pr-gate` | Validates PR creation follows GSD conventions |

--- a/TODO.md
+++ b/TODO.md
@@ -1308,7 +1308,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 
 **Session 17:**
 - [x] T503: Version bump to v2.39.0 — CHANGELOG for T502 (PR #397)
-- [ ] T504: Remove stale module aliases — gsd-gate and e2e-self-report-gate renamed to test-checkpoint-gate
+- [x] T504: Alias modules for stale sync entries — gsd-gate and e2e-self-report-gate delegate to test-checkpoint-gate (PR #398)
+- [ ] T505: Fix README module count — update after T504 alias additions
 
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006


### PR DESCRIPTION
## Summary
- Add `gsd-gate` and `e2e-self-report-gate` alias entries to README PreToolUse table
- Fixes T094-module-docs test failure (missing modules in README)
- Both are aliases for `test-checkpoint-gate` (legacy names from modules.yaml)