### PR TITLE
T522: Fix stale SKILL.md module counts, add --demo

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -37,6 +37,9 @@ custom_commands:
   - name: test
     command: "node $SKILL_DIR/setup.js --test"
     description: "Run all test suites"
+  - name: demo
+    command: "node $SKILL_DIR/setup.js --demo --fast"
+    description: "Interactive demo — see hook-runner in action"
 ---
 
 # hook-runner
@@ -59,7 +62,7 @@ node setup.js --workflow audit     # coverage report
 node setup.js --workflow query Edit  # which workflows affect Edit?
 ```
 
-Built-in: `starter` (safe defaults, 11 modules), `shtd` (full development pipeline, 90 modules), `customer-data-guard`, `no-local-docker`, `cross-project-reset`.
+Built-in: `starter` (safe defaults, 42 modules), `shtd` (full development pipeline, 101 modules), `customer-data-guard`, `no-local-docker`, `cross-project-reset`.
 
 ## Module Contract
 
@@ -90,5 +93,6 @@ node setup.js --stats             # hook activity summary
 node setup.js --perf              # timing analysis
 node setup.js --workflow <cmd>    # workflow management
 node setup.js --test              # run all tests
+node setup.js --demo [--fast]     # interactive demo (no install needed)
 node setup.js --uninstall --confirm  # restore original settings
 ```

--- a/TODO.md
+++ b/TODO.md
@@ -1331,7 +1331,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 **Session 20:**
 - [x] T519: Add --demo CLI command — interactive showcase with real module gates, 6 scenarios, ANSI color (PR #413)
 - [x] T520: Version bump to v2.47.0 — CHANGELOG for T519 (PR #414)
-- [x] T521: Add --demo to README Quick Start and CLI Reference sections
+- [x] T521: Add --demo to README Quick Start and CLI Reference sections (PR #415)
+- [x] T522: Fix stale SKILL.md — update module counts (11→42, 90→101), add --demo command
 
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006


### PR DESCRIPTION
## Summary
- Fix outdated module counts: starter 11→42, shtd 90→101
- Add `demo` custom_command to SKILL.md frontmatter
- Add `--demo [--fast]` to CLI section

## Test plan
- [x] SKILL.md-only change, no code