### PR TITLE
T506: Version bump to v2.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.40.0] — 2026-04-18
+
+### Fixed
+- **Stale sync entries** (T504) — `gsd-gate` and `e2e-self-report-gate` were renamed to `test-checkpoint-gate` but still referenced in `modules.yaml`. Created alias modules that delegate to the real implementation. `--sync` now completes with 0 errors.
+- **README module count** (T505) — Added alias module entries to README PreToolUse table. Fixes T094-module-docs test failure.
+
 ## [2.39.0] — 2026-04-18
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -1309,7 +1309,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 **Session 17:**
 - [x] T503: Version bump to v2.39.0 — CHANGELOG for T502 (PR #397)
 - [x] T504: Alias modules for stale sync entries — gsd-gate and e2e-self-report-gate delegate to test-checkpoint-gate (PR #398)
-- [ ] T505: Fix README module count — update after T504 alias additions
+- [x] T505: Fix README module count — add alias modules to README docs (PR #399)
+- [ ] T506: Version bump to v2.40.0 — CHANGELOG for T504-T505
 
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.39.0",
+  "version": "2.40.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Bump version to v2.40.0
- CHANGELOG entries for T504 (alias modules for stale sync) and T505 (README fix)