### PR TITLE
T533: Version bump to v2.52.0 — CHANGELOG for T532

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.52.0] — 2026-04-19
+
+### Fixed
+- **isInWorktree() false negative** (T532) — `commit-counter-gate` failed to detect worktree sessions when `CLAUDE_PROJECT_DIR` pointed to the main checkout (.git = directory). The function now falls through to check CWD's .git, which is a file in worktrees. Eliminates stale `worktreeRequired` flags that blocked commits/edits in worktree sessions. Updated 3 tests to match.
+
 ## [2.51.0] — 2026-04-19
 
 ### Performance

--- a/TODO.md
+++ b/TODO.md
@@ -1347,6 +1347,7 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T530: Fix perf spikes in high-frequency modules — secret-scan-gate fast path + workflow-compliance-gate cache (PR #424)
 - [x] T531: Version bump to v2.51.0 — CHANGELOG for T530 (PR #425)
 - [x] T532: Fix isInWorktree() false negative — CWD check now runs when CLAUDE_PROJECT_DIR is main checkout (PR #426)
+- [x] T533: Version bump to v2.52.0 — CHANGELOG for T532
 
 ## Next session priorities
 - Marketplace sync to claude-code-skills (T462 — delegated to claude-code-skills TODO.md as T012, v2.32.0→v2.50.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.51.0",
+  "version": "2.52.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
Version bump + CHANGELOG for T532 worktree detection fix.