### PR TITLE
T526: Add gsd workflow to demo summary

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1338,6 +1338,7 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 **Session 21:**
 - [x] T524: Add gsd workflow to README Built-in Workflows table and SKILL.md keywords/listing (PR #418)
 - [x] T525: Version bump to v2.49.0 — CHANGELOG for T524
+- [x] T526: Add gsd workflow to demo summary — consistency with README/SKILL.md
 
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006

--- a/demo.js
+++ b/demo.js
@@ -276,8 +276,11 @@ function runDemo() {
   console.log("           Blocks: force push, destructive git, secret commits, rm -rf");
   console.log("           Adds: commit quality, test reminders, session context");
   console.log("");
-  console.log("  " + C.yellow + "shtd" + C.reset + "     101 modules — full development discipline");
+  console.log("  " + C.yellow + "shtd" + C.reset + "     101 modules — spec-driven development discipline");
   console.log("           Adds: spec-first, test-first, PR workflow, code quality");
+  console.log("");
+  console.log("  " + C.yellow + "gsd" + C.reset + "      101 modules — phase-driven development discipline");
+  console.log("           Like shtd but uses .planning/ phases instead of specs");
   console.log("");
   console.log(C.bold + "  Get started:" + C.reset);
   console.log("");


### PR DESCRIPTION
## Summary
- Add `gsd` (101 modules, phase-driven) to the demo's workflow summary section
- Consistency with T524 which added gsd to README and SKILL.md

## Test plan
- [x] `bash scripts/test/test-T519-demo.sh` — 14 passed, 0 failed