### PR TITLE
T562: Fix T369 victory-gate test for T560 evidence message

### DIFF
--- a/scripts/test/test-T369-victory-gate.js
+++ b/scripts/test/test-T369-victory-gate.js
@@ -59,7 +59,7 @@ var r11 = gate({ tool_name: "Bash", tool_input: { command: heredocCmd } });
 assert("heredoc victory blocks", r11 && r11.decision === "block");
 
 // 12. Block message includes guidance
-assert("block has verification checklist", r4.reason.indexOf("verify") !== -1 || r4.reason.indexOf("VERIFY") !== -1 || r4.reason.indexOf("Verify") !== -1);
+assert("block has verification checklist", r4.reason.indexOf("Run tests") !== -1 || r4.reason.indexOf("evidence") !== -1 || r4.reason.indexOf("verify") !== -1 || r4.reason.indexOf("VERIFY") !== -1);
 assert("block has rephrase guidance", r4.reason.indexOf("Rephrase") !== -1 || r4.reason.indexOf("GOOD") !== -1);
 
 // 14. Victory words in body (not title) should pass — body may describe/quote them


### PR DESCRIPTION
## Summary
- T560 changed victory-gate block message from "verify" to "Run tests first" / "evidence"
- T369 test expected "verify" — now accepts either format
- 15/15 pass

## Test plan
- [x] T369: 15/15 pass
- [x] Full suite: T042 (marketplace sync, separate task) and T314 (intermittent) are the only remaining failures