### PR TITLE
T043: Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 grobomo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/scripts/test/test-T043-license.sh
+++ b/scripts/test/test-T043-license.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# T043: Verify LICENSE file exists and repo metadata is correct
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+
+passed=0
+failed=0
+
+pass() { echo "OK: $1"; passed=$((passed + 1)); }
+fail() { echo "FAIL: $1"; failed=$((failed + 1)); }
+
+# Test 1: LICENSE file exists
+if [ -f "$REPO_DIR/LICENSE" ]; then
+  pass "LICENSE file exists"
+else
+  fail "LICENSE file missing"
+fi
+
+# Test 2: LICENSE contains MIT
+if grep -q "MIT License" "$REPO_DIR/LICENSE" 2>/dev/null; then
+  pass "LICENSE is MIT"
+else
+  fail "LICENSE does not contain MIT License"
+fi
+
+# Test 3: LICENSE contains grobomo (not real name)
+if grep -q "grobomo" "$REPO_DIR/LICENSE" 2>/dev/null; then
+  pass "LICENSE uses grobomo (anonymous)"
+else
+  fail "LICENSE missing grobomo attribution"
+fi
+
+# Test 4: LICENSE does NOT contain real names
+if grep -qiE "(joel|ginsberg|trend.?micro)" "$REPO_DIR/LICENSE" 2>/dev/null; then
+  fail "LICENSE contains PII — must be anonymous for grobomo repo"
+else
+  pass "LICENSE has no PII"
+fi
+
+# Test 5: package.json has license field
+if node -e "const p=JSON.parse(require('fs').readFileSync(process.argv[1])); process.exit(p.license === 'MIT' ? 0 : 1)" "$REPO_DIR/package.json" 2>/dev/null; then
+  pass "package.json license is MIT"
+else
+  fail "package.json license field missing or not MIT"
+fi
+
+echo "  $passed passed, $failed failed"
+[ "$failed" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary
- Add MIT LICENSE file (grobomo attribution, no PII)
- Test suite: `test-T043-license.sh` (5 assertions: exists, MIT, anonymous, no PII, package.json match)

Public repos without a license are legally all-rights-reserved. This unblocks adoption.

## Test plan
- [x] `bash scripts/test/test-T043-license.sh` — 5/5 pass
- [x] Full suite: 87 suites, 1215 passed, 0 failed