### PR TITLE
T030: Fix --from-template arg edge case

### DIFF
--- a/scripts/test/test-T024-workflow-templates.sh
+++ b/scripts/test/test-T024-workflow-templates.sh
@@ -79,6 +79,14 @@ check "dedup has no duplicate force-push-gate" '
   [ "$COUNT" -eq 1 ]
 '
 
+# 11. --from-template with no value shows usage error
+EDGE_OUT=$(cd "$REPO_DIR" && node setup.js --workflow create test-edge --from-template --dir "$TMPDIR" 2>&1) || true
+check "edge: --from-template with no value" 'echo "$EDGE_OUT" | grep -qi "usage"'
+
+# 12. --from-template at end of args shows usage error
+EDGE2_OUT=$(cd "$REPO_DIR" && node setup.js --workflow create test-edge2 --from-template 2>&1) || true
+check "edge: --from-template at end" 'echo "$EDGE2_OUT" | grep -qi "usage"'
+
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ]

--- a/workflow-cli.js
+++ b/workflow-cli.js
@@ -430,7 +430,12 @@ function cmdWorkflow(args) {
     }
     // Check for --from-template flag (supports comma-separated: security,quality)
     var tplIdx = args.indexOf("--from-template");
-    var tplArg = tplIdx !== -1 ? args[tplIdx + 1] : null;
+    var tplRaw = tplIdx !== -1 ? args[tplIdx + 1] : null;
+    var tplArg = tplRaw && tplRaw.indexOf("--") !== 0 ? tplRaw : null;
+    if (tplIdx !== -1 && !tplArg) {
+      console.error("Usage: --from-template <name> (e.g. security, quality, security,quality)");
+      process.exit(1);
+    }
     var yaml;
     if (tplArg) {
       var tplNames = tplArg.split(",");


### PR DESCRIPTION
## Summary
- When `--from-template` is followed by another flag (e.g. `--dir`) or is the last argument, show a usage error instead of treating the next flag as a template name
- Added 2 edge case tests (28/28 template tests pass)

## Test plan
- [x] `--from-template --dir` shows usage error (was: "Unknown template: --dir")
- [x] `--from-template` at end of args shows usage error
- [x] Normal template creation still works
- [x] Full suite: 1171 passed, 0 failed