### PR TITLE
T558: Per-project lesson files for self-reflection

### DIFF
--- a/modules/SessionStart/load-lessons.js
+++ b/modules/SessionStart/load-lessons.js
@@ -9,12 +9,37 @@ var path = require("path");
 var os = require("os");
 
 var CLAUDE_DIR = path.join(os.homedir(), ".claude");
-var LESSONS_FILE = path.join(CLAUDE_DIR, "hooks", "self-analysis-lessons.jsonl");
+var GLOBAL_LESSONS_FILE = path.join(CLAUDE_DIR, "hooks", "self-analysis-lessons.jsonl");
 var ERROR_LOG = path.join(CLAUDE_DIR, "self-analysis-errors.log");
 var ANALYSIS_LOG = path.join(CLAUDE_DIR, "self-analysis.log");
 var MAX_LESSONS = 20; // inject the 20 most recent (T352: increased from 10)
 var MAX_LINES = 200; // rotate when file exceeds this (T351)
 var ARCHIVE_FILE = path.join(CLAUDE_DIR, "hooks", "self-analysis-lessons-archive.jsonl");
+
+// T558: Per-project lessons — each project gets its own lessons file
+// so DDEI lessons don't pollute dd-lab sessions and vice versa
+function getProjectLessonsFile() {
+  var projectDir = process.env.CLAUDE_PROJECT_DIR || "";
+  if (!projectDir) return null;
+  return path.join(projectDir, ".claude", "lessons.jsonl");
+}
+
+// Read lessons from a JSONL file, returning array of lesson strings
+function readLessonsFrom(filePath, maxCount) {
+  try {
+    if (!fs.existsSync(filePath)) return [];
+    var content = fs.readFileSync(filePath, "utf-8").trim();
+    if (!content) return [];
+    var lines = content.split("\n").filter(function(l) { return l.trim(); });
+    var recent = lines.slice(-maxCount);
+    return recent.map(function(line) {
+      try {
+        var obj = JSON.parse(line);
+        return obj.lesson || "";
+      } catch(e) { return ""; }
+    }).filter(function(l) { return l; });
+  } catch(e) { return []; }
+}
 
 function checkBgErrors() {
   // Surface background script errors that the user can't see
@@ -45,14 +70,19 @@ module.exports = function(input) {
   try {
     // T379: Inject self-reflection system description so Claude understands
     // how the feedback loop works and can participate in it.
+    // T558: Updated to reference per-project lessons file
+    var projectLessonsFile = getProjectLessonsFile();
+    var lessonsTarget = projectLessonsFile
+      ? projectLessonsFile.replace(/\\/g, "/")
+      : "~/.claude/hooks/self-analysis-lessons.jsonl";
     parts.push(
       "SELF-REFLECTION SYSTEM: You have a self-reflection system that runs at every Stop event.\n" +
       "How it works: (1) self-reflection.js analyzes your session — gate decisions, edits, user corrections.\n" +
-      "(2) Lessons are extracted and stored in self-analysis-lessons.jsonl.\n" +
+      "(2) Lessons are extracted and stored in per-project lessons files.\n" +
       "(3) This module (load-lessons) injects those lessons at SessionStart so you learn from past sessions.\n" +
       "(4) reflection-score.js tracks your score (clean reflections +points, corrections -points).\n" +
       "YOUR ROLE: When you learn something this session (a mistake, a better pattern, a user correction),\n" +
-      "write it to ~/.claude/hooks/self-analysis-lessons.jsonl as a JSONL line: {\"lesson\": \"...\", \"ts\": \"ISO\", \"session\": \"id\"}.\n" +
+      "write it to " + lessonsTarget + " as a JSONL line: {\"lesson\": \"...\", \"ts\": \"ISO\", \"session\": \"id\"}.\n" +
       "Future sessions will see it. Do NOT reinvent the system — it already exists and runs automatically."
     );
 
@@ -63,42 +93,43 @@ module.exports = function(input) {
         "\nInvestigate and fix these before they recur.");
     }
 
-    // T351: Rotate lessons file if it exceeds MAX_LINES
+    // T351: Rotate global lessons file if it exceeds MAX_LINES
     try {
-      if (fs.existsSync(LESSONS_FILE)) {
-        var allLines = fs.readFileSync(LESSONS_FILE, "utf-8").trim().split("\n");
+      if (fs.existsSync(GLOBAL_LESSONS_FILE)) {
+        var allLines = fs.readFileSync(GLOBAL_LESSONS_FILE, "utf-8").trim().split("\n");
         if (allLines.length > MAX_LINES) {
           var archive = allLines.slice(0, allLines.length - 100);
           var keep = allLines.slice(-100);
-          // Append old lines to archive
           fs.appendFileSync(ARCHIVE_FILE, archive.join("\n") + "\n");
-          // Overwrite lessons with recent 100
-          fs.writeFileSync(LESSONS_FILE, keep.join("\n") + "\n");
+          fs.writeFileSync(GLOBAL_LESSONS_FILE, keep.join("\n") + "\n");
         }
       }
     } catch(e) {}
 
-    // Load lessons
-    if (fs.existsSync(LESSONS_FILE)) {
-      var content = fs.readFileSync(LESSONS_FILE, "utf-8").trim();
-      if (content) {
-        var lines = content.split("\n").filter(function(l) { return l.trim(); });
-        var recent = lines.slice(-MAX_LESSONS);
-        var lessons = recent.map(function(line) {
-          try {
-            var obj = JSON.parse(line);
-            return obj.lesson || "";
-          } catch(e) {
-            return "";
-          }
-        }).filter(function(l) { return l; });
+    // T558: Load from both global and per-project, deduplicate
+    var globalLessons = readLessonsFrom(GLOBAL_LESSONS_FILE, MAX_LESSONS);
+    var projectLessons = projectLessonsFile
+      ? readLessonsFrom(projectLessonsFile, MAX_LESSONS)
+      : [];
 
-        if (lessons.length > 0) {
-          parts.push("SELF-ANALYSIS LESSONS (from past interrupt reflections):\n" +
-            lessons.join("\n") +
-            "\nApply these lessons. If you catch yourself repeating a pattern, stop and correct.");
-        }
+    // Merge: project-specific first (more relevant), then global
+    // Deduplicate by exact string match
+    var seen = {};
+    var allLessons = [];
+    var combined = projectLessons.concat(globalLessons);
+    for (var li = 0; li < combined.length; li++) {
+      if (!seen[combined[li]]) {
+        seen[combined[li]] = true;
+        allLessons.push(combined[li]);
       }
+    }
+    // Cap at MAX_LESSONS total
+    allLessons = allLessons.slice(0, MAX_LESSONS);
+
+    if (allLessons.length > 0) {
+      parts.push("SELF-ANALYSIS LESSONS (from past interrupt reflections):\n" +
+        allLessons.join("\n") +
+        "\nApply these lessons. If you catch yourself repeating a pattern, stop and correct.");
     }
   } catch(e) {}
 

--- a/modules/Stop/self-reflection.js
+++ b/modules/Stop/self-reflection.js
@@ -532,7 +532,22 @@ function writeReflection(result, gitCtx) {
 // lesson and write it to self-analysis-lessons.jsonl (immediate effect via load-lessons)
 // and corrective-feedback.jsonl (for future brain ingestion when /remember API exists).
 var CORRECTIVE_FEEDBACK_PATH = path.join(HOOKS_DIR, "corrective-feedback.jsonl");
-var LESSONS_FILE = path.join(HOOKS_DIR, "self-analysis-lessons.jsonl");
+var GLOBAL_LESSONS_FILE = path.join(HOOKS_DIR, "self-analysis-lessons.jsonl");
+
+// T558: Write lessons to per-project file when available, global as fallback
+function getLessonsFile() {
+  var projectDir = process.env.CLAUDE_PROJECT_DIR || "";
+  if (projectDir) {
+    var projectLessons = path.join(projectDir, ".claude", "lessons.jsonl");
+    // Ensure .claude dir exists
+    var claudeDir = path.join(projectDir, ".claude");
+    try {
+      if (!fs.existsSync(claudeDir)) fs.mkdirSync(claudeDir, { recursive: true });
+    } catch(e) {}
+    return projectLessons;
+  }
+  return GLOBAL_LESSONS_FILE;
+}
 
 function extractCorrectiveFeedback(result, gitCtx) {
   if (!result || !result.issues || result.issues.length === 0) return;
@@ -574,7 +589,7 @@ function extractCorrectiveFeedback(result, gitCtx) {
         source: "self-reflection-T381",
         project: project
       };
-      fs.appendFileSync(LESSONS_FILE, JSON.stringify(lessonEntry) + "\n");
+      fs.appendFileSync(getLessonsFile(), JSON.stringify(lessonEntry) + "\n");
     } catch (e) {}
   }
 }
@@ -614,7 +629,7 @@ function extractOperationalLessons(result, gitCtx) {
         source: "self-reflection-T350",
         project: project
       };
-      fs.appendFileSync(LESSONS_FILE, JSON.stringify(lessonEntry) + "\n");
+      fs.appendFileSync(getLessonsFile(), JSON.stringify(lessonEntry) + "\n");
     } catch (e) {}
   }
 }

