### PR TITLE
T544: Fix 3 pre-existing test failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ Full catalog in `modules/` directory:
 | `git-destructive-guard` | Blocks git reset --hard, checkout ., clean -f without diagnosis |
 | `git-rebase-safety` | Warns about reversed --ours/--theirs during rebase |
 | `hook-editing-gate` | Enforces WORKFLOW tag, WHY comment, exit(1) in hook files |
+| `hook-log-review-gate` | Requires hook-log.jsonl review before creating/editing hook modules |
 | `instruction-to-hook-gate` | Converts user directives into hook modules |
 | `messaging-safety-gate` | Blocks outbound messaging unless authorized |
 | `cross-project-todo-gate` | Blocks writing cross-project TODOs into local TODO.md |
@@ -397,6 +398,7 @@ Full catalog in `modules/` directory:
 | `no-hook-bypass` | Blocks Bash cat/echo writes when Write/Edit is gated |
 | `no-nested-claude` | Blocks nested claude -p calls (use context-reset for cross-project) |
 | `no-passive-rules` | Blocks .md rules when a hook module is better |
+| `no-playwright-direct` | Blocks raw mcp__playwright__* calls, requires Blueprint Extra MCP |
 | `no-rules-gate` | Blocks creation of ~/.claude/rules/ files (use hook modules instead) |
 | `hook-system-reminder` | Reminds Claude that enforcement is ONLY via hook-runner modules |
 | `inter-project-priority-gate` | Blocks non-XREF work when P0 inter-project TODOs are pending |

--- a/TODO.md
+++ b/TODO.md
@@ -1368,6 +1368,7 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T540: Fix commit-counter-gate deadlock in worktrees — skip mismatch enforcement when already in a worktree. 1 new test (20 total). Synced to live hooks.
 - [x] T542: Flip spec-gate and gsd-plan-gate Bash from default-deny to write-pattern detection. New `_bash-write-patterns.js` shared helper (30 patterns). New `hook-log-review-gate` module enforces evidence-based hook design (4hr TTL flag). 42+17+10 tests. (PR #453, v2.61.0)
 - [x] T543: Fix nested-repo branch detection — runner `readBranchFromDir` walks up to find `.git`, spec-gate adds parent git root to `roots[]`. 3 tests. (PR #453, v2.61.0)
+- [x] T544: Fix 3 pre-existing test failures — T094 (README missing 2 modules), T204 (ProjectsCL1 in comment), commit-counter-gate (worktree CWD pollution). T042 marketplace version deferred to marketplace repo sync.
 - [ ] Port remaining OpenClaw modules (configurable/niche: aws-tagging, deploy-gate, messaging-safety, etc.)
 
 ## Architecture Notes

--- a/modules/PreToolUse/_bash-write-patterns.js
+++ b/modules/PreToolUse/_bash-write-patterns.js
@@ -6,7 +6,7 @@
 // scripts, and wsl session management — all clearly not code changes.
 // Real incidents from hook-log.jsonl (2026-04-30):
 //   - powershell "[System.IO.Compression.ZipFile]::OpenRead(...)" blocked in dd-lab
-//   - python stale-audit.py --summary blocked in ProjectsCL1
+//   - python stale-audit.py --summary blocked in projects directory
 //   - wsl -e bash -c 'python3 openclaw-checkin.py' blocked in dd-lab
 // T542: Flip from default-deny allowlist to write-pattern detection.
 "use strict";

--- a/scripts/test/test-commit-counter-gate.js
+++ b/scripts/test/test-commit-counter-gate.js
@@ -165,10 +165,14 @@ test("WRONG BRANCH: detects mismatch between branch and changed files", function
     "labs/dd-lab/scripts/deploy.sh"
   ]);
   process.env.CLAUDE_PROJECT_DIR = dir;
+  // T544: chdir to temp repo so isInWorktree() checks temp .git (dir), not CWD worktree (.git file)
+  var origCwd = process.cwd();
+  process.chdir(dir);
   setCounter(14);
 
   var gate = loadGate();
   var r = gate({ tool_name: "Edit", tool_input: { file_path: path.join(dir, "labs/dd-lab/terraform/main.tf"), old_string: "a", new_string: "b" } });
+  process.chdir(origCwd);
   assert(r !== null, "should block");
   assert(r.decision === "block");
   assert(r.reason.indexOf("WRONG BRANCH") !== -1, "should say WRONG BRANCH, got: " + r.reason.substring(0, 100));
@@ -318,10 +322,14 @@ test("T485: WRONG BRANCH sets worktreeRequired flag", function() {
     "labs/dd-lab/scripts/setup.sh"
   ]);
   process.env.CLAUDE_PROJECT_DIR = dir;
+  // T544: chdir to temp repo so isInWorktree() returns false
+  var origCwd = process.cwd();
+  process.chdir(dir);
   setCounter(14);
 
   var gate = loadGate();
   var r = gate({ tool_name: "Edit", tool_input: { file_path: path.join(dir, "labs/dd-lab/terraform/main.tf"), old_string: "a", new_string: "b" } });
+  process.chdir(origCwd);
   assert(r !== null && r.reason.indexOf("WRONG BRANCH") !== -1, "should detect wrong branch");
   var data = JSON.parse(fs.readFileSync(COUNTER_FILE, "utf-8"));
   assert(data.worktreeRequired === true, "worktreeRequired flag should be set");
@@ -398,10 +406,14 @@ test("T497: real files + metadata files still detect mismatch", function() {
     ".coconut/STATUS_REPORT.md"
   ]);
   process.env.CLAUDE_PROJECT_DIR = dir;
+  // T544: chdir to temp repo so isInWorktree() returns false
+  var origCwd = process.cwd();
+  process.chdir(dir);
   setCounter(14);
 
   var gate = loadGate();
   var r = gate({ tool_name: "Edit", tool_input: { file_path: path.join(dir, "labs/dd-lab/main.tf"), old_string: "a", new_string: "b" } });
+  process.chdir(origCwd);
   // labs/dd-lab doesn't match deploy/nfs/datasec → should still detect mismatch
   assert(r !== null && r.reason.indexOf("WRONG BRANCH") !== -1,
     "should still detect mismatch when real files don't match branch");


### PR DESCRIPTION
## Summary
- **T094**: Add `hook-log-review-gate` and `no-playwright-direct` to README module table
- **T204**: Remove `ProjectsCL1` reference from `_bash-write-patterns.js` comment
- **commit-counter-gate**: Add `process.chdir(dir)` to 3 WRONG BRANCH tests so `isInWorktree()` checks temp repo's `.git` dir instead of CWD worktree's `.git` file

## Test plan
- [x] T094 module docs: 7/7 pass
- [x] T204 portable paths: 3/3 pass
- [x] commit-counter-gate: 20/20 pass
- [ ] T042 marketplace version: deferred to marketplace repo sync (separate task)