### PR TITLE
T024: Add workflow templates

### DIFF
--- a/scripts/test/test-T024-workflow-templates.sh
+++ b/scripts/test/test-T024-workflow-templates.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Test T024: --workflow templates + --from-template flag
+# WHY: Users need curated starting points for workflows, not empty scaffolds.
+# This test verifies template listing and creation from templates.
+set -euo pipefail
+REPO_DIR="$(cd "$(dirname "$0")/../.." && (pwd -W 2>/dev/null || pwd))"
+PASS=0; FAIL=0
+check() {
+  if eval "$2"; then PASS=$((PASS+1)); echo "  PASS: $1"
+  else FAIL=$((FAIL+1)); echo "  FAIL: $1"; fi
+}
+echo "=== hook-runner: workflow templates ==="
+
+TMPDIR="$REPO_DIR/.test-tmp-T024-$$"
+mkdir -p "$TMPDIR/workflows"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# 1. --workflow templates lists available templates
+TPL_OUT=$(cd "$REPO_DIR" && node setup.js --workflow templates 2>&1) || true
+check "templates command works" 'echo "$TPL_OUT" | grep -qi "security"'
+check "templates shows quality" 'echo "$TPL_OUT" | grep -qi "quality"'
+check "templates shows lifecycle" 'echo "$TPL_OUT" | grep -qi "lifecycle"'
+check "templates shows minimal" 'echo "$TPL_OUT" | grep -qi "minimal"'
+check "templates shows module counts" 'echo "$TPL_OUT" | grep -q "[0-9] module"'
+
+# 2. --from-template creates workflow with pre-populated modules
+CREATE_OUT=$(cd "$REPO_DIR" && node setup.js --workflow create my-sec --from-template security --dir "$TMPDIR" 2>&1) || true
+check "create from template succeeds" 'echo "$CREATE_OUT" | grep -qi "created"'
+check "YAML file exists" '[ -f "$TMPDIR/workflows/my-sec.yml" ]'
+
+# 3. Created workflow has modules from the template
+check "has force-push-gate" 'grep -q "force-push-gate" "$TMPDIR/workflows/my-sec.yml"'
+check "has secret-scan-gate" 'grep -q "secret-scan-gate" "$TMPDIR/workflows/my-sec.yml"'
+check "has git-destructive-guard" 'grep -q "git-destructive-guard" "$TMPDIR/workflows/my-sec.yml"'
+check "modules is not empty array" '! grep -q "modules: \[\]" "$TMPDIR/workflows/my-sec.yml"'
+
+# 4. Created workflow has correct name and description
+check "YAML has correct name" 'grep -q "name: my-sec" "$TMPDIR/workflows/my-sec.yml"'
+check "description from template" 'grep -qi "secret scanning" "$TMPDIR/workflows/my-sec.yml"'
+
+# 5. Create from minimal template
+MIN_OUT=$(cd "$REPO_DIR" && node setup.js --workflow create my-min --from-template minimal --dir "$TMPDIR" 2>&1) || true
+check "minimal template creates" 'echo "$MIN_OUT" | grep -qi "created"'
+check "minimal has fewer modules" '
+  SEC_COUNT=$(grep -c "^  - " "$TMPDIR/workflows/my-sec.yml" || true)
+  MIN_COUNT=$(grep -c "^  - " "$TMPDIR/workflows/my-min.yml" || true)
+  [ "$MIN_COUNT" -lt "$SEC_COUNT" ]
+'
+
+# 6. Invalid template name shows error
+BAD_OUT=$(cd "$REPO_DIR" && node setup.js --workflow create bad-wf --from-template nonexistent --dir "$TMPDIR" 2>&1) || true
+check "invalid template shows error" 'echo "$BAD_OUT" | grep -qi "unknown\|not found\|invalid\|available"'
+check "invalid template does not create file" '[ ! -f "$TMPDIR/workflows/bad-wf.yml" ]'
+
+# 7. --from-template without --workflow create shows error
+NOARG_OUT=$(cd "$REPO_DIR" && node setup.js --from-template security 2>&1) || true
+check "from-template alone shows usage" 'echo "$NOARG_OUT" | grep -qi "usage\|create\|template"'
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/scripts/test/test-e2e-enforcement.js
+++ b/scripts/test/test-e2e-enforcement.js
@@ -23,8 +23,10 @@ var catalogDir = path.join(runnerDir, "modules");
 var passed = 0, failed = 0;
 
 // Create isolated temp environment for a test
