### PR TITLE
T549: Add background-task-audit PostToolUse module

### DIFF
--- a/modules.yaml
+++ b/modules.yaml
@@ -42,6 +42,7 @@ modules:
     - rule-hygiene           # validates rule files are granular
     - commit-msg-check       # blocks WIP/fixup commits and over-long first lines
     - test-coverage-check    # warns when source files with tests are modified
+    - background-task-audit  # blocks when background tasks return zero output
 
   Stop:
     - auto-continue          # never stop, always find next task

--- a/modules/PostToolUse/background-task-audit.js
+++ b/modules/PostToolUse/background-task-audit.js
@@ -1,0 +1,91 @@
+// WORKFLOW: shtd, starter
+// TOOLS: TaskOutput
+// WHY: Claude dismisses zero-output background tasks as "resource contention" or
+// "probably hanging" without investigating root cause. Zero output from a background
+// task means the command never started, crashed at import, or is deadlocked — all of
+// which have specific root causes that must be identified. User corrected this pattern
+// 3 times in dd-lab session 22 (2026-05-03).
+//
+// Evidence: Tasks bjgkq9h59 and batytrlvx both returned zero bytes from TaskOutput.
+// Claude said "likely resource contention" and tried to "commit what works and move on"
+// instead of investigating why Playwright hung on t1-ddei-002 but not t2-ddei-001.
+// User: "dont assume anything and move on... investigate and resolve root cause"
+"use strict";
+
+module.exports = function(input) {
+  if (input.tool_name !== "TaskOutput") return null;
+
+  var result = (input.tool_result || "").toString();
+
+  // Parse structured TaskOutput fields
+  var status = (result.match(/<status>(\w+)<\/status>/) || [])[1] || "";
+  var retrieval = (result.match(/<retrieval_status>(\w+)<\/retrieval_status>/) || [])[1] || "";
+  var taskId = (result.match(/<task_id>([^<]+)<\/task_id>/) || [])[1] || "unknown";
+  var output = (result.match(/<output>([\s\S]*?)<\/output>/) || [])[1] || "";
+  output = output.trim();
+
+  // Case 1: Task completed with zero output
+  if (status === "completed" && output.length === 0) {
+    return {
+      decision: "block",
+      reason: "ZERO OUTPUT from completed background task " + taskId + ".\n\n" +
+        "A completed task with no output means one of:\n" +
+        "  - Script crashed before printing (import error, missing module)\n" +
+        "  - stdout not flushed (add PYTHONUNBUFFERED=1 env var)\n" +
+        "  - Wrong command/path\n" +
+        "  - Process was killed before output was captured\n\n" +
+        "REQUIRED: Run the same command in foreground with PYTHONUNBUFFERED=1\n" +
+        "and a timeout to see the actual error. Do NOT assume or move on."
+    };
+  }
+
+  // Case 2: Timeout with zero output
+  if (retrieval === "timeout" && output.length === 0) {
+    return {
+      decision: "block",
+      reason: "TIMEOUT + ZERO OUTPUT from background task " + taskId + ".\n\n" +
+        "The task produced nothing before timing out. Root causes:\n" +
+        "  - Process hanging at startup (import, SSH connect, auth prompt)\n" +
+        "  - stdout buffering hiding output (use PYTHONUNBUFFERED=1)\n" +
+        "  - Blocked on stdin or interactive prompt\n" +
+        "  - Network timeout (tunnel dead, port closed)\n\n" +
+        "REQUIRED: Stop the task. Run in foreground with short timeout\n" +
+        "and PYTHONUNBUFFERED=1 to find where it hangs.\n" +
+        "Do NOT dismiss as 'resource contention' or 'probably busy'."
+    };
+  }
+
+  // Case 3: Still running, checked multiple times, still zero output
+  // Track check count per task
+  if (retrieval === "not_ready" && output.length === 0) {
+    var fs = require("fs");
+    var os = require("os");
+    var path = require("path");
+    var stateFile = path.join(os.tmpdir(), ".bg-task-audit-" + taskId.replace(/[^a-z0-9]/gi, ""));
+
+    var checkCount = 0;
+    try {
+      var prev = JSON.parse(fs.readFileSync(stateFile, "utf-8"));
+      checkCount = (prev.checks || 0) + 1;
+    } catch(e) {
+      checkCount = 1;
+    }
+
+    try {
+      fs.writeFileSync(stateFile, JSON.stringify({ checks: checkCount, ts: Date.now() }));
+    } catch(e) { /* ignore write failure */ }
+
+    if (checkCount >= 2) {
+      return {
+        decision: "block",
+        reason: "BACKGROUND TASK " + taskId + " polled " + checkCount +
+          " times with ZERO output.\n\n" +
+          "The task is running but has produced nothing after multiple checks.\n" +
+          "REQUIRED: Stop the task. Run the command in foreground to find the hang point.\n" +
+          "Do NOT keep polling. Do NOT assume 'still starting up'."
+      };
+    }
+  }
+
+  return null;
+};

