### PR TITLE
T527: Add GitHub release automation on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Extract changelog for this version
+        id: changelog
+        run: |
+          # Extract the section between this version header and the next version header
+          version="${{ steps.version.outputs.version }}"
+          body=$(awk -v ver="$version" '
+            /^## \[/ {
+              if (found) exit
+              if (index($0, "[" ver "]")) { found=1; next }
+            }
+            found { print }
+          ' CHANGELOG.md)
+
+          # Write to file to preserve newlines
+          echo "$body" > /tmp/release-notes.md
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "hook-runner $GITHUB_REF_NAME" \
+            --notes-file /tmp/release-notes.md

--- a/TODO.md
+++ b/TODO.md
@@ -1339,6 +1339,7 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T524: Add gsd workflow to README Built-in Workflows table and SKILL.md keywords/listing (PR #418)
 - [x] T525: Version bump to v2.49.0 — CHANGELOG for T524
 - [x] T526: Add gsd workflow to demo summary — consistency with README/SKILL.md
+- [x] T527: Add GitHub release automation — creates release with CHANGELOG excerpt on tag push
 
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006


### PR DESCRIPTION
## Summary
- New `.github/workflows/release.yml` triggers on `v*` tag push
- Extracts the matching version section from CHANGELOG.md
- Creates a GitHub release with the extracted notes as body
- Gives the repo proper releases visible on the GitHub sidebar

## Test plan
- [ ] After merge, push a new tag (e.g. v2.50.0) and verify the release appears on GitHub
- [ ] Verify release body matches the CHANGELOG entry