### PR TITLE
T513: Fix stale README workflow module counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ The setup wizard will:
 1. Scan your current hooks and generate a styled HTML report
 2. Back up existing hooks to `~/.claude/hooks/archive/`
 3. Install the runner system
-4. Enable the `starter` workflow (with `--yes`) — 11 universally useful modules
+4. Enable the `starter` workflow (with `--yes`) — 40 universally useful modules
 
 Ready for more? Enable the full development pipeline:
 ```bash
-node setup.js --workflow enable shtd    # 90 modules: spec-first, test-first, PR discipline
+node setup.js --workflow enable shtd    # 95 modules: spec-first, test-first, PR discipline
 ```
 
 To undo everything: `node setup.js --uninstall --confirm`
@@ -84,7 +84,7 @@ Claude reads the block message and adjusts its approach — no user intervention
 
 ## Workflows
 
-Workflows are the primary abstraction. Instead of managing 80+ individual modules, you enable a workflow and its modules activate automatically.
+Workflows are the primary abstraction. Instead of managing 115+ individual modules, you enable a workflow and its modules activate automatically.
 
 ```bash
 node setup.js --workflow list              # see available workflows
@@ -98,8 +98,8 @@ node setup.js --workflow query Edit        # which workflows affect Edit?
 
 | Workflow | Modules | What it enforces |
 |----------|---------|-----------------|
-| `starter` | 11 | **Start here.** Safe defaults for any user — blocks force-push, destructive git, secret commits, file deletion. Adds commit quality checks, test reminders, and session context. |
-| `shtd` | 90 | Spec-Hook-Test-Driven — the full development pipeline. Enforces spec → branch → test → implement → PR, plus code quality, infrastructure safety, messaging guards, session lifecycle, and self-improvement. |
+| `starter` | 40 | **Start here.** Safe defaults for any user — blocks force-push, destructive git, secret commits, file deletion. Adds commit quality checks, test reminders, and session context. |
+| `shtd` | 95 | Spec-Hook-Test-Driven — the full development pipeline. Enforces spec → branch → test → implement → PR, plus code quality, infrastructure safety, messaging guards, session lifecycle, and self-improvement. |
 | `customer-data-guard` | 3 | Read-only incident response — blocks env changes, data exfil, and V1 modifications. |
 | `dispatcher-worker` | 3 | Role-aware fleet workflow. Dispatcher specs/distributes, workers implement/test/PR. |
 | `no-local-docker` | 1 | Blocks local Docker commands, forces remote infrastructure. |

--- a/TODO.md
+++ b/TODO.md
@@ -1320,6 +1320,9 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T511: Fix commit-counter-gate worktree detection — CWD fallback (PR #405)
 - [x] T512: Version bump to v2.43.0 — CHANGELOG for T511
 
+**Session 19:**
+- [x] T513: Fix stale README workflow module counts — starter 11→40, shtd 90→95, total 80+→115+
+
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006
 - [ ] Port remaining OpenClaw modules (configurable/niche: aws-tagging, deploy-gate, messaging-safety, etc.)


### PR DESCRIPTION
## Summary
- Updated README workflow module counts to match actual YAML definitions
- starter: 11→40, shtd: 90→95, total reference: 80+→115+

## Test plan
- [x] Verified counts against `workflows/*.yml` files
- [x] Full test suite: 82 suites, 1148 passed, 0 failed