### PR TITLE
T518: Version bump to v2.46.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.46.0] — 2026-04-18
+
+### Improved
+- **Workflow audit extends-aware** (T517) — Audit now counts parent workflow tags toward child workflows (gsd/shtd extend starter). Added drift-check to shtd/gsd YAMLs, alias modules to gsd.yml, fixed config-sync tag. All 7 workflows now show OK. Updated README counts: starter 42, shtd 101.
+
 ## [2.45.0] — 2026-04-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ The setup wizard will:
 1. Scan your current hooks and generate a styled HTML report
 2. Back up existing hooks to `~/.claude/hooks/archive/`
 3. Install the runner system
-4. Enable the `starter` workflow (with `--yes`) — 40 universally useful modules
+4. Enable the `starter` workflow (with `--yes`) — 42 universally useful modules
 
 Ready for more? Enable the full development pipeline:
 ```bash
-node setup.js --workflow enable shtd    # 95 modules: spec-first, test-first, PR discipline
+node setup.js --workflow enable shtd    # 101 modules: spec-first, test-first, PR discipline
 ```
 
 To undo everything: `node setup.js --uninstall --confirm`
@@ -98,8 +98,8 @@ node setup.js --workflow query Edit        # which workflows affect Edit?
 
 | Workflow | Modules | What it enforces |
 |----------|---------|-----------------|
-| `starter` | 40 | **Start here.** Safe defaults for any user — blocks force-push, destructive git, secret commits, file deletion. Adds commit quality checks, test reminders, and session context. |
-| `shtd` | 95 | Spec-Hook-Test-Driven — the full development pipeline. Enforces spec → branch → test → implement → PR, plus code quality, infrastructure safety, messaging guards, session lifecycle, and self-improvement. |
+| `starter` | 42 | **Start here.** Safe defaults for any user — blocks force-push, destructive git, secret commits, file deletion. Adds commit quality checks, test reminders, and session context. |
+| `shtd` | 101 | Spec-Hook-Test-Driven — the full development pipeline. Enforces spec → branch → test → implement → PR, plus code quality, infrastructure safety, messaging guards, session lifecycle, and self-improvement. |
 | `customer-data-guard` | 3 | Read-only incident response — blocks env changes, data exfil, and V1 modifications. |
 | `dispatcher-worker` | 3 | Role-aware fleet workflow. Dispatcher specs/distributes, workers implement/test/PR. |
 | `no-local-docker` | 1 | Blocks local Docker commands, forces remote infrastructure. |

--- a/TODO.md
+++ b/TODO.md
@@ -1325,7 +1325,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T514: Version bump to v2.44.0 — CHANGELOG for T513 (PR #408)
 - [x] T515: Sync workflow YAML ↔ module tags — 5 modules added to YAMLs, 2 tags fixed (PR #409)
 - [x] T516: Version bump to v2.45.0 — CHANGELOG for T515 (PR #410)
-- [x] T517: Workflow audit extends-aware — count parent tags, add drift-check/config-sync/aliases to YAMLs
+- [x] T517: Workflow audit extends-aware — count parent tags, add drift-check/config-sync/aliases to YAMLs (PR #411)
+- [x] T518: Version bump to v2.46.0 — CHANGELOG for T517, README counts updated
 
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.45.0",
+  "version": "2.46.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Version bump to v2.46.0 with CHANGELOG for T517 (audit extends)
- README counts updated: starter 40→42, shtd 95→101

## Test plan
- [x] Docs-only version bump