### PR TITLE
T542: Bump version to v2.61.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.61.0] — 2026-04-30
+
+### Changed
+- **Write-pattern Bash gates** (T542) — spec-gate and gsd-plan-gate flipped from default-deny allowlist to write-pattern detection. Only 30 definite write patterns (sed -i, cp, mv, rm, npm install, etc.) require spec/plan chain. Exploration commands (powershell, python scripts, wsl, npm test, docker ps) now allowed. New `_bash-write-patterns.js` shared helper.
+
+### Added
+- **hook-log-review-gate** (T542) — blocks creation/editing of hook modules unless hook-log.jsonl has been reviewed. Time-based flag (4hr TTL). Added to starter, shtd, gsd workflows. 10 tests.
+
+### Fixed
+- **Nested-repo branch detection** (T543) — runner `readBranchFromDir` walks up directory tree to find `.git`. spec-gate adds parent git root to `roots[]`. 3 tests.
+
+### Stats
+- 91 suites, 1297 tests
+- 121 modules, 13 workflows, 4 templates
+
 ## [2.60.0] — 2026-04-30
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -1366,6 +1366,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 ## Future (backlog)
 - [x] T462: Marketplace sync — obsolete (claude-code-skills replaced by ai-skill-marketplace PR #164)
 - [x] T540: Fix commit-counter-gate deadlock in worktrees — skip mismatch enforcement when already in a worktree. 1 new test (20 total). Synced to live hooks.
+- [x] T542: Flip spec-gate and gsd-plan-gate Bash from default-deny to write-pattern detection. New `_bash-write-patterns.js` shared helper (30 patterns). New `hook-log-review-gate` module enforces evidence-based hook design (4hr TTL flag). 42+17+10 tests. (PR #453, v2.61.0)
+- [x] T543: Fix nested-repo branch detection — runner `readBranchFromDir` walks up to find `.git`, spec-gate adds parent git root to `roots[]`. 3 tests. (PR #453, v2.61.0)
 - [ ] Port remaining OpenClaw modules (configurable/niche: aws-tagging, deploy-gate, messaging-safety, etc.)
 
 ## Architecture Notes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.60.0",
+  "version": "2.61.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Version bump to v2.61.0
- CHANGELOG for T542 (write-pattern gates, hook-log-review-gate) and T543 (nested-repo fix)
- TODO.md updated with completion notes

## Test plan
- [x] No code changes — version/docs only