### PR TITLE
T532: Fix isInWorktree() false negative in commit-counter-gate

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1345,11 +1345,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 
 **Session 22:**
 - [x] T530: Fix perf spikes in high-frequency modules — secret-scan-gate fast path + workflow-compliance-gate cache (PR #424)
-<<<<<<< Updated upstream
 - [x] T531: Version bump to v2.51.0 — CHANGELOG for T530 (PR #425)
-=======
-- [ ] T531: Version bump to v2.51.0 — CHANGELOG for T530
->>>>>>> Stashed changes
+- [x] T532: Fix isInWorktree() false negative — CWD check now runs when CLAUDE_PROJECT_DIR is main checkout
 
 ## Next session priorities
 - Marketplace sync to claude-code-skills (T462 — delegated to claude-code-skills TODO.md as T012, v2.32.0→v2.50.0)

--- a/modules/PreToolUse/commit-counter-gate.js
+++ b/modules/PreToolUse/commit-counter-gate.js
@@ -88,8 +88,11 @@ function getBranch(input) {
 
 // Check if we're in a worktree (vs main checkout)
 // T511: Also check CWD when CLAUDE_PROJECT_DIR has no .git — EnterWorktree
-// changes CWD but not CLAUDE_PROJECT_DIR. Only fall back to CWD when
-// CLAUDE_PROJECT_DIR's .git doesn't exist (e.g. tests set it to a temp dir).
+// changes CWD but not CLAUDE_PROJECT_DIR.
+// T532: Also check CWD when CLAUDE_PROJECT_DIR's .git is a directory (main checkout).
+// EnterWorktree changes CWD to the worktree but CLAUDE_PROJECT_DIR stays pointing at
+// the main checkout. The old code returned false immediately when .git was a dir,
+// never reaching the CWD check. Now: if CLAUDE_PROJECT_DIR is main, fall through to CWD.
 function isInWorktree() {
   var projectDir = process.env.CLAUDE_PROJECT_DIR || "";
   // Check CLAUDE_PROJECT_DIR first
@@ -97,12 +100,13 @@ function isInWorktree() {
     try {
       var gitPath = path.join(projectDir, ".git");
       var stat = fs.statSync(gitPath);
-      // .git exists at CLAUDE_PROJECT_DIR — use it as the authority
-      return stat.isFile(); // file = worktree, dir = main checkout
+      if (stat.isFile()) return true; // .git file = worktree at CLAUDE_PROJECT_DIR
+      // .git is a directory (main checkout) — fall through to CWD check
+      // because EnterWorktree may have moved CWD to a worktree
     } catch(e) { /* no .git at CLAUDE_PROJECT_DIR — fall through to CWD */ }
   }
 
-  // Fallback: check CWD (covers when CLAUDE_PROJECT_DIR is unset or has no .git)
+  // Fallback: check CWD (covers worktree sessions + unset/missing CLAUDE_PROJECT_DIR)
   try {
     var cwd = process.cwd();
     var cwdGit = path.join(cwd, ".git");

--- a/scripts/test/test-commit-counter-gate.js
+++ b/scripts/test/test-commit-counter-gate.js
@@ -200,10 +200,14 @@ test("main checkout without worktree: enforces worktree", function() {
   // Branch keyword "src" matches file dir "src" so mismatch won't fire
   var dir = createTempRepo("build-src-utils", ["src/app.js"]);
   process.env.CLAUDE_PROJECT_DIR = dir;
+  // T532: Also chdir to the temp dir — isInWorktree() now checks CWD too
+  var origCwd = process.cwd();
+  process.chdir(dir);
   setCounter(14);
 
   var gate = loadGate();
   var r = gate({ tool_name: "Edit", tool_input: { file_path: path.join(dir, "src/app.js"), old_string: "a", new_string: "b" } });
+  process.chdir(origCwd);
   assert(r !== null, "should block");
   assert(r.reason.indexOf("main checkout") !== -1,
     "should mention not being in a worktree, got: " + r.reason.substring(0, 150));
@@ -278,11 +282,15 @@ test("T485: git commit blocked when worktreeRequired flag is set (not in worktre
   // Simulate: counter has worktreeRequired=true, session tries git commit
   var dir = createTempRepo("main", ["src/app.js"]);
   process.env.CLAUDE_PROJECT_DIR = dir;
+  // T532: Also chdir to the temp dir — isInWorktree() now checks CWD too
+  var origCwd = process.cwd();
+  process.chdir(dir);
   // Write counter with worktreeRequired flag
   fs.writeFileSync(COUNTER_FILE, JSON.stringify({ count: 15, ts: new Date().toISOString(), worktreeRequired: true }));
 
   var gate = loadGate();
   var r = gate({ tool_name: "Bash", tool_input: { command: "git commit -m 'sneaky commit'" } });
+  process.chdir(origCwd);
   assert(r !== null, "should block git commit");
   assert(r.decision === "block", "should be block decision");
   assert(r.reason.indexOf("WORKTREE REQUIRED") !== -1, "should mention WORKTREE REQUIRED");
@@ -324,10 +332,14 @@ test("T485: WRONG BRANCH sets worktreeRequired flag", function() {
 test("T485: not-in-worktree block sets worktreeRequired flag", function() {
   var dir = createTempRepo("build-src-utils", ["src/utils.js"]);
   process.env.CLAUDE_PROJECT_DIR = dir;
+  // T532: Also chdir to the temp dir — isInWorktree() now checks CWD too
+  var origCwd = process.cwd();
+  process.chdir(dir);
   setCounter(14);
 
   var gate = loadGate();
   var r = gate({ tool_name: "Edit", tool_input: { file_path: path.join(dir, "src/utils.js"), old_string: "a", new_string: "b" } });
+  process.chdir(origCwd);
   assert(r !== null && r.reason.indexOf("main checkout") !== -1, "should enforce worktree");
   var data = JSON.parse(fs.readFileSync(COUNTER_FILE, "utf-8"));
   assert(data.worktreeRequired === true, "worktreeRequired flag should be set");


### PR DESCRIPTION
## Summary
- **Bug**: `isInWorktree()` returned false when in a worktree because `CLAUDE_PROJECT_DIR` points to the main checkout (.git = directory), and the function treated that as authoritative without checking CWD
- **Fix**: Fall through to CWD check when CLAUDE_PROJECT_DIR's .git is a directory. EnterWorktree changes CWD but not CLAUDE_PROJECT_DIR
- **Impact**: Eliminates stale `worktreeRequired` flag that blocked commits/edits in worktree sessions

## Test plan
- [x] All 19 commit-counter-gate tests pass (3 updated to chdir to temp dir)
- [x] Bug scenario: CLAUDE_PROJECT_DIR=main, CWD=worktree → now correctly returns true