### PR TITLE
T529: Fix stale README module count 80+ to 115+

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ hook-runner replaces direct `settings.json` editing. After install, you never to
 
 **1. Modules over shell commands.** Each rule is a `.js` file that receives structured input (tool name, file path, command) and returns a decision. Modules are testable, documented, and version-controlled. Drop a file in a folder and it runs — remove it and it stops.
 
-**2. Workflows over individual modules.** You don't think "I need to enable spec-gate, branch-gate, test-checkpoint-gate, and worker-loop." You think "I want the SHTD development pipeline." Workflows group related modules so you enable one name and get a complete enforcement regime. Disable it and they all go silent. This is how you manage 80+ modules without losing track.
+**2. Workflows over individual modules.** You don't think "I need to enable spec-gate, branch-gate, test-checkpoint-gate, and worker-loop." You think "I want the SHTD development pipeline." Workflows group related modules so you enable one name and get a complete enforcement regime. Disable it and they all go silent. This is how you manage 115+ modules without losing track.
 
 **3. Portability.** Export your module config as YAML (`--export`), sync it to another machine (`--sync`), or share a workflow definition. Workflows also make it easy to switch contexts — enable `customer-data-guard` during incident response, disable it after.
 

--- a/TODO.md
+++ b/TODO.md
@@ -1341,6 +1341,7 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T526: Add gsd workflow to demo summary — consistency with README/SKILL.md
 - [x] T527: Add GitHub release automation — creates release with CHANGELOG excerpt on tag push
 - [x] T528: Version bump to v2.50.0 — CHANGELOG for T526-T527, test release automation
+- [x] T529: Fix stale README "80+ modules" → "115+" + backfill GitHub releases for v2.47-v2.49
 
 ## Future (backlog)
 - [ ] T462: Marketplace sync for T458-T478 changes — delegated to claude-code-skills T006


### PR DESCRIPTION
## Summary
- Fix stale "80+ modules" text in README "Why hook-runner?" section → "115+"
- Also backfilled GitHub releases for v2.47.0-v2.49.0 (done outside PR)

## Test plan
- [ ] README renders correctly on GitHub