### PR TITLE
T538: Version bump to v2.54.0 — CHANGELOG for T536-T537

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.54.0] — 2026-04-19
+
+### Added
+- **`--demo-html` in docs** (T536) — README, CLAUDE.md, and SKILL.md now document the `--demo-html` command alongside the existing `--demo` entry.
+- **Demo HTML test coverage** (T537) — 12 new checks in `test-T519-demo.sh` verify HTML generation, content structure (DOCTYPE, title, scenarios, badges, block reasons, workflows, footer), and `--demo-html` routing through `setup.js`. Total demo tests: 26/26.
+- **SKILL.md sync** (T537) — Local skill copy updated with gsd workflow, demo commands, correct module counts, and `--demo-html`.
+
 ## [2.53.0] — 2026-04-19
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -1355,9 +1355,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T536: Add --demo-html to README, CLAUDE.md, SKILL.md docs (PR #430)
 - [x] T537: Sync stale local skill SKILL.md + add --demo-html test coverage (PR #431)
 
-## Next session priorities
-- Version bump to v2.54.0 for T536-T537 (docs + tests)
-- Marketplace sync to claude-code-skills — v2.32.0 is 22 versions behind v2.53.0
+**Session 24:**
+- [ ] T538: Version bump to v2.54.0 — CHANGELOG for T536-T537 (docs + tests)
 
 ## Future (backlog)
 - [ ] T462: Marketplace sync — delegated to claude-code-skills T012 (v2.32.0→v2.53.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.53.0",
+  "version": "2.54.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Bump version 2.53.0 → 2.54.0
- CHANGELOG entry for T536 (docs) and T537 (test coverage + SKILL.md sync)
- TODO updated with Session 24 task

## Changes covered
- T536: `--demo-html` added to README, CLAUDE.md, SKILL.md
- T537: 12 new demo HTML tests (26/26 total) + local skill SKILL.md sync