--- a/scripts/test/test-T558-per-project-lessons.sh
+++ b/scripts/test/test-T558-per-project-lessons.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# Test T558: Per-project lesson files
+set -euo pipefail
+REPO_DIR="$(cd "$(dirname "$0")/../.." && (pwd -W 2>/dev/null || pwd))"
+PASS=0; FAIL=0
+check() {
+  if eval "$2"; then PASS=$((PASS+1)); echo "  PASS: $1"
+  else FAIL=$((FAIL+1)); echo "  FAIL: $1"; fi
+}
+echo "=== hook-runner: T558 per-project lessons ==="
+
+HELPER="$REPO_DIR/scripts/test/.t558-helper.js"
+cat > "$HELPER" <<'JSEOF'
+var fs = require("fs"), os = require("os"), path = require("path");
+var REPO = path.resolve(__dirname, "../..");
+var LOAD_MOD = path.join(REPO, "modules/SessionStart/load-lessons.js");
+var REFL_MOD = path.join(REPO, "modules/Stop/self-reflection.js");
+
+// Temp dirs for isolated testing
+var TMPDIR = path.join(os.tmpdir(), ".t558-test-" + process.pid);
+var FAKE_HOME = path.join(TMPDIR, "home");
+var FAKE_PROJECT = path.join(TMPDIR, "project");
+var GLOBAL_DIR = path.join(FAKE_HOME, ".claude", "hooks");
+var PROJECT_DIR = path.join(FAKE_PROJECT, ".claude");
+
+function setup() {
+  fs.mkdirSync(GLOBAL_DIR, { recursive: true });
+  fs.mkdirSync(PROJECT_DIR, { recursive: true });
+}
+
+function cleanup() {
+  try { fs.rmSync(TMPDIR, { recursive: true, force: true }); } catch(e) {}
+}
+
+function fresh(mod) {
+  delete require.cache[require.resolve(mod)];
+  return require(mod);
+}
+
+function writeGlobalLesson(lesson) {
+  var f = path.join(GLOBAL_DIR, "self-analysis-lessons.jsonl");
+  fs.appendFileSync(f, JSON.stringify({ lesson: lesson, ts: new Date().toISOString() }) + "\n");
+}
+
+function writeProjectLesson(lesson) {
+  var f = path.join(PROJECT_DIR, "lessons.jsonl");
+  fs.appendFileSync(f, JSON.stringify({ lesson: lesson, ts: new Date().toISOString() }) + "\n");
+}
+
+var action = process.argv[2];
+
+if (action === "load-global-only") {
+  setup();
+  // Override os.homedir and env
+  var origHome = os.homedir;
+  os.homedir = function() { return FAKE_HOME; };
+  delete process.env.CLAUDE_PROJECT_DIR;
+  writeGlobalLesson("Global lesson A");
+  writeGlobalLesson("Global lesson B");
+  var m = fresh(LOAD_MOD);
+  var r = m({});
+  os.homedir = origHome;
+  cleanup();
+  if (!r || !r.text) { console.log("no-output"); process.exit(0); }
+  var hasA = r.text.indexOf("Global lesson A") >= 0;
+  var hasB = r.text.indexOf("Global lesson B") >= 0;
+  console.log(hasA && hasB ? "both" : "missing");
+}
+else if (action === "load-project-only") {
+  setup();
+  var origHome = os.homedir;
+  os.homedir = function() { return FAKE_HOME; };
+  process.env.CLAUDE_PROJECT_DIR = FAKE_PROJECT;
+  writeProjectLesson("Project lesson X");
+  writeProjectLesson("Project lesson Y");
+  var m = fresh(LOAD_MOD);
+  var r = m({});
+  os.homedir = origHome;
+  delete process.env.CLAUDE_PROJECT_DIR;
+  cleanup();
+  if (!r || !r.text) { console.log("no-output"); process.exit(0); }
+  var hasX = r.text.indexOf("Project lesson X") >= 0;
+  var hasY = r.text.indexOf("Project lesson Y") >= 0;
+  console.log(hasX && hasY ? "both" : "missing");
+}
+else if (action === "load-both-merged") {
+  setup();
+  var origHome = os.homedir;
+  os.homedir = function() { return FAKE_HOME; };
+  process.env.CLAUDE_PROJECT_DIR = FAKE_PROJECT;
+  writeGlobalLesson("Universal: never poll from LLM");
+  writeProjectLesson("DDEI: use force click for popovers");
+  var m = fresh(LOAD_MOD);
+  var r = m({});
+  os.homedir = origHome;
+  delete process.env.CLAUDE_PROJECT_DIR;
+  cleanup();
+  if (!r || !r.text) { console.log("no-output"); process.exit(0); }
+  var hasGlobal = r.text.indexOf("never poll from LLM") >= 0;
+  var hasProject = r.text.indexOf("force click for popovers") >= 0;
+  console.log(hasGlobal && hasProject ? "both" : "missing");
+}
+else if (action === "load-dedup") {
+  setup();
+  var origHome = os.homedir;
+  os.homedir = function() { return FAKE_HOME; };
+  process.env.CLAUDE_PROJECT_DIR = FAKE_PROJECT;
+  writeGlobalLesson("Same lesson");
+  writeProjectLesson("Same lesson");
+  writeProjectLesson("Unique project lesson");
+  var m = fresh(LOAD_MOD);
+  var r = m({});
+  os.homedir = origHome;
+  delete process.env.CLAUDE_PROJECT_DIR;
+  cleanup();
+  if (!r || !r.text) { console.log("no-output"); process.exit(0); }
+  // Count occurrences of "Same lesson"
+  var count = (r.text.match(/Same lesson/g) || []).length;
+  console.log(count === 1 ? "deduped" : "count:" + count);
+}
+else if (action === "load-project-priority") {
+  setup();
+  var origHome = os.homedir;
+  os.homedir = function() { return FAKE_HOME; };
+  process.env.CLAUDE_PROJECT_DIR = FAKE_PROJECT;
+  // Write project lessons first, then global
+  writeProjectLesson("Project first");
+  writeGlobalLesson("Global second");
+  var m = fresh(LOAD_MOD);
+  var r = m({});
+  os.homedir = origHome;
+  delete process.env.CLAUDE_PROJECT_DIR;
+  cleanup();
+  if (!r || !r.text) { console.log("no-output"); process.exit(0); }
+  var projIdx = r.text.indexOf("Project first");
+  var globalIdx = r.text.indexOf("Global second");
+  console.log(projIdx < globalIdx ? "project-first" : "wrong-order");
+}
+else if (action === "instruction-has-project-path") {
+  setup();
+  var origHome = os.homedir;
+  os.homedir = function() { return FAKE_HOME; };
+  process.env.CLAUDE_PROJECT_DIR = FAKE_PROJECT;
+  var m = fresh(LOAD_MOD);
+  var r = m({});
+  os.homedir = origHome;
+  var projDir = process.env.CLAUDE_PROJECT_DIR;
+  delete process.env.CLAUDE_PROJECT_DIR;
+  cleanup();
+  if (!r || !r.text) { console.log("no-output"); process.exit(0); }
+  // Should reference .claude/lessons.jsonl, not global path
+  var hasProjectRef = r.text.indexOf("lessons.jsonl") >= 0;
+  console.log(hasProjectRef ? "has-ref" : "no-ref");
+}
+else if (action === "instruction-fallback-global") {
+  setup();
+  var origHome = os.homedir;
+  os.homedir = function() { return FAKE_HOME; };
+  delete process.env.CLAUDE_PROJECT_DIR;
+  var m = fresh(LOAD_MOD);
+  var r = m({});
+  os.homedir = origHome;
+  cleanup();
+  if (!r || !r.text) { console.log("no-output"); process.exit(0); }
+  var hasGlobalRef = r.text.indexOf("self-analysis-lessons.jsonl") >= 0;
+  console.log(hasGlobalRef ? "has-global" : "no-global");
+}
+else if (action === "reflection-getlessonsfile") {
+  // Test that self-reflection.js has getLessonsFile function
+  setup();
+  var src = fs.readFileSync(REFL_MOD, "utf-8");
+  var hasFunc = src.indexOf("function getLessonsFile") >= 0;
+  var usesFunc = (src.match(/getLessonsFile\(\)/g) || []).length;
+  var noOldRef = src.indexOf("appendFileSync(LESSONS_FILE") === -1;
+  cleanup();
+  console.log(hasFunc && usesFunc >= 2 && noOldRef ? "correct" : "hasFunc:" + hasFunc + ",uses:" + usesFunc + ",noOld:" + noOldRef);
+}
+else if (action === "reflection-global-lessons-renamed") {
+  var src = fs.readFileSync(REFL_MOD, "utf-8");
+  var hasGlobal = src.indexOf("GLOBAL_LESSONS_FILE") >= 0;
+  var noOldVar = (src.match(/^var LESSONS_FILE\b/m) || []).length === 0;
+  console.log(hasGlobal && noOldVar ? "renamed" : "not-renamed");
+}
+JSEOF
+trap 'rm -f "$HELPER"' EXIT
+
+H="node $HELPER"
+
+# --- load-lessons.js structure ---
+check "has WORKFLOW tag" 'head -3 "$REPO_DIR/modules/SessionStart/load-lessons.js" | grep -q "WORKFLOW:"'
+check "has WHY comment" 'head -10 "$REPO_DIR/modules/SessionStart/load-lessons.js" | grep -q "// WHY:"'
+check "has getProjectLessonsFile function" 'grep -q "getProjectLessonsFile" "$REPO_DIR/modules/SessionStart/load-lessons.js"'
+check "has readLessonsFrom helper" 'grep -q "readLessonsFrom" "$REPO_DIR/modules/SessionStart/load-lessons.js"'
+
+# --- Loading behavior ---
+OUT=$($H load-global-only)
+check "loads global lessons when no project" '[ "$OUT" = "both" ]'
+
+OUT=$($H load-project-only)
+check "loads per-project lessons" '[ "$OUT" = "both" ]'
+
+OUT=$($H load-both-merged)
+check "merges global + project lessons" '[ "$OUT" = "both" ]'
+
+OUT=$($H load-dedup)
+check "deduplicates identical lessons" '[ "$OUT" = "deduped" ]'
+
+OUT=$($H load-project-priority)
+check "project lessons appear before global" '[ "$OUT" = "project-first" ]'
+
+# --- Instruction text ---
+OUT=$($H instruction-has-project-path)
+check "instruction references per-project path" '[ "$OUT" = "has-ref" ]'
+
+OUT=$($H instruction-fallback-global)
+check "instruction falls back to global without project" '[ "$OUT" = "has-global" ]'
+
+# --- self-reflection.js changes ---
+OUT=$($H reflection-getlessonsfile)
+check "self-reflection uses getLessonsFile()" '[ "$OUT" = "correct" ]'
+
+OUT=$($H reflection-global-lessons-renamed)
+check "LESSONS_FILE renamed to GLOBAL_LESSONS_FILE" '[ "$OUT" = "renamed" ]'
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary
- `load-lessons.js` reads from both global and per-project (`$CLAUDE_PROJECT_DIR/.claude/lessons.jsonl`) lesson files
- Project lessons get priority (appear first), duplicates removed
- `self-reflection.js` writes new lessons to per-project file, falls back to global
- Stops cross-pollination (DDEI lessons no longer leak into dd-lab sessions)

## Test plan
- [x] 13/13 tests pass (`test-T558-per-project-lessons.sh`)
- [x] Global-only loading still works
- [x] Per-project loading works
- [x] Merge, dedup, priority order verified
- [x] Instruction text adapts to project context
- [x] self-reflection.js properly refactored (no dangling LESSONS_FILE refs)