### PR TITLE
T531: Version bump to v2.51.0 — CHANGELOG for T530

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.51.0] — 2026-04-19
+
+### Performance
+- **secret-scan-gate fast path** (T530) — Added `--name-only` pre-check before expensive `git diff --cached`. When all staged files are safe extensions (.md, .yml, .txt, etc.), skips the full diff entirely. Reduces 200–1416ms spikes to ~5ms on metadata-only commits.
+- **workflow-compliance-gate cache** (T530) — Replaced `require(workflow.js)` + `require(hook-log.js)` with direct JSON file reads + file-based cache with mtime key. hook-log.js only loaded on block/exception (rare), not the common pass path. Saves ~14ms per tool call across 936+ calls/session.
+
 ## [2.50.0] — 2026-04-18
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -1344,7 +1344,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T529: Fix stale README "80+ modules" → "115+" + backfill GitHub releases for v2.47-v2.49
 
 **Session 22:**
-- [x] T530: Fix perf spikes in high-frequency modules — secret-scan-gate fast path + workflow-compliance-gate cache
+- [x] T530: Fix perf spikes in high-frequency modules — secret-scan-gate fast path + workflow-compliance-gate cache (PR #424)
+- [x] T531: Version bump to v2.51.0 — CHANGELOG for T530
 
 ## Next session priorities
 - Marketplace sync to claude-code-skills (T462 — delegated to claude-code-skills TODO.md as T012, v2.32.0→v2.50.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.50.0",
+  "version": "2.51.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Version bump to v2.51.0
- CHANGELOG entry for T530 performance optimizations (secret-scan-gate fast path, workflow-compliance-gate cache)

## Test plan
- [x] package.json version updated
- [x] CHANGELOG has new section