### PR TITLE
T515: Sync workflow YAML module lists with actual tags

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1322,7 +1322,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 
 **Session 19:**
 - [x] T513: Fix stale README workflow module counts — starter 11→40, shtd 90→95, total 80+→115+ (PR #407)
-- [x] T514: Version bump to v2.44.0 — CHANGELOG for T513
+- [x] T514: Version bump to v2.44.0 — CHANGELOG for T513 (PR #408)
+- [x] T515: Sync workflow YAML ↔ module tags — 5 modules added to YAMLs, 2 tags fixed
 
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006

--- a/modules/Stop/auto-continue.js
+++ b/modules/Stop/auto-continue.js
@@ -1,4 +1,4 @@
-// WORKFLOW: starter
+// WORKFLOW: shtd, gsd, starter
 // WHY: Claude stops and lists options instead of doing the work.
 // The message text in stop-message.txt was iterated over 15+ versions by the user.
 // DO NOT rewrite, condense, or rephrase it. It is a user-authored artifact.

--- a/modules/Stop/never-give-up.js
+++ b/modules/Stop/never-give-up.js
@@ -1,4 +1,4 @@
-// WORKFLOW: starter
+// WORKFLOW: shtd, gsd, starter
 // WHY: Claude declares things "impossible" after one failed attempt.
 // Past examples: "can't screenshot VM" (solved by Azure Boot Diagnostics),
 // "can't send email" (solved by SMTP relay). Research before giving up.

--- a/workflows/gsd.yml
+++ b/workflows/gsd.yml
@@ -101,9 +101,11 @@ modules:
   - hook-autocommit
   - no-adhoc-commands
   - cross-project-todo-gate
+  - inter-project-priority-gate
   - cwd-drift-detector
   - no-focus-steal
   - settings-audit-log
+  - inter-project-audit
   - settings-change-gate
   - settings-hooks-gate
   # Messaging safety
@@ -129,6 +131,7 @@ modules:
   - lesson-effectiveness
   # Session lifecycle
   - auto-continue
+  - inter-project-priority
   - backup-check
   - chat-export
   - config-sync

--- a/workflows/shtd.yml
+++ b/workflows/shtd.yml
@@ -73,6 +73,8 @@ modules:
   - task-completion-gate
   - test-before-done
   - test-checkpoint-gate
+  - gsd-gate
+  - e2e-self-report-gate
   - unresolved-issues-check
   - why-reminder
   - workflow-gate
@@ -113,9 +115,11 @@ modules:
   - hook-autocommit
   - no-adhoc-commands
   - cross-project-todo-gate
+  - inter-project-priority-gate
   - cwd-drift-detector
   - no-focus-steal
   - settings-audit-log
+  - inter-project-audit
   - settings-change-gate
   - settings-hooks-gate
   # Messaging safety
@@ -141,6 +145,7 @@ modules:
   - lesson-effectiveness
   # Session lifecycle
   - auto-continue
+  - inter-project-priority
   - backup-check
   - chat-export
   - config-sync

--- a/workflows/starter.yml
+++ b/workflows/starter.yml
@@ -43,6 +43,9 @@ modules:
   - disk-space-detect
   - crlf-ssh-key-check
   - crlf-detector
+  # Inter-project coordination
+  - inter-project-audit
+  - inter-project-priority
   # Session lifecycle — context and continuity
   - auto-continue
   - never-give-up


### PR DESCRIPTION
## Summary
- Added 5 modules missing from workflow YAMLs (inter-project-priority-gate, inter-project-audit, inter-project-priority, gsd-gate, e2e-self-report-gate)
- Fixed 2 module tags (auto-continue, never-give-up: starter → shtd, gsd, starter)
- Workflow audit now clean: shtd 100 actual = 100 YAML, starter 42 actual = 42 YAML

## Test plan
- [x] `--workflow audit` shows OK for shtd and starter
- [x] test-T097-workflow-modules: 9/9 passed
- [x] test-T099-filter-by-config: 7/7 passed
- [x] test-T102-workflow-audit: 7/7 passed
- [x] test-modules: 444/444 passed