### PR TITLE
T536: Add --demo-html to docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ node setup.js --snapshot drift  # detect drift from last snapshot
 node setup.js --snapshot backup # copy to git repo, commit, push
 node setup.js --snapshot restore # clone repo, restore files
 node setup.js --demo         # interactive demo (--fast to skip animation)
+node setup.js --demo-html    # generate standalone HTML demo page
 node setup.js --version      # show version
 node setup.js --help         # show all commands
 ```

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ To undo everything: `node setup.js --uninstall --confirm`
 
 **Want to see it in action first?** Run the interactive demo — no install needed:
 ```bash
-npx grobomo/hook-runner --demo
+npx grobomo/hook-runner --demo          # terminal demo
+npx grobomo/hook-runner --demo-html     # shareable HTML page
 ```
 
 ## What does a block look like?
@@ -306,6 +307,7 @@ node setup.js --prune [N]             # prune log entries older than N days
 
 # Demo & Development
 node setup.js --demo [--fast]          # interactive demo (no install needed)
+node setup.js --demo-html              # generate standalone HTML demo page
 node setup.js --test-module <file> [--input <json>]  # test one module
 node setup.js --test                   # run all test suites
 node setup.js --version                # show version

--- a/SKILL.md
+++ b/SKILL.md
@@ -95,5 +95,6 @@ node setup.js --perf              # timing analysis
 node setup.js --workflow <cmd>    # workflow management
 node setup.js --test              # run all tests
 node setup.js --demo [--fast]     # interactive demo (no install needed)
+node setup.js --demo-html         # generate shareable HTML demo page
 node setup.js --uninstall --confirm  # restore original settings
 ```

--- a/TODO.md
+++ b/TODO.md
@@ -1352,6 +1352,7 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 **Session 23:**
 - [x] T534: Demo as static HTML export — shareable demo without npx, `node demo.js --html` (PR #428)
 - [x] T535: Version bump to v2.53.0 — CHANGELOG for T534 (PR #429)
+- [ ] T536: Add --demo-html to README, CLAUDE.md, SKILL.md docs
 
 ## Future (backlog)
 - [ ] T462: Marketplace sync — delegated to claude-code-skills T012 (v2.32.0→v2.53.0)


### PR DESCRIPTION
## Summary
- Add `--demo-html` to README Quick Start and CLI Reference sections
- Add `--demo-html` to CLAUDE.md CLI Commands section
- Add `--demo-html` to SKILL.md reference

## Test plan
- [x] No code changes — docs only