### PR TITLE
T524: Add gsd workflow to README and SKILL.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ node setup.js --workflow query Edit        # which workflows affect Edit?
 |----------|---------|-----------------|
 | `starter` | 42 | **Start here.** Safe defaults for any user — blocks force-push, destructive git, secret commits, file deletion. Adds commit quality checks, test reminders, and session context. |
 | `shtd` | 101 | Spec-Hook-Test-Driven — the full development pipeline. Enforces spec → branch → test → implement → PR, plus code quality, infrastructure safety, messaging guards, session lifecycle, and self-improvement. |
+| `gsd` | 101 | GSD-driven development — replaces shtd's spec-based flow with phase-based flow (.planning/ → ROADMAP.md → phase plan → branch → execute → PR). Same safety and quality modules as shtd. |
 | `customer-data-guard` | 3 | Read-only incident response — blocks env changes, data exfil, and V1 modifications. |
 | `dispatcher-worker` | 3 | Role-aware fleet workflow. Dispatcher specs/distributes, workers implement/test/PR. |
 | `no-local-docker` | 1 | Blocks local Docker commands, forces remote infrastructure. |

--- a/SKILL.md
+++ b/SKILL.md
@@ -14,6 +14,7 @@ keywords:
   - gate
   - module
   - shtd
+  - gsd
   - starter
 custom_commands:
   - name: setup
@@ -62,7 +63,7 @@ node setup.js --workflow audit     # coverage report
 node setup.js --workflow query Edit  # which workflows affect Edit?
 ```
 
-Built-in: `starter` (safe defaults, 42 modules), `shtd` (full development pipeline, 101 modules), `customer-data-guard`, `no-local-docker`, `cross-project-reset`.
+Built-in: `starter` (safe defaults, 42 modules), `shtd` (spec-driven pipeline, 101 modules), `gsd` (phase-driven pipeline, 101 modules), `customer-data-guard`, `no-local-docker`, `cross-project-reset`.
 
 ## Module Contract
 

--- a/TODO.md
+++ b/TODO.md
@@ -1335,6 +1335,9 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T522: Fix stale SKILL.md — update module counts (11→42, 90→101), add --demo command (PR #416)
 - [x] T523: Fix npx --demo + version bump to v2.48.0 — add demo.js to files array, CHANGELOG for T521-T523
 
+**Session 21:**
+- [x] T524: Add gsd workflow to README Built-in Workflows table and SKILL.md keywords/listing
+
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006
 - [ ] Port remaining OpenClaw modules (configurable/niche: aws-tagging, deploy-gate, messaging-safety, etc.)


### PR DESCRIPTION
## Summary
- Add `gsd` workflow (101 modules, phase-driven development) to README Built-in Workflows table
- Add `gsd` keyword and listing to SKILL.md marketplace description
- gsd was defined in `workflows/gsd.yml` but missing from all documentation

## Test plan
- [ ] Verify README table renders correctly on GitHub
- [ ] Verify SKILL.md YAML frontmatter is valid