### PR TITLE
T528: Version bump to v2.50.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.50.0] — 2026-04-18
+
+### Added
+- **GitHub release automation** (T527) — New `.github/workflows/release.yml` creates a GitHub release with CHANGELOG excerpt whenever a version tag (`v*`) is pushed. Releases appear on the repo sidebar with full release notes.
+- **gsd workflow in demo** (T526) — Demo summary now shows the `gsd` workflow alongside `starter` and `shtd`.
+
 ## [2.49.0] — 2026-04-18
 
 ### Fixed

--- a/TODO.md
+++ b/TODO.md
@@ -1340,6 +1340,7 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T525: Version bump to v2.49.0 — CHANGELOG for T524
 - [x] T526: Add gsd workflow to demo summary — consistency with README/SKILL.md
 - [x] T527: Add GitHub release automation — creates release with CHANGELOG excerpt on tag push
+- [x] T528: Version bump to v2.50.0 — CHANGELOG for T526-T527, test release automation
 
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.49.0",
+  "version": "2.50.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Version bump 2.49.0 → 2.50.0
- CHANGELOG entries for T526 (gsd in demo) and T527 (release automation)
- After merge + tag push, the new release.yml workflow should auto-create a GitHub release

## Test plan
- [ ] Push tag v2.50.0 after merge
- [ ] Verify GitHub release appears with correct CHANGELOG excerpt