### PR TITLE
T541: Bump version to v2.60.0 (#452)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.60.0] — 2026-04-30
+
+### Added
+- **no-playwright-direct gate** (T541) — blocks all `mcp__playwright__*` tool calls. Claude must use Blueprint Extra MCP via mcp-manager instead (session management, tab lifecycle, SSO handling). Added to starter, shtd, and gsd workflows. 12 tests.
+
+### Stats
+- 88 suites, 1227 tests
+- 119 modules, 13 workflows, 4 templates
+
 ## [2.59.0] — 2026-04-25
 
 ### Fixed

--- a/TODO.md
+++ b/TODO.md
@@ -1360,6 +1360,9 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T538: Version bump to v2.54.0 — CHANGELOG for T536-T537 (PR #432)
 - [x] T539: Fix preserve-iterated-content perf — 30min TTL, skip save on hit, new-file fast path (PR #433)
 
+## From v1-helper (2026-04-30)
+- [x] T541: Create no-playwright-direct.js PreToolUse module — blocks all `mcp__playwright__*` tool calls. Added to starter, shtd, gsd workflows. 12 tests. (PR #451, v2.60.0)
+
 ## Future (backlog)
 - [x] T462: Marketplace sync — obsolete (claude-code-skills replaced by ai-skill-marketplace PR #164)
 - [x] T540: Fix commit-counter-gate deadlock in worktrees — skip mismatch enforcement when already in a worktree. 1 new test (20 total). Synced to live hooks.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.59.0",
+  "version": "2.60.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Version bump to v2.60.0
- CHANGELOG entry for no-playwright-direct gate (T541, PR #451)
- TODO.md updated — T541 marked complete

## Test plan
- [x] 88 suites, 1227 tests pass
- [x] Workflow audit clean (119 modules)