### PR TITLE
T019: Add .coconut/ and hermes to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ SESSION_STATE.md
 workflow-config.json
 scripts/test/archive/
 run-modules/
+.coconut/
+scripts/hermes-message.json


### PR DESCRIPTION
## Summary
- Add `.coconut/` (OpenClaw status mailbox) and `scripts/hermes-message.json` (transient IPC file) to `.gitignore`
- Neither should be version-controlled

## Test plan
- [x] `git status` no longer shows these files
- [ ] CI passes