### PR TITLE
T535: Version bump to v2.53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.53.0] — 2026-04-19
+
+### Added
+- **Static HTML demo export** (T534) — `node demo.js --html` generates a standalone HTML page with the same 6 scenarios as the terminal demo. Dark GitHub-style theme with stat cards, scenario results, block reasons, workflow overview, and getting started section. Also accessible via `node setup.js --demo-html`. Shareable via email/Slack without requiring `npx`.
+
 ## [2.52.0] — 2026-04-19
 
 ### Fixed

--- a/TODO.md
+++ b/TODO.md
@@ -1350,7 +1350,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T533: Version bump to v2.52.0 — CHANGELOG for T532 (PR #427)
 
 **Session 23:**
-- [ ] T534: Demo as static HTML export — shareable demo without npx, `node demo.js --html`
+- [x] T534: Demo as static HTML export — shareable demo without npx, `node demo.js --html` (PR #428)
+- [ ] T535: Version bump to v2.53.0 — CHANGELOG for T534
 
 ## Next session priorities
 - Marketplace sync to claude-code-skills (T462 — delegated to claude-code-skills TODO.md as T012, v2.32.0→v2.50.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.52.0",
+  "version": "2.53.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Version bump to v2.53.0
- CHANGELOG entry for T534 (static HTML demo export)
- TODO updated with T534 completion and T535 task

## Test plan
- [x] Full test suite passes (1162/1162)