--- a/scripts/test/.t549-helper.js
+++ b/scripts/test/.t549-helper.js
@@ -1,0 +1,109 @@
+var fs = require('fs'), os = require('os'), path = require('path');
+var REPO = path.resolve(__dirname, '../..');
+var MOD_PATH = path.join(REPO, 'modules/PostToolUse/background-task-audit.js');
+
+function fresh() { delete require.cache[require.resolve(MOD_PATH)]; return require(MOD_PATH); }
+function cleanState(taskId) {
+  var safe = (taskId || '').replace(/[^a-z0-9]/gi, '');
+  var f = path.join(os.tmpdir(), '.bg-task-audit-' + safe);
+  try { fs.unlinkSync(f); } catch(e) {}
+}
+
+var action = process.argv[2];
+
+if (action === 'skip-non-taskoutput') {
+  var m = fresh();
+  var r = m({tool_name: 'Bash', tool_input: {command: 'test'}, tool_result: 'output'});
+  console.log(r === null ? 'null' : 'not-null');
+}
+else if (action === 'completed-zero-output') {
+  var m = fresh();
+  var r = m({tool_name: 'TaskOutput', tool_result:
+    '<status>completed</status><retrieval_status>success</retrieval_status>' +
+    '<task_id>test123</task_id><output></output>'});
+  console.log(r ? r.decision : 'null');
+}
+else if (action === 'completed-zero-reason') {
+  var m = fresh();
+  var r = m({tool_name: 'TaskOutput', tool_result:
+    '<status>completed</status><retrieval_status>success</retrieval_status>' +
+    '<task_id>test123</task_id><output></output>'});
+  console.log(r ? r.reason : 'no-reason');
+}
+else if (action === 'completed-with-output') {
+  var m = fresh();
+  var r = m({tool_name: 'TaskOutput', tool_result:
+    '<status>completed</status><retrieval_status>success</retrieval_status>' +
+    '<task_id>test456</task_id><output>Build succeeded</output>'});
+  console.log(r === null ? 'null' : r.decision);
+}
+else if (action === 'timeout-zero-output') {
+  var m = fresh();
+  var r = m({tool_name: 'TaskOutput', tool_result:
+    '<status>running</status><retrieval_status>timeout</retrieval_status>' +
+    '<task_id>test789</task_id><output></output>'});
+  console.log(r ? r.decision : 'null');
+}
+else if (action === 'timeout-zero-reason') {
+  var m = fresh();
+  var r = m({tool_name: 'TaskOutput', tool_result:
+    '<status>running</status><retrieval_status>timeout</retrieval_status>' +
+    '<task_id>test789</task_id><output></output>'});
+  console.log(r ? r.reason : 'no-reason');
+}
+else if (action === 'timeout-with-output') {
+  var m = fresh();
+  var r = m({tool_name: 'TaskOutput', tool_result:
+    '<status>running</status><retrieval_status>timeout</retrieval_status>' +
+    '<task_id>test789b</task_id><output>Partial output here</output>'});
+  console.log(r === null ? 'null' : r.decision);
+}
+else if (action === 'not-ready-first') {
+  cleanState('poll1');
+  var m = fresh();
+  var r = m({tool_name: 'TaskOutput', tool_result:
+    '<status>running</status><retrieval_status>not_ready</retrieval_status>' +
+    '<task_id>poll1</task_id><output></output>'});
+  console.log(r === null ? 'null' : r.decision);
+}
+else if (action === 'not-ready-second') {
+  var m = fresh();
+  var r = m({tool_name: 'TaskOutput', tool_result:
+    '<status>running</status><retrieval_status>not_ready</retrieval_status>' +
+    '<task_id>poll1</task_id><output></output>'});
+  console.log(r ? r.decision : 'null');
+}
+else if (action === 'not-ready-second-reason') {
+  var m = fresh();
+  var r = m({tool_name: 'TaskOutput', tool_result:
+    '<status>running</status><retrieval_status>not_ready</retrieval_status>' +
+    '<task_id>poll1</task_id><output></output>'});
+  console.log(r ? r.reason : 'no-reason');
+}
+else if (action === 'not-ready-with-output') {
+  cleanState('poll2');
+  var m = fresh();
+  m({tool_name: 'TaskOutput', tool_result:
+    '<status>running</status><retrieval_status>not_ready</retrieval_status>' +
+    '<task_id>poll2</task_id><output></output>'});
+  var r = m({tool_name: 'TaskOutput', tool_result:
+    '<status>running</status><retrieval_status>not_ready</retrieval_status>' +
+    '<task_id>poll2</task_id><output>Starting up...</output>'});
+  console.log(r === null ? 'null' : r.decision);
+}
+else if (action === 'clean-poll1') {
+  cleanState('poll1');
+  console.log('cleaned');
+}
+else if (action === 'whitespace-output') {
+  var m = fresh();
+  var r = m({tool_name: 'TaskOutput', tool_result:
+    '<status>completed</status><retrieval_status>success</retrieval_status>' +
+    '<task_id>ws1</task_id><output>   \n  \n  </output>'});
+  console.log(r ? r.decision : 'null');
+}
+else if (action === 'no-tool-result') {
+  var m = fresh();
+  var r = m({tool_name: 'TaskOutput', tool_result: undefined});
+  console.log(r === null ? 'null' : r.decision);
+}

