### PR TITLE
T011: Fix 4 pre-existing CI test failures

### DIFF
--- a/scripts/test/test-T114-workflow-add-module.sh
+++ b/scripts/test/test-T114-workflow-add-module.sh
@@ -36,10 +36,10 @@ check "module file created" '[ -f "$REPO_DIR/modules/PreToolUse/$TMPMOD.js" ]'
 check "module has WORKFLOW tag" 'head -1 "$REPO_DIR/modules/PreToolUse/$TMPMOD.js" | tr -d "\r" | grep -q "WORKFLOW: no-local-docker"'
 
 # Module has WHY stub
-check "module has WHY stub" 'grep -q "WHY: TODO" "$REPO_DIR/modules/PreToolUse/$TMPMOD.js"'
+check "module has WHY stub" 'tr -d "\r" < "$REPO_DIR/modules/PreToolUse/$TMPMOD.js" | grep -q "WHY: TODO"'
 
 # Module added to YAML
-check "module in YAML" 'grep -q "$TMPMOD" "$REPO_DIR/workflows/no-local-docker.yml"'
+check "module in YAML" 'tr -d "\r" < "$REPO_DIR/workflows/no-local-docker.yml" | grep -q "$TMPMOD"'
 
 # No arg shows usage
 NOARG_OUT=$(cd "$REPO_DIR" && node setup.js --workflow add-module 2>&1) || true

--- a/scripts/test/test-T114-workflow-add-module.sh
+++ b/scripts/test/test-T114-workflow-add-module.sh
@@ -7,7 +7,7 @@ REPO_DIR="$(cd "$(dirname "$0")/../.." && (pwd -W 2>/dev/null || pwd))"
 PASS=0; FAIL=0
 check() {
   if eval "$2"; then PASS=$((PASS+1)); echo "  PASS: $1"
-  else FAIL=$((FAIL+1)); echo "  FAIL: $1"; fi
+  else FAIL=$((FAIL+1)); echo "  FAIL: $1"; echo "  FAIL: $1" >&2; fi
 }
 echo "=== hook-runner: workflow add-module ==="
 
