### PR TITLE
T517: Make workflow audit extends-aware

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1324,7 +1324,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T513: Fix stale README workflow module counts — starter 11→40, shtd 90→95, total 80+→115+ (PR #407)
 - [x] T514: Version bump to v2.44.0 — CHANGELOG for T513 (PR #408)
 - [x] T515: Sync workflow YAML ↔ module tags — 5 modules added to YAMLs, 2 tags fixed (PR #409)
-- [x] T516: Version bump to v2.45.0 — CHANGELOG for T515
+- [x] T516: Version bump to v2.45.0 — CHANGELOG for T515 (PR #410)
+- [x] T517: Workflow audit extends-aware — count parent tags, add drift-check/config-sync/aliases to YAMLs
 
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006

--- a/modules/Stop/config-sync.js
+++ b/modules/Stop/config-sync.js
@@ -1,4 +1,4 @@
-// WORKFLOW: shtd
+// WORKFLOW: shtd, gsd
 // WHY: Config changes (rules, hooks, skills) made during sessions were lost
 // because ~/.claude wasn't committed/pushed. This auto-syncs to grobomo/claude-config
 // so the cloud copy stays current and new PCs can bootstrap from it.

--- a/workflow-cli.js
+++ b/workflow-cli.js
@@ -196,6 +196,36 @@ function cmdWorkflow(args) {
       }
     }
 
+    // Build extends map: child → parent (e.g. gsd → starter, shtd → starter)
+    var extendsMap = {};
+    for (var exi = 0; exi < workflows.length; exi++) {
+      if (workflows[exi].extends) extendsMap[workflows[exi].name] = workflows[exi].extends;
+    }
+
+    // Effective tag counts: include parent workflow tags for workflows with extends
+    var effectiveTagCounts = {};
+    for (var etk in tagCounts) effectiveTagCounts[etk] = tagCounts[etk];
+    // Count unique modules per workflow (including inherited from parent)
+    for (var ewi = 0; ewi < workflows.length; ewi++) {
+      var ewn = workflows[ewi].name;
+      if (!extendsMap[ewn]) continue;
+      // Collect unique module names tagged with this workflow OR any ancestor
+      var effectiveModules = {};
+      for (var eti = 0; eti < tagged.length; eti++) {
+        var etTags = tagged[eti].tags || [];
+        for (var etgi = 0; etgi < etTags.length; etgi++) {
+          if (etTags[etgi] === ewn) { effectiveModules[tagged[eti].name] = true; break; }
+          // Walk the extends chain: if this tag is an ancestor of ewn, count it
+          var cur = ewn;
+          while (extendsMap[cur]) {
+            cur = extendsMap[cur];
+            if (etTags[etgi] === cur) { effectiveModules[tagged[eti].name] = true; break; }
+          }
+        }
+      }
+      effectiveTagCounts[ewn] = Object.keys(effectiveModules).length;
+    }
+
     // Coverage summary
     console.log("=== Workflow Audit ===");
     console.log("");
@@ -208,8 +238,9 @@ function cmdWorkflow(args) {
     for (var wi = 0; wi < wfNames.length; wi++) {
       var wn = wfNames[wi];
       var yamlCount = yamlModules[wn].length;
-      var actualCount = tagCounts[wn] || 0;
-      console.log("  " + wn + ": " + actualCount + " modules — " + (yamlCount === actualCount ? "OK (matches YAML)" : actualCount + " actual vs " + yamlCount + " in YAML"));
+      var actualCount = effectiveTagCounts[wn] || 0;
+      var suffix = extendsMap[wn] ? " (includes " + extendsMap[wn] + ")" : "";
+      console.log("  " + wn + ": " + actualCount + " modules — " + (yamlCount === actualCount ? "OK (matches YAML)" + suffix : actualCount + " actual vs " + yamlCount + " in YAML" + suffix));
     }
 
     // Orphan tags: modules tagged with a workflow that has no YAML

--- a/workflow.js
+++ b/workflow.js
@@ -144,6 +144,7 @@ function loadWorkflow(yamlPath) {
       };
     }),
     modules: modules,
+    extends: parsed.extends || null,
     _path: yamlPath,
   };
 }

--- a/workflows/gsd.yml
+++ b/workflows/gsd.yml
@@ -61,6 +61,8 @@ modules:
   - task-completion-gate
   - test-before-done
   - test-checkpoint-gate
+  - gsd-gate
+  - e2e-self-report-gate
   - unresolved-issues-check
   - why-reminder
   - workflow-gate
@@ -133,6 +135,7 @@ modules:
   - auto-continue
   - inter-project-priority
   - backup-check
+  - drift-check
   - chat-export
   - config-sync
   - load-instructions

--- a/workflows/shtd.yml
+++ b/workflows/shtd.yml
@@ -147,6 +147,7 @@ modules:
   - auto-continue
   - inter-project-priority
   - backup-check
+  - drift-check
   - chat-export
   - config-sync
   - load-instructions


### PR DESCRIPTION
## Summary
- `loadWorkflow` now exposes the `extends` field from workflow YAML
- Audit counts parent workflow tags toward child workflows (gsd/shtd extend starter)
- Added 3 missing modules to YAMLs (drift-check, gsd-gate alias, e2e-self-report-gate alias)
- Fixed config-sync tag: `shtd` → `shtd, gsd`
- All 7 workflows now show OK in audit

## Test plan
- [x] `--workflow audit`: all workflows OK (shtd 101, gsd 101, starter 42)
- [x] test-T102-workflow-audit: 7/7 passed
- [x] test-T101-workflow-cli: 8/8 passed
- [x] test-T097-workflow-modules: 9/9 passed
- [x] test-T098-workflow-config: 8/8 passed