--- a/scripts/test/test-T549-background-task-audit.sh
+++ b/scripts/test/test-T549-background-task-audit.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Test T549: background-task-audit PostToolUse module
+set -euo pipefail
+REPO_DIR="$(cd "$(dirname "$0")/../.." && (pwd -W 2>/dev/null || pwd))"
+PASS=0; FAIL=0
+check() {
+  if eval "$2"; then PASS=$((PASS+1)); echo "  PASS: $1"
+  else FAIL=$((FAIL+1)); echo "  FAIL: $1"; fi
+}
+echo "=== hook-runner: T549 background-task-audit ==="
+
+MOD="$REPO_DIR/modules/PostToolUse/background-task-audit.js"
+H="node $REPO_DIR/scripts/test/.t549-helper.js"
+
+# --- Module structure ---
+check "exports function" 'node -e "var m = require(process.argv[1]); process.exit(typeof m === \"function\" ? 0 : 1)" "$MOD" 2>/dev/null'
+check "has WORKFLOW tag" 'head -3 "$MOD" | grep -q "WORKFLOW:"'
+check "has WHY comment" 'head -10 "$MOD" | grep -q "// WHY:"'
+check "has TOOLS: TaskOutput tag" 'head -3 "$MOD" | grep -q "TOOLS:.*TaskOutput"'
+
+# --- Tool filtering ---
+OUT=$($H skip-non-taskoutput)
+check "skips non-TaskOutput tools" '[ "$OUT" = "null" ]'
+
+# --- Case 1: Completed with zero output ---
+OUT=$($H completed-zero-output)
+check "blocks completed + zero output" '[ "$OUT" = "block" ]'
+
+OUT=$($H completed-zero-reason)
+check "reason mentions ZERO OUTPUT" 'echo "$OUT" | grep -qi "ZERO OUTPUT"'
+
+OUT=$($H completed-zero-reason)
+check "reason suggests foreground run" 'echo "$OUT" | grep -qi "foreground"'
+
+OUT=$($H completed-with-output)
+check "allows completed + has output" '[ "$OUT" = "null" ]'
+
+OUT=$($H whitespace-output)
+check "whitespace-only output = zero" '[ "$OUT" = "block" ]'
+
+# --- Case 2: Timeout with zero output ---
+OUT=$($H timeout-zero-output)
+check "blocks timeout + zero output" '[ "$OUT" = "block" ]'
+
+OUT=$($H timeout-zero-reason)
+check "timeout reason mentions hang" 'echo "$OUT" | grep -qi "hang"'
+
+OUT=$($H timeout-with-output)
+check "allows timeout + partial output" '[ "$OUT" = "null" ]'
+
+# --- Case 3: Repeated not_ready polls ---
+$H clean-poll1 >/dev/null
+OUT=$($H not-ready-first)
+check "first not_ready poll allowed" '[ "$OUT" = "null" ]'
+
+OUT=$($H not-ready-second)
+check "second not_ready poll blocks" '[ "$OUT" = "block" ]'
+
+OUT=$($H not-ready-second-reason)
+check "block reason mentions poll count" 'echo "$OUT" | grep -q "polled"'
+
+OUT=$($H not-ready-with-output)
+check "not_ready + output on 2nd check allowed" '[ "$OUT" = "null" ]'
+
+# --- Edge cases ---
+OUT=$($H no-tool-result)
+check "handles undefined tool_result" '[ "$OUT" = "null" ]'
+
+# --- Workflow presence ---
+check "in starter workflow" 'grep -q "background-task-audit" "$REPO_DIR/workflows/starter.yml"'
+check "in shtd workflow" 'grep -q "background-task-audit" "$REPO_DIR/workflows/shtd.yml"'
+check "in gsd workflow" 'grep -q "background-task-audit" "$REPO_DIR/workflows/gsd.yml"'
+
+# --- README ---
+check "in README module table" 'grep -q "background-task-audit" "$REPO_DIR/README.md"'
+
+# Cleanup
+$H clean-poll1 >/dev/null 2>&1 || true
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/workflows/gsd.yml
+++ b/workflows/gsd.yml
@@ -88,6 +88,7 @@ modules:
   - rule-hygiene
   - test-coverage-check
   - test-evidence
