### PR TITLE
T547: Fix worktree detection + block counter state tampering

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1369,7 +1369,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T542: Flip spec-gate and gsd-plan-gate Bash from default-deny to write-pattern detection. New `_bash-write-patterns.js` shared helper (30 patterns). New `hook-log-review-gate` module enforces evidence-based hook design (4hr TTL flag). 42+17+10 tests. (PR #453, v2.61.0)
 - [x] T543: Fix nested-repo branch detection — runner `readBranchFromDir` walks up to find `.git`, spec-gate adds parent git root to `roots[]`. 3 tests. (PR #453, v2.61.0)
 - [x] T544: Fix 3 pre-existing test failures — T094 (README missing 2 modules), T204 (ProjectsCL1 in comment), commit-counter-gate (worktree CWD pollution). T042 marketplace version deferred to marketplace repo sync.
-- [ ] T545: Auto-sync skill package.json during setup.js install — fixes T034 install-drift test failure
+- [x] T545: Auto-sync skill package.json during setup.js install — fixes T034 install-drift test failure (PR #456)
+- [x] T547: Fix worktree detection (walk up dir tree via `findWorktreeGitFile()` + `git rev-parse --git-dir` fallback) + block counter state tampering (HMAC integrity + Bash command blocking). 30 tests pass.
 - [ ] Port remaining OpenClaw modules (configurable/niche: aws-tagging, deploy-gate, messaging-safety, etc.)
 
 ## Architecture Notes

--- a/TODO.md
+++ b/TODO.md
@@ -1370,7 +1370,7 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T543: Fix nested-repo branch detection — runner `readBranchFromDir` walks up to find `.git`, spec-gate adds parent git root to `roots[]`. 3 tests. (PR #453, v2.61.0)
 - [x] T544: Fix 3 pre-existing test failures — T094 (README missing 2 modules), T204 (ProjectsCL1 in comment), commit-counter-gate (worktree CWD pollution). T042 marketplace version deferred to marketplace repo sync.
 - [x] T545: Auto-sync skill package.json during setup.js install — fixes T034 install-drift test failure (PR #456)
-- [x] T547: Fix worktree detection (walk up dir tree via `findWorktreeGitFile()` + `git rev-parse --git-dir` fallback) + block counter state tampering (HMAC integrity + Bash command blocking). 30 tests pass.
+- [ ] T547: Git gate fixes — worktree detection, counter tampering, enforcement-gate .gitignore exemption (T546)
 - [ ] Port remaining OpenClaw modules (configurable/niche: aws-tagging, deploy-gate, messaging-safety, etc.)
 
 ## Architecture Notes

--- a/modules/PreToolUse/commit-counter-gate.js
+++ b/modules/PreToolUse/commit-counter-gate.js
@@ -10,32 +10,64 @@
 // because the gate just said "commit now" without checking branch fitness.
 // Now: detects mismatch → tells Claude to use EnterWorktree instead of committing
 // to the wrong branch. Also enforces worktrees over bare branch checkouts.
+// T547: Fix worktree detection — walk up directory tree from CWD and CLAUDE_PROJECT_DIR
+// instead of only checking immediate .git. EnterWorktree puts CWD inside a worktree
+// subdirectory but CLAUDE_PROJECT_DIR stays at the main checkout.
+// T547: Block state file tampering — Claude used `node -e` to reset the counter file
+// directly, bypassing the gate. Now uses HMAC integrity check + Bash command detection.
 "use strict";
 var fs = require("fs");
 var path = require("path");
 var cp = require("child_process");
 var os = require("os");
+var crypto = require("crypto");
 
 var COUNTER_FILE = path.join(os.homedir(), ".claude", "hooks", ".uncommitted-edit-count");
 var MAX_EDITS = 15;
+// HMAC key derived from machine-specific data (not a secret — just prevents casual resets)
+var HMAC_KEY = "ccg:" + os.hostname() + ":" + os.homedir();
 
 // Patterns indicating file-modifying Bash commands (shared helper — DRY with spec-before-code-gate)
 var FILE_MODIFY_PATTERNS = require("./_file-modify-patterns");
 
+// State file names that are protected from Bash tampering
+var PROTECTED_STATE_FILES = [
+  "uncommitted-edit-count",
+  "spec-before-code-state",
+  "commit-counter-state"
+];
+
+function computeHmac(data) {
+  return crypto.createHmac("sha256", HMAC_KEY)
+    .update(JSON.stringify({ count: data.count, worktreeRequired: !!data.worktreeRequired }))
+    .digest("hex").slice(0, 16);
+}
+
 function readCounter() {
   try {
     var data = JSON.parse(fs.readFileSync(COUNTER_FILE, "utf-8"));
-    return { count: data.count || 0, worktreeRequired: !!data.worktreeRequired };
-  } catch(e) { return { count: 0, worktreeRequired: false }; }
+    // Legacy file without HMAC — trust it but upgrade on next write
+    if (!data.hmac) {
+      return { count: data.count || 0, worktreeRequired: !!data.worktreeRequired, tampered: false };
+    }
+    var expected = computeHmac(data);
+    if (data.hmac !== expected) {
+      // HMAC mismatch — file was tampered with externally
+      return { count: data.count || 0, worktreeRequired: !!data.worktreeRequired, tampered: true };
+    }
+    return { count: data.count || 0, worktreeRequired: !!data.worktreeRequired, tampered: false };
+  } catch(e) { return { count: 0, worktreeRequired: false, tampered: false }; }
 }
 
 function writeCounter(count, worktreeRequired) {
   try {
-    fs.writeFileSync(COUNTER_FILE, JSON.stringify({
+    var data = {
       count: count,
       ts: new Date().toISOString(),
       worktreeRequired: !!worktreeRequired
-    }));
+    };
+    data.hmac = computeHmac(data);
+    fs.writeFileSync(COUNTER_FILE, JSON.stringify(data));
   } catch(e) {}
 }
 
@@ -86,6 +118,25 @@ function getBranch(input) {
   return "";
 }
 
+// T547: Walk up from a directory looking for .git file (worktree marker).
+// Returns true if any ancestor has a .git FILE (not directory).
+// Stops at filesystem root or after 20 levels to avoid infinite loops.
+function findWorktreeGitFile(startDir) {
+  var dir = startDir;
+  for (var i = 0; i < 20; i++) {
+    try {
+      var gitPath = path.join(dir, ".git");
+      var stat = fs.statSync(gitPath);
+      if (stat.isFile()) return true;   // .git file = worktree
+      if (stat.isDirectory()) return false; // .git dir = main checkout, stop walking
+    } catch(e) { /* no .git here, keep walking up */ }
+    var parent = path.dirname(dir);
+    if (parent === dir) break; // filesystem root
+    dir = parent;
+  }
+  return false;
+}
+
 // Check if we're in a worktree (vs main checkout)
 // T511: Also check CWD when CLAUDE_PROJECT_DIR has no .git — EnterWorktree
 // changes CWD but not CLAUDE_PROJECT_DIR.
@@ -93,9 +144,12 @@ function getBranch(input) {
 // EnterWorktree changes CWD to the worktree but CLAUDE_PROJECT_DIR stays pointing at
 // the main checkout. The old code returned false immediately when .git was a dir,
 // never reaching the CWD check. Now: if CLAUDE_PROJECT_DIR is main, fall through to CWD.
+// T547: Walk up directory tree instead of only checking immediate .git.
+// EnterWorktree creates worktrees at CLAUDE_PROJECT_DIR/.claude/worktrees/<name>/
+// but hook process CWD may be a subdirectory. Walking up finds the .git file.
 function isInWorktree() {
   var projectDir = process.env.CLAUDE_PROJECT_DIR || "";
-  // Check CLAUDE_PROJECT_DIR first
+  // Check CLAUDE_PROJECT_DIR first (immediate check for speed)
   if (projectDir) {
     try {
       var gitPath = path.join(projectDir, ".git");
@@ -106,12 +160,22 @@ function isInWorktree() {
     } catch(e) { /* no .git at CLAUDE_PROJECT_DIR — fall through to CWD */ }
   }
 
-  // Fallback: check CWD (covers worktree sessions + unset/missing CLAUDE_PROJECT_DIR)
+  // T547: Walk up from CWD looking for .git file (worktree marker).
+  // Covers: CWD is inside worktree subdir, or CWD IS the worktree root.
   try {
-    var cwd = process.cwd();
-    var cwdGit = path.join(cwd, ".git");
-    if (fs.statSync(cwdGit).isFile()) return true;
-  } catch(e) { /* no .git at cwd either */ }
+    if (findWorktreeGitFile(process.cwd())) return true;
+  } catch(e) { /* cwd inaccessible */ }
+
+  // T547: If CWD is the main checkout but CLAUDE_PROJECT_DIR has worktrees,
+  // check if `git rev-parse --git-dir` reveals a worktree.
+  // This catches the case where the harness CWD hasn't moved but git operations
+  // target a worktree (e.g. via `cd worktree && git commit` in a single Bash call).
+  try {
+    var opts = { encoding: "utf-8", timeout: 3000, windowsHide: true };
+    var gitDir = cp.execFileSync("git", ["rev-parse", "--git-dir"], opts).trim();
+    // In a worktree, --git-dir returns the .git/worktrees/<name> path
+    if (/[\/\\]\.git[\/\\]worktrees[\/\\]/.test(gitDir)) return true;
+  } catch(e) { /* not in a git repo or git not available */ }
 
   return false;
 }
@@ -192,6 +256,17 @@ function checkBranchFileMismatch(branch, files) {
   };
 }
 
+// T547: Detect Bash commands that tamper with gate state files.
+// Incident: Claude used `node -e "fs.writeFileSync(...uncommitted-edit-count...)"` to
+// reset the counter to 0, bypassing the worktreeRequired gate entirely.
+function detectStateTampering(cmd) {
+  if (!cmd) return false;
+  for (var i = 0; i < PROTECTED_STATE_FILES.length; i++) {
+    if (cmd.indexOf(PROTECTED_STATE_FILES[i]) !== -1) return true;
+  }
+  return false;
+}
+
 module.exports = function(input) {
   var cmd = "";
   if (input.tool_name === "Bash") {
@@ -200,11 +275,34 @@ module.exports = function(input) {
     } catch(e) { cmd = (input.tool_input || {}).command || ""; }
   }
 
+  // T547: Block Bash commands that tamper with gate state files
+  // Skip git commit/log/diff — commit messages and diffs may legitimately mention state file names
+  if (input.tool_name === "Bash" && !(/git\s+(commit|log|diff|show|grep)/.test(cmd)) && detectStateTampering(cmd)) {
+    return {
+      decision: "block",
+      reason: "COMMIT COUNTER — STATE TAMPERING BLOCKED: This command references a gate state file.\n" +
+        "WHY: Claude previously used `node -e` to reset the counter file directly,\n" +
+        "bypassing worktree enforcement entirely.\n\n" +
+        "Gate state files are managed exclusively by hook modules.\n" +
+        "To clear the worktreeRequired flag: call EnterWorktree, then commit in the worktree."
+    };
+  }
+
   // Reset counter on git commit — but block if worktree was required
   // T485: Previously, Claude bypassed the worktree enforcement by just committing
   // on the wrong branch. Now: if the gate flagged "worktree required", block commits too.
   if (input.tool_name === "Bash" && /git\s+commit/.test(cmd)) {
     var state = readCounter();
+    // T547: If HMAC check failed, the counter was tampered with — restore worktreeRequired
+    if (state.tampered) {
+      writeCounter(state.count, true); // re-sign with correct HMAC, keep worktreeRequired
+      return {
+        decision: "block",
+        reason: "COMMIT COUNTER — INTEGRITY VIOLATION: The counter state file was modified outside this gate.\n" +
+          "The worktreeRequired flag has been restored.\n" +
+          "REQUIRED: Call EnterWorktree first, then commit in the worktree."
+      };
+    }
     if (state.worktreeRequired && !isInWorktree()) {
       return {
         decision: "block",
@@ -234,6 +332,15 @@ module.exports = function(input) {
   if (!isFileModify) return null;
 
   var counterState = readCounter();
+  // T547: If tampering detected on read, restore with correct HMAC
+  if (counterState.tampered) {
+    writeCounter(counterState.count, true);
+    return {
+      decision: "block",
+      reason: "COMMIT COUNTER — INTEGRITY VIOLATION: The counter state file was modified outside this gate.\n" +
+        "Counter and worktreeRequired flag have been restored. Retry your edit."
+    };
+  }
   var count = counterState.count + 1;
   writeCounter(count, counterState.worktreeRequired);
 

--- a/modules/PreToolUse/enforcement-gate.js
+++ b/modules/PreToolUse/enforcement-gate.js
@@ -15,8 +15,10 @@ module.exports = function(input) {
 
   var targetFile = toolInput.file_path || "";
 
-  // Allow writing TODO.md (bootstrap)
-  if (path.basename(targetFile) === "TODO.md") return null;
+  // Allow writing TODO.md (bootstrap) and .gitignore (T546: chicken-and-egg —
+  // untracked files make tree dirty, but you need .gitignore to ignore them)
+  var basename = path.basename(targetFile);
+  if (basename === "TODO.md" || basename === ".gitignore") return null;
 
   // Allow editing ~/.claude/ (user config, not a project)
   var home = (process.env.HOME || process.env.USERPROFILE || "").replace(/\\/g, "/");

--- a/modules/PreToolUse/unresolved-issues-gate.js
+++ b/modules/PreToolUse/unresolved-issues-gate.js
@@ -37,7 +37,13 @@ module.exports = function(input) {
     cmd = (typeof input.tool_input === "string" ? JSON.parse(input.tool_input) : input.tool_input || {}).command || "";
   } catch(e) { cmd = (input.tool_input || {}).command || ""; }
 
-  if (!/git\s+commit/.test(cmd)) return null;
+  // T547: Match actual git commit commands, not "git commit" appearing in heredoc bodies,
+  // PR descriptions, or string literals. Extract the first real command (after cd/&&).
+  // Strip heredoc bodies and quoted strings before checking.
+  var cmdForCheck = cmd.replace(/\$\(cat\s+<<'?EOF'?[\s\S]*?EOF\s*\)/g, "")  // remove heredocs
+                       .replace(/"[^"]*"/g, '""')                               // remove double-quoted strings
+                       .replace(/'[^']*'/g, "''");                              // remove single-quoted strings
+  if (!/git\s+commit/.test(cmdForCheck)) return null;
 
   // Find project root (look for .git)
   var projectDir = process.env.CLAUDE_PROJECT_DIR || process.cwd();

--- a/scripts/test/test-T370-unresolved-issues-gate.js
+++ b/scripts/test/test-T370-unresolved-issues-gate.js
@@ -120,6 +120,31 @@ var notesDir = setupProject("session-notes", "# Notes\n- timeout increased to 36
 var r17 = runGate(notesDir);
 assert("session notes with issue words pass", r17 === null);
 
+// --- T547: false positive tests — "git commit" in heredoc/string bodies ---
+
+function runGateRaw(projectDir, rawCmd) {
+  var origDir = process.env.CLAUDE_PROJECT_DIR;
+  process.env.CLAUDE_PROJECT_DIR = projectDir;
+  delete require.cache[require.resolve(MOD)];
+  var g = require(MOD);
+  var result = g({ tool_name: "Bash", tool_input: { command: rawCmd } });
+  process.env.CLAUDE_PROJECT_DIR = origDir || "";
+  return result;
+}
+
+// 18. gh pr create with "git commit" in heredoc body should NOT trigger
+var fpDir = setupProject("fp-heredoc", "# TODO\n- [ ] T999: FAIL in some test\n");
+var r18 = runGateRaw(fpDir, 'gh pr create --title "T547" --body "$(cat <<\'EOF\'\nExcluding git commit/log/diff from check.\nEOF\n)"');
+assert("T547: gh pr create with heredoc mentioning commits passes", r18 === null);
+
+// 19. node -e with "git commit" in string should NOT trigger
+var r19 = runGateRaw(fpDir, 'node -e "console.log(\'Has git commit exclusion:\', true)"');
+assert("T547: node -e with commit in string passes", r19 === null);
+
+// 20. Actual git commit should still trigger
+var r20 = runGateRaw(fpDir, 'git commit -m "fix something"');
+assert("T547: actual git commit still blocks on FAIL", r20 && r20.decision === "block");
+
 // Cleanup
 try { fs.rmSync(tmpBase, { recursive: true, force: true }); } catch(e) {}
 

--- a/scripts/test/test-commit-counter-gate.js
+++ b/scripts/test/test-commit-counter-gate.js
@@ -463,6 +463,169 @@ test("T540: mismatch in worktree gives commit guidance, not WRONG BRANCH", funct
   cleanupRepo(dir);
 });
 
+// --- T547: State file tampering detection ---
+
+test("T547: blocks Bash commands referencing counter state file", function() {
+  resetCounter();
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: { command: 'node -e "fs.writeFileSync(...uncommitted-edit-count...)"' } });
+  assert(r !== null, "should block");
+  assert(r.decision === "block", "should be block decision");
+  assert(r.reason.indexOf("STATE TAMPERING") !== -1, "should mention state tampering, got: " + r.reason.substring(0, 100));
+});
+
+test("T547: blocks Bash commands referencing spec-before-code state file", function() {
+  resetCounter();
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: { command: 'cat ~/.claude/hooks/.spec-before-code-state | jq .' } });
+  assert(r !== null, "should block");
+  assert(r.reason.indexOf("STATE TAMPERING") !== -1, "should mention state tampering");
+});
+
+test("T547: allows Bash commands that don't reference state files", function() {
+  resetCounter();
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: { command: "git status" } });
+  assert(r === null, "should pass");
+});
+
+test("T547: allows git commit with state file name in message", function() {
+  resetCounter();
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: { command: "git commit -m 'fix uncommitted-edit-count handling'" } });
+  // git commit is handled by the commit handler, not the tamper detector
+  assert(r === null, "should allow git commit even if message mentions state file");
+});
+
+test("T547: HMAC integrity violation detected on git commit", function() {
+  var dir = createTempRepo("main", []);
+  process.env.CLAUDE_PROJECT_DIR = dir;
+  // Write counter with an HMAC field but wrong value (simulates external tampering)
+  fs.writeFileSync(COUNTER_FILE, JSON.stringify({
+    count: 0, ts: new Date().toISOString(), worktreeRequired: false, hmac: "deadbeef12345678"
+  }));
+
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: { command: "git commit -m 'after tamper'" } });
+  assert(r !== null, "should block");
+  assert(r.decision === "block", "should be block decision");
+  assert(r.reason.indexOf("INTEGRITY VIOLATION") !== -1,
+    "should mention integrity violation, got: " + r.reason.substring(0, 150));
+
+  cleanupRepo(dir);
+});
+
+test("T547: HMAC integrity violation detected on file edit", function() {
+  // Write counter with bad HMAC at count=0 — the edit should detect tamper on read
+  fs.writeFileSync(COUNTER_FILE, JSON.stringify({
+    count: 0, ts: new Date().toISOString(), worktreeRequired: true, hmac: "baadcafe00000000"
+  }));
+
+  var gate = loadGate();
+  var r = gate({ tool_name: "Edit", tool_input: { file_path: "/tmp/test.js", old_string: "a", new_string: "b" } });
+  assert(r !== null, "should block");
+  assert(r.reason.indexOf("INTEGRITY VIOLATION") !== -1,
+    "should mention integrity violation, got: " + r.reason.substring(0, 150));
+});
+
+test("T547: legacy counter (no HMAC) treated as valid", function() {
+  // Write counter without HMAC field — legacy format should be trusted
+  fs.writeFileSync(COUNTER_FILE, JSON.stringify({
+    count: 5, ts: new Date().toISOString(), worktreeRequired: false
+  }));
+
+  var gate = loadGate();
+  var r = gate({ tool_name: "Edit", tool_input: { file_path: "/tmp/test.js", old_string: "a", new_string: "b" } });
+  assert(r === null, "should pass (legacy counter, count only 6)");
+  var data = JSON.parse(fs.readFileSync(COUNTER_FILE, "utf-8"));
+  assert(data.count === 6, "counter should increment to 6");
+  assert(data.hmac, "should now have HMAC after gate writes");
+});
+
+test("T547: counter written by gate passes HMAC check on re-read", function() {
+  // Let the gate write a counter, then read it back — should not be tampered
+  resetCounter();
+  var gate = loadGate();
+  gate({ tool_name: "Edit", tool_input: { file_path: "/tmp/test.js", old_string: "a", new_string: "b" } });
+  // Now the counter has count=1 with valid HMAC. Another edit should work fine.
+  gate = loadGate();
+  var r = gate({ tool_name: "Edit", tool_input: { file_path: "/tmp/test2.js", old_string: "a", new_string: "b" } });
+  assert(r === null, "should pass (count=2, valid HMAC)");
+  var data = JSON.parse(fs.readFileSync(COUNTER_FILE, "utf-8"));
+  assert(data.count === 2, "counter should be 2");
+});
+
+// --- T547: Walk-up worktree detection ---
+
+test("T547: isInWorktree detects worktree from subdirectory of worktree root", function() {
+  // Create a main checkout, then create a fake worktree as a subdirectory
+  var mainDir = createTempRepo("main", []);
+  var worktreeDir = path.join(mainDir, ".claude", "worktrees", "test-wt");
+  fs.mkdirSync(worktreeDir, { recursive: true });
+  // Make the worktree's .git a file (the worktree marker)
+  var realGitDir = path.join(os.tmpdir(), "fake-git-walk-" + Date.now());
+  fs.mkdirSync(realGitDir, { recursive: true });
+  fs.writeFileSync(path.join(realGitDir, "HEAD"), "ref: refs/heads/test-branch\n");
+  fs.writeFileSync(path.join(worktreeDir, ".git"), "gitdir: " + realGitDir);
+
+  // Create a subdirectory inside the worktree (simulates CWD being deeper)
+  var subDir = path.join(worktreeDir, "src", "components");
+  fs.mkdirSync(subDir, { recursive: true });
+
+  // Point CLAUDE_PROJECT_DIR at main checkout (like real EnterWorktree does)
+  process.env.CLAUDE_PROJECT_DIR = mainDir;
+  var origCwd = process.cwd();
+  // Set CWD to subdirectory of worktree
+  process.chdir(subDir);
+
+  // The counter needs worktreeRequired + high count to trigger isInWorktree check
+  setCounter(14);
+  // Create dirty files in the main repo so git diff > 0
+  fs.mkdirSync(path.join(mainDir, "src"), { recursive: true });
+  fs.writeFileSync(path.join(mainDir, "src/app.js"), "dirty");
+  cp.execFileSync("git", ["add", "src/app.js"], { cwd: mainDir, windowsHide: true });
+
+  var gate = loadGate();
+  // Use git commit which checks isInWorktree via worktreeRequired path
+  fs.writeFileSync(COUNTER_FILE, JSON.stringify({
+    count: 15, ts: new Date().toISOString(), worktreeRequired: true
+  }));
+  var r = gate({ tool_name: "Bash", tool_input: { command: "git commit -m 'test'" } });
+
+  process.chdir(origCwd);
+
+  // Should NOT block — we're in a worktree (walk-up should find .git file)
+  assert(r === null, "should allow commit — walk-up should detect worktree from subdirectory, got: " +
+    (r ? r.reason.substring(0, 150) : "null"));
+
+  fs.rmSync(realGitDir, { recursive: true, force: true });
+  cleanupRepo(mainDir);
+});
+
+test("T547: isInWorktree returns false when CWD is in main checkout subdirectory", function() {
+  // Main checkout with .git directory (not file) — walking up should find .git dir and return false
+  var dir = createTempRepo("build-src-utils", ["src/utils.js"]);
+  process.env.CLAUDE_PROJECT_DIR = dir;
+  var subDir = path.join(dir, "src");
+  var origCwd = process.cwd();
+  process.chdir(subDir);
+
+  // Set worktreeRequired and try to commit
+  fs.writeFileSync(COUNTER_FILE, JSON.stringify({
+    count: 15, ts: new Date().toISOString(), worktreeRequired: true
+  }));
+
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: { command: "git commit -m 'test'" } });
+  process.chdir(origCwd);
+
+  // Should block — we're in main checkout (walk-up finds .git dir, not file)
+  assert(r !== null, "should block — main checkout subdir is not a worktree");
+  assert(r.reason.indexOf("WORKTREE REQUIRED") !== -1, "should say WORKTREE REQUIRED");
+
+  cleanupRepo(dir);
+});
+
 // --- Cleanup ---
 process.env.CLAUDE_PROJECT_DIR = origProjectDir || "";
 process.env.HOOK_RUNNER_TEST = origTestEnv || "";


### PR DESCRIPTION
## Summary
- **Worktree detection**: `isInWorktree()` now walks up the directory tree via `findWorktreeGitFile()` instead of only checking immediate `.git`. Falls back to `git rev-parse --git-dir` to detect worktree paths. Fixes deadlock where gate could not recognize session was in a worktree.
- **Counter bypass prevention**: Added HMAC integrity check on counter state file — external writes (via `node -e`, etc.) are detected and worktreeRequired flag is restored. Bash commands referencing state file names are blocked (excluding VCS operations).

## Test plan
- [x] 30/30 commit-counter-gate tests pass (was 21, +9 new)
- [x] 1273/1274 full suite pass (T042 marketplace version pre-existing)
- [x] Synced to live hooks