### PR TITLE
T508: Version bump to v2.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.41.0] — 2026-04-18
+
+### Added
+- **Per-file test timeout** (T507) — Test files can now declare `// TIMEOUT: N` (seconds) in their first 5 lines to override the default 60s timeout. Applied to `test-commit-counter-gate.js` (90s) which needs extra time for git repo creation on Windows.
+
 ## [2.40.0] — 2026-04-18
 
 ### Fixed

--- a/TODO.md
+++ b/TODO.md
@@ -1311,7 +1311,10 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T504: Alias modules for stale sync entries — gsd-gate and e2e-self-report-gate delegate to test-checkpoint-gate (PR #398)
 - [x] T505: Fix README module count — add alias modules to README docs (PR #399)
 - [x] T506: Version bump to v2.40.0 — CHANGELOG for T504-T505 (PR #400)
-- [ ] T507: Per-file test timeout — read `// TIMEOUT: N` from test files, fixes commit-counter-gate 60s timeout
+- [x] T507: Per-file test timeout — read `// TIMEOUT: N` from test files, fixes commit-counter-gate 60s timeout (PR #401)
+
+**Session 18:**
+- [x] T508: Version bump to v2.41.0 — CHANGELOG for T507
 
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.40.0",
+  "version": "2.41.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Version bump to v2.41.0
- CHANGELOG entry for T507 (per-file test timeout)

## Test plan
- [x] Full test suite: 82 suites, 1148 passed, 0 failed, 0 timeouts