+  - background-task-audit
   - empty-output-detector
   - result-review-gate
   - update-stale-docs

--- a/workflows/shtd.yml
+++ b/workflows/shtd.yml
@@ -100,6 +100,7 @@ modules:
   - rule-hygiene
   - test-coverage-check
   - test-evidence
+  - background-task-audit
   - empty-output-detector
   - result-review-gate
   - update-stale-docs

--- a/workflows/starter.yml
+++ b/workflows/starter.yml
@@ -23,6 +23,7 @@ modules:
   - no-hardcoded-paths
   - test-coverage-check
   - test-evidence
+  - background-task-audit
   - preserve-iterated-content
   # Hook system protection — prevent self-sabotage
   - hook-editing-gate


### PR DESCRIPTION
## Summary
- New `background-task-audit` PostToolUse module that blocks when background tasks (TaskOutput) return zero output
- Forces root cause investigation instead of dismissing as "resource contention" or "probably hanging"
- Three detection cases: completed+zero output, timeout+zero output, repeated not_ready polling with zero output
- Added to starter, shtd, and gsd workflows
- 22 tests covering all cases + edge cases

## Test plan
- [x] 22/22 tests pass (`test-T549-background-task-audit.sh`)
- [x] Module structure validated (WORKFLOW tag, WHY comment, TOOLS tag)
- [x] Workflow presence verified (starter, shtd, gsd)
- [x] README already has entry (added in T559)