### PR TITLE
T509: Add TOOLS tags to 11 modules for perf optimization

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1314,7 +1314,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T507: Per-file test timeout — read `// TIMEOUT: N` from test files, fixes commit-counter-gate 60s timeout (PR #401)
 
 **Session 18:**
-- [x] T508: Version bump to v2.41.0 — CHANGELOG for T507
+- [x] T508: Version bump to v2.41.0 — CHANGELOG for T507 (PR #402)
+- [x] T509: Add TOOLS tags to 11 modules — perf optimization (~5ms/module per non-matching call)
 
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006

--- a/modules/PostToolUse/commit-msg-check.js
+++ b/modules/PostToolUse/commit-msg-check.js
@@ -1,4 +1,5 @@
 // WORKFLOW: shtd, gsd
+// TOOLS: Bash
 // WHY: Sloppy commit messages made PR history unreadable.
 // Commit message check: warns if git commit messages don't follow conventions
 // PostToolUse module — runs after Bash tool completes

--- a/modules/PostToolUse/crlf-detector.js
+++ b/modules/PostToolUse/crlf-detector.js
@@ -1,4 +1,5 @@
 // WORKFLOW: shtd, starter
+// TOOLS: Write, Edit
 // WHY: On Windows, Write/Edit can produce CRLF line endings that break shell scripts,
 // YAML files, SSH keys, and other Unix-sensitive formats. The crlf-ssh-key-check
 // module only covers SSH keys — this catches CRLF in all sensitive file types.

--- a/modules/PostToolUse/empty-output-detector.js
+++ b/modules/PostToolUse/empty-output-detector.js
@@ -1,4 +1,5 @@
 // WORKFLOW: shtd, gsd
+// TOOLS: Bash
 // WHY: Claude treats empty command output as success — e.g., `ls screenshots/` returning
 // nothing means no screenshots exist, but Claude proceeds as if they do. Empty output
 // from directory listings, file checks, and query commands often means silent failure.

--- a/modules/PostToolUse/hook-autocommit.js
+++ b/modules/PostToolUse/hook-autocommit.js
@@ -1,4 +1,5 @@
 // WORKFLOW: shtd, starter
+// TOOLS: Edit, Write
 // WHY: Hook module edits were lost because they were never committed to the hook-runner repo.
 // Auto-commit hook module changes to the run-modules git repo.
 // Every Write/Edit to a hook module file gets committed automatically.

--- a/modules/PostToolUse/result-review-gate.js
+++ b/modules/PostToolUse/result-review-gate.js
@@ -1,4 +1,5 @@
 // WORKFLOW: shtd, gsd
+// TOOLS: Read
 // WHY: Claude reads test reports and PDFs, sees mostly-green results, and immediately
 // commits without enumerating every FAIL/WARN/timeout. Hours wasted in E2E cycles
 // when bugs shipped because the report "looked fine" at a glance.

--- a/modules/PostToolUse/rule-hygiene.js
+++ b/modules/PostToolUse/rule-hygiene.js
@@ -1,4 +1,5 @@
 // WORKFLOW: shtd, gsd
+// TOOLS: Edit, Write
 // WHY: Rules grew into multi-topic dump files that were hard to maintain.
 // Rule hygiene: validates rule files are granular and path-scoped
 var fs = require("fs");

--- a/modules/PostToolUse/settings-audit-log.js
+++ b/modules/PostToolUse/settings-audit-log.js
@@ -1,4 +1,5 @@
 // WORKFLOW: shtd, gsd
+// TOOLS: Bash, Edit, Write
 // WHY: Settings changes happened silently with no audit trail.
 // Audit log: records all modifications to ~/.claude/ config files.
 // Logs to ~/.claude/audit/settings-changes.jsonl with timestamp, file, tool, and diff.

--- a/modules/PostToolUse/test-coverage-check.js
+++ b/modules/PostToolUse/test-coverage-check.js
@@ -1,4 +1,5 @@
 // WORKFLOW: shtd, starter
+// TOOLS: Edit, Write
 // WHY: Source files were modified but existing tests never ran, hiding regressions.
 // PostToolUse: warn when source files are modified but tests exist that should be run
 // Triggers after Edit or Write tool completions.

--- a/modules/PostToolUse/troubleshoot-detector.js
+++ b/modules/PostToolUse/troubleshoot-detector.js
@@ -1,4 +1,5 @@
 // WORKFLOW: shtd, gsd
+// TOOLS: Bash
 // WHY: Claude tried 3 wrong ways to call claude -p before finding the right
 // pattern in an existing project. The troubleshooting cycle wasted time and
 // the lesson was almost lost. This module detects "fail-fail-succeed" patterns

--- a/modules/PostToolUse/update-stale-docs.js
+++ b/modules/PostToolUse/update-stale-docs.js
@@ -1,4 +1,5 @@
 // WORKFLOW: shtd, gsd
+// TOOLS: Edit, Write
 // WHY: Dead code references and stale docs accumulate silently. When Claude
 // edits code that removes or renames something, the docs and rules that
 // reference the old thing become misleading for future sessions.

--- a/modules/PreToolUse/branch-pr-gate.js
+++ b/modules/PreToolUse/branch-pr-gate.js
@@ -1,4 +1,5 @@
 // WORKFLOW: shtd, gsd
+// TOOLS: Bash, Edit, Write
 // WHY: Claude committed directly to main, bypassing review.
 "use strict";
 // Branch-PR gate: enforces Model C workflow.


### PR DESCRIPTION
## Summary
- Added `// TOOLS:` tags to 11 modules (1 PreToolUse, 10 PostToolUse) that were loading on every tool call
- Modules now skip loading when the current tool doesn't match their TOOLS tag (~5ms saved per skip)
- 4 modules intentionally left without TOOLS tags (cwd-drift-detector, workflow-compliance-gate, disk-space-detect, hook-health-monitor) because they need to run on all tools

### Modules updated
- `PreToolUse/branch-pr-gate` → Bash, Edit, Write
- `PostToolUse/commit-msg-check` → Bash
- `PostToolUse/crlf-detector` → Write, Edit
- `PostToolUse/empty-output-detector` → Bash
- `PostToolUse/hook-autocommit` → Edit, Write
- `PostToolUse/result-review-gate` → Read
- `PostToolUse/rule-hygiene` → Edit, Write
- `PostToolUse/settings-audit-log` → Bash, Edit, Write
- `PostToolUse/test-coverage-check` → Edit, Write
- `PostToolUse/troubleshoot-detector` → Bash
- `PostToolUse/update-stale-docs` → Edit, Write

## Test plan
- [x] test-T371-empty-output-detector: 15/15 passed
- [x] test-T368-result-review-gate: 15/15 passed
- [x] test-modules: 444/444 passed