### PR TITLE
T541: Add no-playwright-direct PreToolUse gate (#451)

### DIFF
--- a/modules/PreToolUse/no-playwright-direct.js
+++ b/modules/PreToolUse/no-playwright-direct.js
@@ -1,0 +1,22 @@
+// WORKFLOW: shtd, starter, gsd
+// WHY: Claude ignored CLAUDE.md instructions to never use Playwright directly and called
+// mcp__playwright__* tools instead of Blueprint Extra MCP via mcp-manager. Blueprint wraps
+// Playwright with session management, tab lifecycle, and SSO handling that raw Playwright lacks.
+"use strict";
+
+module.exports = function(input) {
+  var tool = input.tool_name || "";
+
+  if (tool.indexOf("mcp__playwright__") === 0) {
+    return {
+      decision: "block",
+      reason: "BLOCKED: Do not use Playwright MCP tools directly.\n" +
+        "Tool: " + tool + "\n" +
+        "FIX: Use Blueprint Extra MCP via mcp-manager instead.\n" +
+        "Blueprint provides session management, tab lifecycle, and SSO handling.\n" +
+        "Example: mcp__mcp-manager__mcpm (then use blueprint-extra tools)"
+    };
+  }
+
+  return null;
+};

--- a/scripts/test/test-no-playwright-direct.js
+++ b/scripts/test/test-no-playwright-direct.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+"use strict";
+// Test suite for no-playwright-direct module (T541)
+
+var path = require("path");
+var MOD = path.join(__dirname, "../../modules/PreToolUse/no-playwright-direct.js");
+
+var pass = 0, fail = 0;
+function assert(name, ok) {
+  if (ok) { console.log("  PASS: " + name); pass++; }
+  else { console.log("  FAIL: " + name); fail++; }
+}
+
+var gate = require(MOD);
+
+console.log("=== hook-runner: no-playwright-direct (T541) ===");
+
+// 1. Direct playwright tool blocked
+var r1 = gate({ tool_name: "mcp__playwright__browser_click", tool_input: { selector: "#btn" } });
+assert("mcp__playwright__browser_click blocked", r1 && r1.decision === "block");
+
+// 2. Another playwright tool blocked
+var r2 = gate({ tool_name: "mcp__playwright__browser_navigate", tool_input: { url: "https://example.com" } });
+assert("mcp__playwright__browser_navigate blocked", r2 && r2.decision === "block");
+
+// 3. browser_snapshot blocked
+var r3 = gate({ tool_name: "mcp__playwright__browser_snapshot", tool_input: {} });
+assert("mcp__playwright__browser_snapshot blocked", r3 && r3.decision === "block");
+
+// 4. browser_fill_form blocked
+var r4 = gate({ tool_name: "mcp__playwright__browser_fill_form", tool_input: {} });
+assert("mcp__playwright__browser_fill_form blocked", r4 && r4.decision === "block");
+
+// 5. Block reason mentions Blueprint
+assert("block reason mentions Blueprint", r1.reason.indexOf("Blueprint") !== -1);
+
+// 6. Block reason includes the tool name
+assert("block reason includes tool name", r2.reason.indexOf("mcp__playwright__browser_navigate") !== -1);
+
+// 7. Non-playwright MCP tool passes
+var r7 = gate({ tool_name: "mcp__mcp-manager__mcpm", tool_input: {} });
+assert("mcp-manager tool passes", r7 === null);
+
+// 8. Regular tool passes
+var r8 = gate({ tool_name: "Bash", tool_input: { command: "echo hello" } });
+assert("Bash tool passes", r8 === null);
+
+// 9. Read tool passes
+var r9 = gate({ tool_name: "Read", tool_input: { file_path: "/tmp/foo.txt" } });
+assert("Read tool passes", r9 === null);
+
+// 10. Edit tool passes
+var r10 = gate({ tool_name: "Edit", tool_input: { file_path: "/tmp/foo.txt" } });
+assert("Edit tool passes", r10 === null);
+
+// 11. Empty tool_name passes
+var r11 = gate({ tool_name: "", tool_input: {} });
+assert("empty tool_name passes", r11 === null);
+
+// 12. Missing tool_name passes
+var r12 = gate({ tool_input: {} });
+assert("missing tool_name passes", r12 === null);
+
+// Summary
+console.log("\n" + pass + " passed, " + fail + " failed");
+process.exit(fail > 0 ? 1 : 0);

--- a/workflows/gsd.yml
+++ b/workflows/gsd.yml
@@ -71,6 +71,7 @@ modules:
   - gh-auto-gate
   - no-hook-bypass
   - no-nested-claude
+  - no-playwright-direct
   - publish-json-guard
   # Code quality
   - archive-not-delete

--- a/workflows/shtd.yml
+++ b/workflows/shtd.yml
@@ -83,6 +83,7 @@ modules:
   - gh-auto-gate
   - no-hook-bypass
   - no-nested-claude
+  - no-playwright-direct
   - publish-json-guard
   # Code quality
   - archive-not-delete

--- a/workflows/starter.yml
+++ b/workflows/starter.yml
@@ -37,6 +37,7 @@ modules:
   - settings-hooks-gate
   - messaging-safety-gate
   - no-nested-claude
+  - no-playwright-direct
   - no-focus-steal
   - windowless-spawn-gate
   # Infrastructure — disk, CRLF, SSH


### PR DESCRIPTION
## Summary
- New `no-playwright-direct.js` PreToolUse module that blocks all `mcp__playwright__*` tool calls
- Claude must use Blueprint Extra MCP via mcp-manager instead (provides session management, tab lifecycle, SSO handling)
- Added to starter, shtd, and gsd workflows

## Test plan
- [x] 12/12 unit tests pass (`test-no-playwright-direct.js`)
- [x] 448/0 module validation pass
- [x] Workflow audit clean (starter 43, shtd 102, gsd 102)