### PR TITLE
T525: Version bump to v2.49.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.49.0] — 2026-04-18
+
+### Fixed
+- **Missing gsd workflow in docs** (T524) — `gsd` (101 modules, phase-driven development) was defined in `workflows/gsd.yml` but missing from README Built-in Workflows table and SKILL.md keywords/listing.
+
 ## [2.48.0] — 2026-04-18
 
 ### Fixed

--- a/TODO.md
+++ b/TODO.md
@@ -1336,7 +1336,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T523: Fix npx --demo + version bump to v2.48.0 — add demo.js to files array, CHANGELOG for T521-T523
 
 **Session 21:**
-- [x] T524: Add gsd workflow to README Built-in Workflows table and SKILL.md keywords/listing
+- [x] T524: Add gsd workflow to README Built-in Workflows table and SKILL.md keywords/listing (PR #418)
+- [x] T525: Version bump to v2.49.0 — CHANGELOG for T524
 
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.48.0",
+  "version": "2.49.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Version bump 2.48.0 → 2.49.0
- CHANGELOG entry for T524 (gsd workflow added to docs)

## Test plan
- [ ] `node setup.js --version` shows 2.49.0