### PR TITLE
T514: Version bump to v2.44.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.44.0] — 2026-04-18
+
+### Fixed
+- **README module counts** (T513) — Updated stale workflow module counts: starter 11→40, shtd 90→95, total 80+→115+.
+
 ## [2.43.0] — 2026-04-18
 
 ### Fixed

--- a/TODO.md
+++ b/TODO.md
@@ -1321,7 +1321,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T512: Version bump to v2.43.0 — CHANGELOG for T511
 
 **Session 19:**
-- [x] T513: Fix stale README workflow module counts — starter 11→40, shtd 90→95, total 80+→115+
+- [x] T513: Fix stale README workflow module counts — starter 11→40, shtd 90→95, total 80+→115+ (PR #407)
+- [x] T514: Version bump to v2.44.0 — CHANGELOG for T513
 
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.43.0",
+  "version": "2.44.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Version bump to v2.44.0 with CHANGELOG for T513 (README module count fix)

## Test plan
- [x] No code changes, docs-only version bump