### PR TITLE
T031: Bump package.json to v2.57.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.55.0",
+  "version": "2.57.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Sync package.json version (was 2.55.0) with latest git tag v2.57.0

## Test plan
- [x] `node setup.js --version` shows `hook-runner v2.57.0`