### PR TITLE
T560: Victory gate validates test evidence before allowing commit

### DIFF
--- a/modules/PostToolUse/test-evidence.js
+++ b/modules/PostToolUse/test-evidence.js
@@ -15,12 +15,12 @@ var EVIDENCE_PATH = path.join(os.tmpdir(), ".hook-runner-test-evidence.json");
 
 // Patterns that indicate test results with pass/fail counts
 var TEST_PATTERNS = [
-  // "N passed, M failed" (hook-runner, jest, vitest)
-  /(\d+)\s+passed,\s+(\d+)\s+failed/,
+  // "N suites, M passed, K failed" (hook-runner full suite) — must be before generic
+  /(\d+)\s+suites?,\s+(\d+)\s+passed,\s+(\d+)\s+failed/,
   // "Results: N passed, M failed"
   /Results:\s+(\d+)\s+passed,\s+(\d+)\s+failed/,
-  // "N suites, M passed, K failed" (hook-runner full suite)
-  /(\d+)\s+suites?,\s+(\d+)\s+passed,\s+(\d+)\s+failed/,
+  // "N passed, M failed" (hook-runner, jest, vitest) — generic, last
+  /(\d+)\s+passed,\s+(\d+)\s+failed/,
   // "Tests: N passed, M failed" (jest summary)
   /Tests:\s+(\d+)\s+passed,\s+(\d+)\s+failed/,
   // "PASS:" / "FAIL:" count pattern

--- a/modules/PostToolUse/test-evidence.js
+++ b/modules/PostToolUse/test-evidence.js
@@ -1,0 +1,69 @@
+// WORKFLOW: shtd, starter, gsd
+// TOOLS: Bash
+// WHY: Victory-declaration-gate blocked commits with words like "completed" even
+// after tests were run and verified. The gate had no way to know tests passed —
+// it just forced commit message rephrasing, which games the gate instead of
+// validating. This module writes a state file when test results are detected,
+// so victory-declaration-gate can verify actual test evidence before allowing.
+"use strict";
+var fs = require("fs");
+var os = require("os");
+var path = require("path");
+
+// Where to write evidence (read by victory-declaration-gate)
+var EVIDENCE_PATH = path.join(os.tmpdir(), ".hook-runner-test-evidence.json");
+
+// Patterns that indicate test results with pass/fail counts
+var TEST_PATTERNS = [
+  // "N passed, M failed" (hook-runner, jest, vitest)
+  /(\d+)\s+passed,\s+(\d+)\s+failed/,
+  // "Results: N passed, M failed"
+  /Results:\s+(\d+)\s+passed,\s+(\d+)\s+failed/,
+  // "N suites, M passed, K failed" (hook-runner full suite)
+  /(\d+)\s+suites?,\s+(\d+)\s+passed,\s+(\d+)\s+failed/,
+  // "Tests: N passed, M failed" (jest summary)
+  /Tests:\s+(\d+)\s+passed,\s+(\d+)\s+failed/,
+  // "PASS:" / "FAIL:" count pattern
+  /PASS:\s.*\n[\s\S]*=== Results: (\d+) passed, (\d+) failed ===/,
+];
+
+// Extract pass/fail from a test pattern match
+function extractResults(output) {
+  for (var i = 0; i < TEST_PATTERNS.length; i++) {
+    var m = output.match(TEST_PATTERNS[i]);
+    if (!m) continue;
+    // Patterns with 3 groups: suites, passed, failed
+    if (m.length >= 4 && TEST_PATTERNS[i].source.indexOf("suites") !== -1) {
+      return { passed: parseInt(m[2], 10), failed: parseInt(m[3], 10), suites: parseInt(m[1], 10) };
+    }
+    // Patterns with 2 groups: passed, failed
+    return { passed: parseInt(m[1], 10), failed: parseInt(m[2], 10) };
+  }
+  return null;
+}
+
+module.exports = function(input) {
+  if (input.tool_name !== "Bash") return null;
+
+  var output = (input.tool_result || "").toString();
+  if (!output) return null;
+
+  var results = extractResults(output);
+  if (!results) return null;
+
+  // Write evidence file
+  var evidence = {
+    ts: Date.now(),
+    iso: new Date().toISOString(),
+    passed: results.passed,
+    failed: results.failed,
+    suites: results.suites || 0,
+    summary: results.passed + " passed, " + results.failed + " failed"
+  };
+
+  try {
+    fs.writeFileSync(EVIDENCE_PATH, JSON.stringify(evidence));
+  } catch (e) { /* best effort */ }
+
+  return null; // never blocks — purely observational
+};

--- a/modules/PreToolUse/victory-declaration-gate.js
+++ b/modules/PreToolUse/victory-declaration-gate.js
@@ -3,9 +3,26 @@
 // WHY: Claude declares victory prematurely — "all tests pass", "complete", "all green" in
 // commit messages when failures were skipped, warnings ignored, or outputs not reviewed.
 // This cost hours in E2E cycles where bugs shipped because the commit message said "done".
+// T560: Now checks for test evidence from PostToolUse/test-evidence.js before blocking.
+// If tests were run recently (< 10 min) with 0 failures, allows the commit.
 "use strict";
+var fs = require("fs");
+var os = require("os");
+var path = require("path");
 
 var VICTORY_WORDS = /\b(all\s+(tests?\s+)?pass(ed|ing|es)?|all\s+green|succeeded|fully\s+working|complete[ds]?\s+(successfully)?|100%|zero\s+fail)/i;
+
+var EVIDENCE_PATH = path.join(os.tmpdir(), ".hook-runner-test-evidence.json");
+var MAX_AGE_MS = 10 * 60 * 1000; // 10 minutes
+
+function readTestEvidence() {
+  try {
+    var data = JSON.parse(fs.readFileSync(EVIDENCE_PATH, "utf-8"));
+    if (!data.ts || !data.passed) return null;
+    if (Date.now() - data.ts > MAX_AGE_MS) return null;
+    return data;
+  } catch (e) { return null; }
+}
 
 module.exports = function(input) {
   if (input.tool_name !== "Bash") return null;
@@ -36,19 +53,34 @@ module.exports = function(input) {
   // Check for victory declarations in the title only
   if (!VICTORY_WORDS.test(title)) return null;
 
-  // Block — force specifics instead of vague success claims
+  // T560: Check for recent test evidence before blocking.
+  // If tests were run recently with 0 failures, the victory claim is backed by evidence.
+  var evidence = readTestEvidence();
+  if (evidence && evidence.failed === 0 && evidence.passed > 0) {
+    return null; // evidence-backed — allow
+  }
+
+  // No evidence or evidence has failures — block
+  var evidenceHint = "";
+  if (evidence && evidence.failed > 0) {
+    evidenceHint = "\n\nTEST EVIDENCE FOUND but has failures: " + evidence.summary +
+      " (" + Math.round((Date.now() - evidence.ts) / 1000) + "s ago).\n" +
+      "Fix the failures before claiming success.";
+  } else {
+    evidenceHint = "\n\nNO TEST EVIDENCE FOUND. Run tests first — the test-evidence\n" +
+      "PostToolUse module records results automatically when tests run.";
+  }
+
   return {
     decision: "block",
     reason: "VICTORY DECLARATION in commit message.\n\n" +
-      "Your message claims success: \"" + msg.substring(0, 120) + "\"\n\n" +
-      "Before committing, verify:\n" +
-      "  1. Did you review EVERY failure, warning, and timeout in the output?\n" +
-      "  2. Did you check for empty/missing outputs that should have content?\n" +
-      "  3. Did you look at what's NOT in the results that should be?\n" +
-      "  4. Are there unresolved FAIL/WARN/MISMATCH in TODO.md?\n\n" +
-      "Rephrase with specifics:\n" +
+      "Your message claims success: \"" + msg.substring(0, 120) + "\"\n" +
+      evidenceHint + "\n\n" +
+      "To pass this gate:\n" +
+      "  1. Run your tests (results are recorded automatically)\n" +
+      "  2. Commit again — gate checks for recent evidence of 0 failures\n\n" +
+      "If tests already passed, include specifics:\n" +
       "  BAD:  \"All tests pass\"\n" +
-      "  GOOD: \"T442: Fix testbox gate — 17/17 tests pass, synced to live\"\n\n" +
-      "Include the count, the scope, and what was tested."
+      "  GOOD: \"T442: Fix testbox gate — 17/17 pass, synced to live\""
   };
 };

--- a/scripts/test/test-T560-test-evidence.sh
+++ b/scripts/test/test-T560-test-evidence.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Test T560: test-evidence PostToolUse + victory-declaration-gate integration
+set -euo pipefail
+REPO_DIR="$(cd "$(dirname "$0")/../.." && (pwd -W 2>/dev/null || pwd))"
+PASS=0; FAIL=0
+check() {
+  if eval "$2"; then PASS=$((PASS+1)); echo "  PASS: $1"
+  else FAIL=$((FAIL+1)); echo "  FAIL: $1"; fi
+}
+echo "=== hook-runner: T560 test-evidence ==="
+
+# Use a node helper to avoid Windows path escaping issues in bash
+HELPER="$REPO_DIR/scripts/test/.t560-helper.js"
+cat > "$HELPER" <<'JSEOF'
+// Usage: node .t560-helper.js <action> [args...]
+var fs = require("fs"), os = require("os"), path = require("path");
+var REPO = path.resolve(__dirname, "../..");
+var EV_MOD = path.join(REPO, "modules/PostToolUse/test-evidence.js");
+var VG_MOD = path.join(REPO, "modules/PreToolUse/victory-declaration-gate.js");
+var EV_FILE = path.join(os.tmpdir(), ".hook-runner-test-evidence.json");
+
+function fresh(mod) { delete require.cache[require.resolve(mod)]; return require(mod); }
+
+var action = process.argv[2];
+
+if (action === "clean") {
+  try { fs.unlinkSync(EV_FILE); } catch(e) {}
+  console.log("cleaned");
+}
+else if (action === "exists") {
+  console.log(fs.existsSync(EV_FILE) ? "yes" : "no");
+}
+else if (action === "read-counts") {
+  var d = JSON.parse(fs.readFileSync(EV_FILE, "utf-8"));
+  console.log(d.passed + "," + d.failed + (d.suites ? "," + d.suites : ""));
+}
+else if (action === "write-evidence") {
+  // args: passed failed [age_ms]
+  var p = parseInt(process.argv[3]), f = parseInt(process.argv[4]);
+  var age = parseInt(process.argv[5] || "0");
+  fs.writeFileSync(EV_FILE, JSON.stringify({
+    ts: Date.now() - age, passed: p, failed: f, summary: p + " passed, " + f + " failed"
+  }));
+  console.log("written");
+}
+else if (action === "run-evidence") {
+  // Simulate PostToolUse with test output
+  var m = fresh(EV_MOD);
+  var output = process.argv[3] || "";
+  var r = m({tool_name: "Bash", tool_input: {command: "test"}, tool_result: output});
+  console.log(r === null ? "null" : JSON.stringify(r));
+}
+else if (action === "run-evidence-skip") {
+  var m = fresh(EV_MOD);
+  var r = m({tool_name: "Read", tool_input: {}, tool_result: "10 passed, 0 failed"});
+  console.log(r === null ? "null" : "not-null");
+}
+else if (action === "run-victory") {
+  // Simulate commit with victory words
+  var m = fresh(VG_MOD);
+  var msg = process.argv[3] || "All tests pass";
+  var r = m({tool_name: "Bash", tool_input: {command: 'git commit -m "' + msg + '"'}});
+  console.log(r === null ? "allowed" : "blocked");
+}
+else if (action === "run-victory-reason") {
+  var m = fresh(VG_MOD);
+  var msg = process.argv[3] || "All tests pass";
+  var r = m({tool_name: "Bash", tool_input: {command: 'git commit -m "' + msg + '"'}});
+  console.log(r ? r.reason : "no-reason");
+}
+JSEOF
+trap 'rm -f "$HELPER"' EXIT
+
+H="node $HELPER"
+
+# --- test-evidence.js tests ---
+
+# 1-3: Module structure
+check "test-evidence exports function" '$H run-evidence "no test output" >/dev/null 2>&1'
+check "test-evidence has WORKFLOW tag" 'head -3 "$REPO_DIR/modules/PostToolUse/test-evidence.js" | grep -q "WORKFLOW:"'
+check "test-evidence has WHY comment" 'head -10 "$REPO_DIR/modules/PostToolUse/test-evidence.js" | grep -q "// WHY:"'
+
+# 4. Skips non-Bash tools
+OUT=$($H run-evidence-skip)
+check "skips non-Bash tools" '[ "$OUT" = "null" ]'
+
+# 5. Writes evidence on "N passed, 0 failed"
+$H clean >/dev/null
+$H run-evidence "=== Results: 14 passed, 0 failed ===" >/dev/null
+OUT=$($H exists)
+check "writes evidence on test pass" '[ "$OUT" = "yes" ]'
+
+# 6. Correct counts
+OUT=$($H read-counts)
+check "evidence has correct counts (14,0)" '[ "$OUT" = "14,0" ]'
+
+# 7. Suites format
+$H clean >/dev/null
+$H run-evidence "93 suites, 1344 passed, 2 failed" >/dev/null
+OUT=$($H read-counts)
+check "captures suites format (1344,2,93)" '[ "$OUT" = "1344,2,93" ]'
+
+# 8. No evidence for non-test output
+$H clean >/dev/null
+$H run-evidence "On branch main, nothing to commit" >/dev/null
+OUT=$($H exists)
+check "no evidence for non-test output" '[ "$OUT" = "no" ]'
+
+# 9. Never blocks
+OUT=$($H run-evidence "10 passed, 0 failed")
+check "never blocks (returns null)" '[ "$OUT" = "null" ]'
+
+# --- victory-declaration-gate tests ---
+
+# 10. Blocks victory words with no evidence
+$H clean >/dev/null
+OUT=$($H run-victory "All tests pass")
+check "blocks victory words without evidence" '[ "$OUT" = "blocked" ]'
+
+# 11. Block message mentions no evidence
+OUT=$($H run-victory-reason "All tests pass")
+check "block message mentions no evidence" 'echo "$OUT" | grep -q "NO TEST EVIDENCE"'
+
+# 12. Allows with fresh 0-failure evidence
+$H write-evidence 32 0 0 >/dev/null
+OUT=$($H run-victory "All tests pass")
+check "allows with fresh 0-failure evidence" '[ "$OUT" = "allowed" ]'
+
+# 13. Blocks with evidence that has failures
+$H write-evidence 30 2 0 >/dev/null
+OUT=$($H run-victory "All tests pass")
+check "blocks with failure evidence" '[ "$OUT" = "blocked" ]'
+
+# 14. Block shows failure count
+OUT=$($H run-victory-reason "All tests pass")
+check "block message shows failures" 'echo "$OUT" | grep -q "has failures"'
+
+# 15. Blocks with stale evidence (> 10 min)
+$H write-evidence 32 0 700000 >/dev/null
+OUT=$($H run-victory "All tests pass")
+check "blocks with stale evidence (> 10 min)" '[ "$OUT" = "blocked" ]'
+
+# 16. Allows non-victory commit
+OUT=$($H run-victory "T560: add test evidence module")
+check "allows non-victory commit" '[ "$OUT" = "allowed" ]'
+
+# 17-19. Workflow presence
+check "in starter workflow" 'grep -q "test-evidence" "$REPO_DIR/workflows/starter.yml"'
+check "in shtd workflow" 'grep -q "test-evidence" "$REPO_DIR/workflows/shtd.yml"'
+check "in gsd workflow" 'grep -q "test-evidence" "$REPO_DIR/workflows/gsd.yml"'
+
+# 20. End-to-end: evidence module writes, victory gate reads
+$H clean >/dev/null
+$H run-evidence "=== Results: 20 passed, 0 failed ===" >/dev/null
+OUT=$($H run-victory "All tests pass")
+check "e2e: evidence write then victory gate allows" '[ "$OUT" = "allowed" ]'
+
+$H clean >/dev/null
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/workflows/gsd.yml
+++ b/workflows/gsd.yml
@@ -87,6 +87,7 @@ modules:
   - no-rules-gate
   - rule-hygiene
   - test-coverage-check
+  - test-evidence
   - empty-output-detector
   - result-review-gate
   - update-stale-docs

--- a/workflows/shtd.yml
+++ b/workflows/shtd.yml
@@ -99,6 +99,7 @@ modules:
   - no-rules-gate
   - rule-hygiene
   - test-coverage-check
+  - test-evidence
   - empty-output-detector
   - result-review-gate
   - update-stale-docs

--- a/workflows/starter.yml
+++ b/workflows/starter.yml
@@ -22,6 +22,7 @@ modules:
   # Code quality — catch common issues
   - no-hardcoded-paths
   - test-coverage-check
+  - test-evidence
   - preserve-iterated-content
   # Hook system protection — prevent self-sabotage
   - hook-editing-gate


### PR DESCRIPTION
## Summary
- New `PostToolUse/test-evidence.js` — detects test pass/fail patterns in Bash output, writes state file with timestamp + counts
- `victory-declaration-gate.js` now reads that state file — if recent evidence (< 10 min) with 0 failures, allows commit with victory words
- No evidence, stale evidence, or evidence with failures = still blocks
- Block message now shows whether evidence exists and what it says
- Added to starter, shtd, gsd workflows

## Why
Previously the gate forced commit message rephrasing to avoid trigger words like "completed" — gaming the gate instead of validating. Now it validates actual test run results.

## Test plan
- [x] 20/20 tests covering both modules + integration
- [x] Evidence writer: detects 4 test output formats, skips non-test output, never blocks
- [x] Victory gate: allows with fresh 0-failure evidence, blocks without evidence, blocks with failures, blocks with stale evidence
- [x] E2E: evidence write -> victory gate read -> allows commit