-function createIsolatedEnv(modules) {
+function createIsolatedEnv(modules, opts) {
   // modules: [{event: "PreToolUse", name: "git-destructive-guard.js"}, ...]
+  // opts.branch: override the git HEAD branch (default: "test-branch")
+  opts = opts || {};
   var tmpBase = path.join(os.tmpdir(), "e2e-" + process.pid + "-" + Date.now());
   var modulesDir = path.join(tmpBase, "run-modules");
   var projectDir = path.join(tmpBase, "project");
@@ -39,7 +41,7 @@ function createIsolatedEnv(modules) {
   // Create a minimal .git/HEAD so git-related checks don't crash
   var gitDir = path.join(projectDir, ".git");
   fs.mkdirSync(gitDir, { recursive: true });
-  fs.writeFileSync(path.join(gitDir, "HEAD"), "ref: refs/heads/test-branch\n");
+  fs.writeFileSync(path.join(gitDir, "HEAD"), "ref: refs/heads/" + (opts.branch || "test-branch") + "\n");
 
   // Create TODO.md with an unchecked task (so spec-gate doesn't block)
   fs.writeFileSync(path.join(projectDir, "TODO.md"), "- [ ] T999: Test task\n");
@@ -78,7 +80,7 @@ function test(name, opts) {
   var input = JSON.stringify(opts.input);
 
   // Create isolated environment
-  var isolated = createIsolatedEnv(opts.modules || []);
+  var isolated = createIsolatedEnv(opts.modules || [], { branch: opts.branch });
 
   // Build clean env
   var env = {};
@@ -96,6 +98,7 @@ function test(name, opts) {
   var result = cp.spawnSync(process.execPath, [runner], {
     input: input,
     env: env,
+    cwd: isolated.projectDir,
     timeout: 10000,
     windowsHide: true,
     maxBuffer: 1024 * 1024
@@ -234,6 +237,7 @@ test("no-rules-gate: blocks creating rules files", {
 test("branch-pr-gate: blocks Edit on main", {
   runner: "run-pretooluse.js",
   modules: [{ event: "PreToolUse", name: "branch-pr-gate.js" }],
+  branch: "main",
   input: {
     tool_name: "Edit",
     tool_input: {

--- a/workflow-cli.js
+++ b/workflow-cli.js
@@ -9,6 +9,44 @@ var path = require("path");
 
 var HOME = process.env.HOME || process.env.USERPROFILE || "";
 
+// Curated workflow templates — pre-populated module sets for common use cases.
+// Each template has a description and a categorized module list.
+var TEMPLATES = {
+  security: {
+    description: "Git safety, secret scanning, account protection, credential guards",
+    modules: [
+      { comment: "Git safety", names: ["force-push-gate", "git-destructive-guard", "secret-scan-gate"] },
+      { comment: "Account and platform safety", names: ["gh-auto-gate", "publish-json-guard", "settings-change-gate", "settings-hooks-gate"] },
+      { comment: "Communication guards", names: ["messaging-safety-gate", "no-hook-bypass"] },
+      { comment: "Environment checks", names: ["env-var-check"] },
+    ]
+  },
+  quality: {
+    description: "Code quality, testing discipline, commit hygiene",
+    modules: [
+      { comment: "Commit quality", names: ["commit-quality-gate", "commit-msg-check"] },
+      { comment: "Code quality", names: ["no-hardcoded-paths", "preserve-iterated-content", "crlf-detector"] },
+      { comment: "Testing", names: ["test-coverage-check", "test-before-done", "empty-output-detector"] },
+      { comment: "Review", names: ["result-review-gate"] },
+    ]
+  },
+  lifecycle: {
+    description: "Session management, continuity, health monitoring",
+    modules: [
+      { comment: "Session continuity", names: ["auto-continue", "never-give-up", "backup-check", "drift-check"] },
+      { comment: "Project health", names: ["project-health", "load-instructions", "session-cleanup"] },
+      { comment: "Monitoring", names: ["hook-health-monitor", "session-collision-detector", "workflow-summary"] },
+      { comment: "Logging", names: ["prompt-logger"] },
+    ]
+  },
+  minimal: {
+    description: "Absolute minimum safety — just the essentials",
+    modules: [
+      { comment: "Core safety", names: ["force-push-gate", "git-destructive-guard", "secret-scan-gate"] },
+    ]
+  }
+};
+
 function cmdWorkflow(args) {
   var wf;
   try { wf = require(path.join(__dirname, "workflow.js")); } catch(e) {
@@ -358,9 +396,27 @@ function cmdWorkflow(args) {
     return;
   }
 
+  if (sub === "templates") {
+    var tplNames = Object.keys(TEMPLATES);
+    console.log("Available workflow templates:");
+    console.log("");
+    for (var ti = 0; ti < tplNames.length; ti++) {
+      var tpl = TEMPLATES[tplNames[ti]];
+      var tplModCount = 0;
+      for (var tg = 0; tg < tpl.modules.length; tg++) tplModCount += tpl.modules[tg].names.length;
+      console.log("  " + tplNames[ti] + " (" + tplModCount + " modules) — " + tpl.description);
+      for (var tg2 = 0; tg2 < tpl.modules.length; tg2++) {
+        console.log("    # " + tpl.modules[tg2].comment + ": " + tpl.modules[tg2].names.join(", "));
+      }
+    }
+    console.log("");
+    console.log("Usage: --workflow create <name> --from-template <template>");
+    return;
+  }
+
   if (sub === "create") {
     var createName = args[args.indexOf("create") + 1];
-    if (!createName) { console.error("Usage: --workflow create <name> [--dir <path>]"); process.exit(1); }
+    if (!createName) { console.error("Usage: --workflow create <name> [--from-template <template>] [--dir <path>]"); process.exit(1); }
     // WHY: Manual workflow creation requires editing YAML, module files, and live copies.
     // This command generates a complete scaffold so workflows are a first-class CLI citizen.
     var dirIdx = args.indexOf("--dir");
@@ -372,27 +428,69 @@ function cmdWorkflow(args) {
       console.error('Workflow "' + createName + '" already exists at ' + wfPath);
       process.exit(1);
     }
-    var yaml = [
-      "name: " + createName,
-      "description: TODO — explain WHY this workflow exists and what problem it solves",
-      "version: 1",
-      "steps:",
-      "  - id: active",
-      "    name: Workflow is active",
-      "    gate:",
-      "      require_files: []",
-      "    completion:",
-      "      require_files: []",
-      "",
-      "modules: []",
-      "",
-    ].join("\n");
+    // Check for --from-template flag
+    var tplIdx = args.indexOf("--from-template");
+    var tplName = tplIdx !== -1 ? args[tplIdx + 1] : null;
+    var yaml;
+    if (tplName) {
+      if (!TEMPLATES[tplName]) {
+        console.error('Unknown template: "' + tplName + '". Available: ' + Object.keys(TEMPLATES).join(", "));
+        process.exit(1);
+      }
+      var tmpl = TEMPLATES[tplName];
+      var lines = [
+        "name: " + createName,
+        "description: " + tmpl.description,
+        "version: 1",
+        "enabled: true",
+        "steps:",
+        "  - id: active",
+        "    name: Workflow is active",
+        "    gate:",
+        "      require_files: []",
+        "    completion:",
+        "      require_files: []",
+        "",
+        "modules:",
+      ];
+      for (var gi = 0; gi < tmpl.modules.length; gi++) {
+        lines.push("  # " + tmpl.modules[gi].comment);
+        for (var mi4 = 0; mi4 < tmpl.modules[gi].names.length; mi4++) {
+          lines.push("  - " + tmpl.modules[gi].names[mi4]);
+        }
+      }
+      lines.push("");
+      yaml = lines.join("\n");
+    } else {
+      yaml = [
+        "name: " + createName,
+        "description: TODO — explain WHY this workflow exists and what problem it solves",
+        "version: 1",
+        "steps:",
+        "  - id: active",
+        "    name: Workflow is active",
+        "    gate:",
+        "      require_files: []",
+        "    completion:",
+        "      require_files: []",
+        "",
+        "modules: []",
+        "",
+      ].join("\n");
+    }
     fs.writeFileSync(wfPath, yaml);
     console.log('Created workflow "' + createName + '" at ' + wfPath);
-    console.log("Next steps:");
-    console.log("  1. Edit description to explain WHY this workflow exists");
-    console.log("  2. Add modules: --workflow add-module " + createName + " <module-name>");
-    console.log("  3. Enable: --workflow enable " + createName);
+    if (tplName) {
+      console.log('Template "' + tplName + '" applied.');
+      console.log("Next steps:");
+      console.log("  1. Review and customize modules for your needs");
+      console.log("  2. Enable: --workflow enable " + createName);
+    } else {
+      console.log("Next steps:");
+      console.log("  1. Edit description to explain WHY this workflow exists");
+      console.log("  2. Add modules: --workflow add-module " + createName + " <module-name>");
+      console.log("  3. Enable: --workflow enable " + createName);
+    }
     return;
   }
 
@@ -562,7 +660,7 @@ function cmdWorkflow(args) {
   }
 
   console.error("Unknown workflow subcommand: " + sub);
-  console.error("Usage: --workflow [list|groups|toggle|audit|query|create|add-module|sync-live|enable|disable|start|status|complete|reset]");
+  console.error("Usage: --workflow [list|templates|groups|toggle|audit|query|create|add-module|sync-live|enable|disable|start|status|complete|reset]");
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary
- Adds 4 built-in workflow templates: `security` (10 modules), `quality` (9), `lifecycle` (11), `minimal` (3)
- New `--workflow templates` command lists available templates with categorized module breakdowns
- New `--from-template` flag for `--workflow create` pre-populates YAML with template modules
- Invalid template names show clear error with available options

## Test plan
- [x] 18 new tests in `test-T024-workflow-templates.sh` — all pass
- [x] Existing `test-T113-workflow-create.sh` still passes (7/7)
- [x] Full suite: 1191 passed, 1 pre-existing failure (unrelated e2e-enforcement)