### PR TITLE
T035: Bump to v2.58.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.57.0",
+  "version": "2.58.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Bump package.json to v2.58.0
- Covers: install drift detection (#444), SKILL.md slash commands (#443)

## Test plan
- [ ] `node setup.js --version` shows v2.58.0