### PR TITLE
T507: Per-file test timeout via // TIMEOUT: N comment

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1310,7 +1310,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T503: Version bump to v2.39.0 — CHANGELOG for T502 (PR #397)
 - [x] T504: Alias modules for stale sync entries — gsd-gate and e2e-self-report-gate delegate to test-checkpoint-gate (PR #398)
 - [x] T505: Fix README module count — add alias modules to README docs (PR #399)
-- [ ] T506: Version bump to v2.40.0 — CHANGELOG for T504-T505
+- [x] T506: Version bump to v2.40.0 — CHANGELOG for T504-T505 (PR #400)
+- [ ] T507: Per-file test timeout — read `// TIMEOUT: N` from test files, fixes commit-counter-gate 60s timeout
 
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006

--- a/scripts/test/test-T482-test-timeouts.js
+++ b/scripts/test/test-T482-test-timeouts.js
@@ -123,7 +123,29 @@ test("help text mentions new flags", function() {
   assert(setupSrc.indexOf("--sh-only") !== -1, "help should mention --sh-only");
 });
 
-// Test 17: verify test directory has both .js and .sh files (for filter logic to matter)
+// Test 17: per-file TIMEOUT comment support in setup.js
+test("per-file TIMEOUT comment parsing in test runner", function() {
+  assert(setupSrc.indexOf("TIMEOUT:") !== -1, "should parse TIMEOUT comment");
+  assert(setupSrc.indexOf("tmMatch") !== -1, "should store timeout match");
+});
+
+// Test 18: commit-counter-gate has TIMEOUT: 90 comment
+test("commit-counter-gate has per-file timeout override", function() {
+  var ccg = fs.readFileSync(path.join(REPO_DIR, "scripts/test/test-commit-counter-gate.js"), "utf-8").slice(0, 200);
+  var m = ccg.match(/\/\/\s*TIMEOUT:\s*(\d+)/);
+  assert(m, "should have // TIMEOUT: N comment");
+  assert(parseInt(m[1], 10) >= 90, "timeout should be at least 90s, got " + m[1]);
+});
+
+// Test 19: per-file timeout regex matches both JS and bash comments
+test("timeout regex handles JS and bash comment styles", function() {
+  var re = /(?:\/\/|#)\s*TIMEOUT:\s*(\d+)/;
+  assert(re.test("// TIMEOUT: 90"), "should match JS comment");
+  assert(re.test("# TIMEOUT: 120"), "should match bash comment");
+  assert(!re.test("var TIMEOUT = 60"), "should NOT match variable assignment");
+});
+
+// Test 20: verify test directory has both .js and .sh files (for filter logic to matter)
 test("test directory has both JS and bash tests", function() {
   var testDir = path.join(REPO_DIR, "scripts", "test");
   var files = fs.readdirSync(testDir).filter(function(f) { return f.indexOf("test-") === 0; });

--- a/scripts/test/test-commit-counter-gate.js
+++ b/scripts/test/test-commit-counter-gate.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 "use strict";
+// TIMEOUT: 90
 // Tests for commit-counter-gate.js — T466 branch-file mismatch + worktree enforcement
 var path = require("path");
 var fs = require("fs");

--- a/setup.js
+++ b/setup.js
@@ -1235,7 +1235,13 @@ function cmdTest(args) {
     var isJs = testFiles[ti].slice(-3) === ".js";
     var suiteName = testFiles[ti].replace("test-", "").replace(/\.(sh|js)$/, "");
     var suiteStart = Date.now();
+    // Per-file timeout: read "// TIMEOUT: N" or "# TIMEOUT: N" from first 5 lines
     var testTimeout = isJs ? JS_TIMEOUT : SH_TIMEOUT;
+    try {
+      var head = fs.readFileSync(testPath, "utf-8").slice(0, 500);
+      var tmMatch = head.match(/(?:\/\/|#)\s*TIMEOUT:\s*(\d+)/);
+      if (tmMatch) testTimeout = parseInt(tmMatch[1], 10) * 1000;
+    } catch(e2) {}
     console.log("");
     console.log("  [" + suiteName + "] " + testFiles[ti] + " (timeout: " + (testTimeout / 1000) + "s)");
     try {

--- a/specs/rdp-testbox-gate/tasks.md
+++ b/specs/rdp-testbox-gate/tasks.md
@@ -1,0 +1,5 @@
+# T398: rdp-testbox-gate — Tasks
+
+- [x] T398: Create spec and test suite for rdp-testbox-gate module
+
+**Checkpoint**: `bash scripts/test/test-rdp-testbox-gate.js`


### PR DESCRIPTION
## Summary
- Test runner reads `// TIMEOUT: N` or `# TIMEOUT: N` from test file headers for per-file timeout override
- Adds `// TIMEOUT: 90` to `test-commit-counter-gate.js` (creates temp git repos, needs >60s on Windows)
- 3 new tests in T482 suite verifying parsing, regex, and the specific override
- Also completes stale `specs/rdp-testbox-gate/tasks.md` spec chain