### PR TITLE
T012: Remove debug stderr from T114 test

### DIFF
--- a/scripts/test/test-T114-workflow-add-module.sh
+++ b/scripts/test/test-T114-workflow-add-module.sh
@@ -7,7 +7,7 @@ REPO_DIR="$(cd "$(dirname "$0")/../.." && (pwd -W 2>/dev/null || pwd))"
 PASS=0; FAIL=0
 check() {
   if eval "$2"; then PASS=$((PASS+1)); echo "  PASS: $1"
-  else FAIL=$((FAIL+1)); echo "  FAIL: $1"; echo "  FAIL: $1" >&2; fi
+  else FAIL=$((FAIL+1)); echo "  FAIL: $1"; fi
 }
 echo "=== hook-runner: workflow add-module ==="
 
@@ -27,7 +27,6 @@ cleanup_t114() {
 trap cleanup_t114 EXIT
 
 ADD_OUT=$(cd "$REPO_DIR" && node setup.js --workflow add-module no-local-docker "$TMPMOD" 2>&1) || true
-echo "  [debug] add-module output: $(echo "$ADD_OUT" | head -3 | tr '\n' ' ')" >&2
 check "add-module succeeds" 'echo "$ADD_OUT" | grep -qi "created"'
 
 # Module file exists
@@ -40,8 +39,6 @@ check "module has WORKFLOW tag" 'head -1 "$REPO_DIR/modules/PreToolUse/$TMPMOD.j
 check "module has WHY stub" 'tr -d "\r" < "$REPO_DIR/modules/PreToolUse/$TMPMOD.js" | grep -q "WHY: TODO"'
 
 # Module added to YAML
-echo "  [debug] TMPMOD=$TMPMOD" >&2
-echo "  [debug] YAML tail: $(tail -3 "$REPO_DIR/workflows/no-local-docker.yml" | tr '\r\n' '|')" >&2
 check "module in YAML" 'tr -d "\r" < "$REPO_DIR/workflows/no-local-docker.yml" | grep -q "$TMPMOD"'
 
 # No arg shows usage


### PR DESCRIPTION
## Summary
- Remove `[debug]` stderr lines from T114 workflow-add-module test
- Remove extra `>&2` from `check()` failure handler
- These were added temporarily to diagnose the Windows CI YAML failure (fixed in #435)

## Test plan
- [x] T114 passes locally (8/8)
- [ ] CI: test + test-windows green