### PR TITLE
T545: Bump version to v2.62.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.62.0] — 2026-04-30
+
+### Fixed
+- **Test suite fixes** (T544) — README missing docs for `hook-log-review-gate` and `no-playwright-direct`. Removed `ProjectsCL1` reference from `_bash-write-patterns.js` comment. Fixed `commit-counter-gate` tests failing in worktree context (CWD `.git` file polluted `isInWorktree()` check).
+- **Skill version drift** (T545) — `setup.js --yes` now auto-syncs core JS files + `package.json` to `~/.claude/skills/hook-runner/`. Previously health check warned about drift but nothing auto-fixed it.
+
+### Stats
+- 90 suites, 1264 tests
+- 115 modules, 13 workflows, 4 templates
+
 ## [2.61.0] — 2026-04-30
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.61.0",
+  "version": "2.62.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Version bump to v2.62.0
- CHANGELOG entries for T544 (test fixes) and T545 (skill version sync)

## Test plan
- [x] All tests pass (90 suites, 1264 tests, 1 known marketplace version failure)