### PR TITLE
T520: Version bump to v2.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.47.0] — 2026-04-18
+
+### Added
+- **Interactive demo command** (T519) — `node setup.js --demo` showcases hook-runner without a live Claude Code session. Simulates 6 scenarios using real modules (force push, destructive git, rm -rf, vague commits, normal ops). ANSI color output, `--fast` flag. Also runnable standalone via `node demo.js`.
+
 ## [2.46.0] — 2026-04-18
 
 ### Improved

--- a/TODO.md
+++ b/TODO.md
@@ -1329,7 +1329,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T518: Version bump to v2.46.0 — CHANGELOG for T517, README counts updated (PR #412)
 
 **Session 20:**
-- [x] T519: Add --demo CLI command — interactive showcase with real module gates, 6 scenarios, ANSI color
+- [x] T519: Add --demo CLI command — interactive showcase with real module gates, 6 scenarios, ANSI color (PR #413)
+- [x] T520: Version bump to v2.47.0 — CHANGELOG for T519
 
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.46.0",
+  "version": "2.47.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Version bump 2.46.0 → 2.47.0
- CHANGELOG entry for T519 (--demo command)

## Test plan
- [x] No code changes — version and docs only