### PR TITLE
T512: Version bump to v2.43.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.43.0] — 2026-04-18
+
+### Fixed
+- **commit-counter-gate worktree detection** (T511) — `isInWorktree()` and `getBranch()` only checked `CLAUDE_PROJECT_DIR`, which doesn't update when `EnterWorktree` switches the CWD. Now falls back to CWD when `CLAUDE_PROJECT_DIR` has no `.git`, fixing the stuck `worktreeRequired` flag.
+
 ## [2.42.0] — 2026-04-18
 
 ### Improved

--- a/TODO.md
+++ b/TODO.md
@@ -1317,7 +1317,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T508: Version bump to v2.41.0 — CHANGELOG for T507 (PR #402)
 - [x] T509: Add TOOLS tags to 11 modules — perf optimization (~5ms/module per non-matching call) (PR #403)
 - [x] T510: Version bump to v2.42.0 — CHANGELOG for T509 (PR #404)
-- [x] T511: Fix commit-counter-gate worktree detection — isInWorktree() and getBranch() now fall back to CWD when CLAUDE_PROJECT_DIR has no .git
+- [x] T511: Fix commit-counter-gate worktree detection — CWD fallback (PR #405)
+- [x] T512: Version bump to v2.43.0 — CHANGELOG for T511
 
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.42.0",
+  "version": "2.43.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Version bump to v2.43.0
- CHANGELOG entry for T511 (commit-counter-gate worktree detection fix)

## Test plan
- [x] test-commit-counter-gate: 19/19 passed