### PR TITLE
T510: Version bump to v2.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.42.0] — 2026-04-18
+
+### Improved
+- **TOOLS tag coverage** (T509) — Added `// TOOLS:` tags to 11 modules (1 PreToolUse, 10 PostToolUse) that were loading on every tool call. Modules now skip loading when the current tool doesn't match, saving ~5ms per skip. Only 4 modules intentionally remain untagged (they inspect all tools).
+
 ## [2.41.0] — 2026-04-18
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -1315,7 +1315,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 
 **Session 18:**
 - [x] T508: Version bump to v2.41.0 — CHANGELOG for T507 (PR #402)
-- [x] T509: Add TOOLS tags to 11 modules — perf optimization (~5ms/module per non-matching call)
+- [x] T509: Add TOOLS tags to 11 modules — perf optimization (~5ms/module per non-matching call) (PR #403)
+- [x] T510: Version bump to v2.42.0 — CHANGELOG for T509
 
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.41.0",
+  "version": "2.42.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Version bump to v2.42.0
- CHANGELOG entry for T509 (TOOLS tag perf optimization)

## Test plan
- [x] Full test suite: 82 suites, 1148 passed, 0 failed