### PR TITLE
T516: Version bump to v2.45.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.45.0] — 2026-04-18
+
+### Fixed
+- **Workflow YAML ↔ tag sync** (T515) — Added 5 modules missing from workflow YAMLs (inter-project-priority-gate, inter-project-audit, inter-project-priority, gsd-gate, e2e-self-report-gate). Fixed auto-continue and never-give-up tags from `starter` to `shtd, gsd, starter`. Workflow audit now clean for shtd (100) and starter (42).
+
 ## [2.44.0] — 2026-04-18
 
 ### Fixed

--- a/TODO.md
+++ b/TODO.md
@@ -1323,7 +1323,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 **Session 19:**
 - [x] T513: Fix stale README workflow module counts — starter 11→40, shtd 90→95, total 80+→115+ (PR #407)
 - [x] T514: Version bump to v2.44.0 — CHANGELOG for T513 (PR #408)
-- [x] T515: Sync workflow YAML ↔ module tags — 5 modules added to YAMLs, 2 tags fixed
+- [x] T515: Sync workflow YAML ↔ module tags — 5 modules added to YAMLs, 2 tags fixed (PR #409)
+- [x] T516: Version bump to v2.45.0 — CHANGELOG for T515
 
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.44.0",
+  "version": "2.45.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Version bump to v2.45.0 with CHANGELOG for T515 (workflow YAML sync)

## Test plan
- [x] No code changes, docs-only version bump