### PR TITLE
T523: Fix npx --demo + version bump to v2.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.48.0] — 2026-04-18
+
+### Fixed
+- **npx --demo broken** (T523) — `demo.js` was missing from package.json `files` array, so `npx grobomo/hook-runner --demo` would fail.
+- **Stale SKILL.md** (T522) — Updated module counts (starter 11→42, shtd 90→101), added demo custom_command.
+- **README --demo** (T521) — Added demo callout to Quick Start and CLI Reference sections.
+
 ## [2.47.0] — 2026-04-18
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -1332,7 +1332,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T519: Add --demo CLI command — interactive showcase with real module gates, 6 scenarios, ANSI color (PR #413)
 - [x] T520: Version bump to v2.47.0 — CHANGELOG for T519 (PR #414)
 - [x] T521: Add --demo to README Quick Start and CLI Reference sections (PR #415)
-- [x] T522: Fix stale SKILL.md — update module counts (11→42, 90→101), add --demo command
+- [x] T522: Fix stale SKILL.md — update module counts (11→42, 90→101), add --demo command (PR #416)
+- [x] T523: Fix npx --demo + version bump to v2.48.0 — add demo.js to files array, CHANGELOG for T521-T523
 
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "hook-runner",
-  "version": "2.47.0",
+  "version": "2.48.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"
   },
   "files": [
     "setup.js",
+    "demo.js",
     "report.js",
     "constants.js",
     "workflow.js",


### PR DESCRIPTION
## Summary
- Add `demo.js` to package.json `files` array — fixes `npx grobomo/hook-runner --demo` 
- Version bump 2.47.0 → 2.48.0
- CHANGELOG entries for T521 (README), T522 (SKILL.md), T523 (this fix)

## Test plan
- [x] `demo.js` now listed in files array
- [x] package.json version updated