### PR TITLE
T545: Auto-sync skill copy during setup.js install

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1369,6 +1369,7 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T542: Flip spec-gate and gsd-plan-gate Bash from default-deny to write-pattern detection. New `_bash-write-patterns.js` shared helper (30 patterns). New `hook-log-review-gate` module enforces evidence-based hook design (4hr TTL flag). 42+17+10 tests. (PR #453, v2.61.0)
 - [x] T543: Fix nested-repo branch detection — runner `readBranchFromDir` walks up to find `.git`, spec-gate adds parent git root to `roots[]`. 3 tests. (PR #453, v2.61.0)
 - [x] T544: Fix 3 pre-existing test failures — T094 (README missing 2 modules), T204 (ProjectsCL1 in comment), commit-counter-gate (worktree CWD pollution). T042 marketplace version deferred to marketplace repo sync.
+- [ ] T545: Auto-sync skill package.json during setup.js install — fixes T034 install-drift test failure
 - [ ] Port remaining OpenClaw modules (configurable/niche: aws-tagging, deploy-gate, messaging-safety, etc.)
 
 ## Architecture Notes

--- a/setup.js
+++ b/setup.js
@@ -1426,7 +1426,25 @@ function cmdWizard(reportOnly, dryRun, openMode, autoYes, analyzeMode, deepMode,
   console.log("  Report: " + afterReport);
   if (openMode) openFile(afterReport);
 
-  // Step 7: Enable default workflows (if --yes or interactive)
+  // Step 7: Sync skill copy — keep ~/.claude/skills/hook-runner/ in sync with repo
+  // T545: Health check warned about version drift but nothing auto-fixed it.
+  // Copy core JS files + package.json so the skill install matches the repo.
+  var skillDir = path.join(os.homedir(), ".claude", "skills", "hook-runner");
+  if (fs.existsSync(skillDir)) {
+    var coreFiles = fs.readdirSync(__dirname).filter(function(f) {
+      return f.slice(-3) === ".js" || f === "package.json";
+    });
+    var synced = 0;
+    for (var si = 0; si < coreFiles.length; si++) {
+      try {
+        fs.copyFileSync(path.join(__dirname, coreFiles[si]), path.join(skillDir, coreFiles[si]));
+        synced++;
+      } catch(e) {}
+    }
+    console.log("  Skill synced: " + synced + " files → ~/.claude/skills/hook-runner/");
+  }
+
+  // Step 8: Enable default workflows (if --yes or interactive)
   // WHY: New users don't know which workflows to enable. "starter" provides
   // safe defaults (force-push, secret-scan, archive-not-delete) without
   // overwhelming them with 90 shtd modules. Users enable shtd manually later.


### PR DESCRIPTION
## Summary
- Add step 7 to installer that copies core JS + package.json to `~/.claude/skills/hook-runner/`
- Fixes T034 install-drift test failure where skill version lagged behind repo after upgrades

## Test plan
- [x] T034 install drift: 4/4 pass (was 3/4)
- [x] Setup wizard: 7/7 pass
- [x] `node setup.js --yes` output shows "Skill synced: 21 files"