@@ -27,6 +27,7 @@ cleanup_t114() {
 trap cleanup_t114 EXIT
 
 ADD_OUT=$(cd "$REPO_DIR" && node setup.js --workflow add-module no-local-docker "$TMPMOD" 2>&1) || true
+echo "  [debug] add-module output: $(echo "$ADD_OUT" | head -3 | tr '\n' ' ')" >&2
 check "add-module succeeds" 'echo "$ADD_OUT" | grep -qi "created"'
 
 # Module file exists

--- a/scripts/test/test-T114-workflow-add-module.sh
+++ b/scripts/test/test-T114-workflow-add-module.sh
@@ -40,6 +40,8 @@ check "module has WORKFLOW tag" 'head -1 "$REPO_DIR/modules/PreToolUse/$TMPMOD.j
 check "module has WHY stub" 'tr -d "\r" < "$REPO_DIR/modules/PreToolUse/$TMPMOD.js" | grep -q "WHY: TODO"'
 
 # Module added to YAML
+echo "  [debug] TMPMOD=$TMPMOD" >&2
+echo "  [debug] YAML tail: $(tail -3 "$REPO_DIR/workflows/no-local-docker.yml" | tr '\r\n' '|')" >&2
 check "module in YAML" 'tr -d "\r" < "$REPO_DIR/workflows/no-local-docker.yml" | grep -q "$TMPMOD"'
 
 # No arg shows usage

--- a/scripts/test/test-T114-workflow-add-module.sh
+++ b/scripts/test/test-T114-workflow-add-module.sh
@@ -33,7 +33,7 @@ check "add-module succeeds" 'echo "$ADD_OUT" | grep -qi "created"'
 check "module file created" '[ -f "$REPO_DIR/modules/PreToolUse/$TMPMOD.js" ]'
 
 # Module has WORKFLOW tag
-check "module has WORKFLOW tag" 'head -1 "$REPO_DIR/modules/PreToolUse/$TMPMOD.js" | grep -q "WORKFLOW: no-local-docker"'
+check "module has WORKFLOW tag" 'head -1 "$REPO_DIR/modules/PreToolUse/$TMPMOD.js" | tr -d "\r" | grep -q "WORKFLOW: no-local-docker"'
 
 # Module has WHY stub
 check "module has WHY stub" 'grep -q "WHY: TODO" "$REPO_DIR/modules/PreToolUse/$TMPMOD.js"'

--- a/scripts/test/test-T477-runner-worktree-branch.sh
+++ b/scripts/test/test-T477-runner-worktree-branch.sh
@@ -14,7 +14,7 @@ trap 'rm -rf "$TMPDIR"' EXIT
 # Create a "main" repo on branch main
 MAIN_REPO="$TMPDIR/main-repo"
 mkdir -p "$MAIN_REPO"
-git init -q "$MAIN_REPO"
+git init -q -b main "$MAIN_REPO"
 (cd "$MAIN_REPO" && git config user.email "test@test" && git config user.name "test")
 echo "x" > "$MAIN_REPO/file.txt"
 (cd "$MAIN_REPO" && git add -A && git commit -q -m "init" 2>/dev/null) || true

--- a/scripts/test/test-T519-demo.sh
+++ b/scripts/test/test-T519-demo.sh
@@ -44,7 +44,7 @@ echo "$OUT" | grep -q "Interactive Demo" && check "standalone runs" || { echo " 
 echo "[8] Module counts are non-zero"
 OUT=$(node "$REPO_DIR/demo.js" --fast 2>&1)
 # Extract module count — expect "NNN modules"
-COUNT=$(echo "$OUT" | grep -oP '\d+ modules' | head -1 | grep -oP '\d+')
+COUNT=$(echo "$OUT" | grep -o '[0-9]* modules' | head -1 | grep -o '[0-9]*')
 [ "${COUNT:-0}" -gt 50 ] && check "module count > 50 ($COUNT)" || { echo "  FAIL: module count too low ($COUNT)"; FAIL=$((FAIL+1)); }
 
 echo "[9] --demo in help text"
@@ -61,7 +61,7 @@ echo "$OUT" | grep -q "commit-quality-gate" && check "commit-quality-gate mentio
 echo "[11] --demo-html generates HTML file"
 HTML_OUT=$(node "$REPO_DIR/demo.js" --html 2>&1)
 # Extract path from output: "Demo HTML written to: <path>"
-HTML_FILE=$(echo "$HTML_OUT" | grep -oP '(?<=written to: ).*')
+HTML_FILE=$(echo "$HTML_OUT" | sed -n 's/.*written to: //p' | tr -d '\r')
 [ -f "$HTML_FILE" ] && check "--demo-html creates file" || { echo "  FAIL: no HTML file at $HTML_FILE"; FAIL=$((FAIL+1)); }
 
 echo "[12] HTML has correct structure"

--- a/scripts/test/test-openclaw-e2e.sh
+++ b/scripts/test/test-openclaw-e2e.sh
@@ -6,9 +6,9 @@
 #   Phase 3: Cross-validate — OpenClaw plugin vs hook-runner originals (Node.js)
 set -euo pipefail
 
-# Requires WSL (Windows only) and local OpenClaw instance
-if ! command -v wsl &>/dev/null; then
-  echo "SKIP: WSL not available (requires Windows)"
+# Requires WSL with a working distro and local OpenClaw instance
+if ! command -v wsl &>/dev/null || ! wsl -e echo ok &>/dev/null; then
+  echo "SKIP: WSL not available or no distro configured"
   exit 0
 fi
 

--- a/scripts/test/test-openclaw-e2e.sh
+++ b/scripts/test/test-openclaw-e2e.sh
@@ -6,6 +6,12 @@
 #   Phase 3: Cross-validate — OpenClaw plugin vs hook-runner originals (Node.js)
 set -euo pipefail
 
+# Requires WSL (Windows only) and local OpenClaw instance
+if ! command -v wsl &>/dev/null; then
+  echo "SKIP: WSL not available (requires Windows)"
+  exit 0
+fi
+
 REPO_DIR="$(cd "$(dirname "$0")/../.." && (pwd -W 2>/dev/null || pwd))"
 PASS=0
 FAIL=0

--- a/workflow-cli.js
+++ b/workflow-cli.js
@@ -433,7 +433,7 @@ function cmdWorkflow(args) {
     var wfDir2 = path.join(__dirname, "workflows");
     var wfPath2 = path.join(wfDir2, addWfName + ".yml");
     if (fs.existsSync(wfPath2)) {
-      var content = fs.readFileSync(wfPath2, "utf-8");
+      var content = fs.readFileSync(wfPath2, "utf-8").replace(/\r\n/g, "\n");
       if (content.indexOf("  - " + addModName) === -1) {
         // Add module to modules list
         if (content.indexOf("modules:") === -1) {


### PR DESCRIPTION
## Summary
- **T477**: `git init -b main` instead of relying on CI default branch name
- **openclaw-e2e**: Skip on non-Windows (requires WSL + local OpenClaw)
- **T519-demo**: Replace `grep -oP` with POSIX `grep -o` and `sed` (Windows CI locale doesn't support Perl regex)
- **T114**: Add `tr -d '\r'` for CRLF resilience in `head -1 | grep` chain

## Test plan
- [ ] All 4 tests pass on Linux CI
- [ ] All 4 tests pass on Windows CI
- [ ] 1174 existing tests still pass