### PR TITLE
T565: Add tests for gh-auto-gate and spec-before-code-gate

### DIFF
--- a/scripts/test/test-gh-auto-gate.js
+++ b/scripts/test/test-gh-auto-gate.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * Test suite for gh-auto-gate PreToolUse module.
+ * Ensures raw gh/git remote commands are blocked in favor of gh_auto.
+ */
+"use strict";
+
+var path = require("path");
+
+var pass = 0;
+var fail = 0;
+
+function ok(name, result) {
+  if (result) {
+    pass++;
+    console.log("OK: " + name);
+  } else {
+    fail++;
+    console.log("FAIL: " + name);
+  }
+}
+
+var modulePath = path.join(__dirname, "..", "..", "modules", "PreToolUse", "gh-auto-gate.js");
+
+function runGate(command) {
+  delete require.cache[require.resolve(modulePath)];
+  var gate = require(modulePath);
+  return gate({ tool_name: "Bash", tool_input: { command: command } });
+}
+
+function blocks(command) {
+  var result = runGate(command);
+  return result && result.decision === "block";
+}
+
+function passes(command) {
+  return runGate(command) === null;
+}
+
+// === Raw gh commands should be blocked ===
+ok("gh pr list: blocked", blocks("gh pr list"));
+ok("gh pr create: blocked", blocks("gh pr create --title test"));
+ok("gh issue list: blocked", blocks("gh issue list"));
+ok("gh pr merge: blocked", blocks("gh pr merge 123 --squash"));
+ok("gh pr view: blocked", blocks("gh pr view 42"));
+ok("gh release create: blocked", blocks("gh release create v1.0"));
+ok("gh repo view: blocked", blocks("gh repo view"));
+
+// === Raw git remote commands should be blocked ===
+ok("git push: blocked", blocks("git push origin main"));
+ok("git pull: blocked", blocks("git pull --rebase"));
+ok("git fetch: blocked", blocks("git fetch origin"));
+ok("git ls-remote: blocked", blocks("git ls-remote origin"));
+ok("git push with flags: blocked", blocks("git push -u origin feature"));
+
+// === gh_auto equivalents should pass ===
+ok("gh_auto pr list: pass", passes("gh_auto pr list"));
+ok("gh_auto push: pass", passes("gh_auto push origin main"));
+ok("gh_auto pull: pass", passes("gh_auto pull --rebase"));
+ok("gh_auto fetch: pass", passes("bash ~/bin/gh_auto fetch origin"));
+
+// === GH_TOKEN explicit should pass ===
+ok("GH_TOKEN= gh pr list: pass", passes("GH_TOKEN=ghp_abc gh pr list"));
+ok("GH_TOKEN= git push: pass", passes("GH_TOKEN=ghp_abc git push origin main"));
+
+// === gh auth commands should pass (needed for token management) ===
+ok("gh auth switch: pass", passes("gh auth switch --user grobomo"));
+ok("gh auth status: pass", passes("gh auth status"));
+ok("gh auth login: pass", passes("gh auth login"));
+
+// === gh api user (diagnostic) should pass ===
+ok("gh api user: pass", passes("gh api user"));
+
+// === Non-GitHub commands should pass ===
+ok("non-Bash tool: pass", function() {
+  delete require.cache[require.resolve(modulePath)];
+  var gate = require(modulePath);
+  return gate({ tool_name: "Read", tool_input: { file_path: "/tmp/test" } }) === null;
+}());
+ok("git status: pass", passes("git status"));
+ok("git log: pass", passes("git log --oneline -5"));
+ok("git diff: pass", passes("git diff HEAD"));
+ok("git add: pass", passes("git add file.js"));
+ok("git commit: pass", passes("git commit -m 'test'"));
+ok("git branch: pass", passes("git branch -a"));
+ok("ls: pass", passes("ls -la"));
+ok("npm test: pass", passes("npm test"));
+
+// === Block message quality ===
+ok("block message has suggestion", function() {
+  var result = runGate("gh pr list");
+  return result && result.reason.indexOf("gh_auto") !== -1;
+}());
+ok("git push suggestion uses gh_auto", function() {
+  var result = runGate("git push origin main");
+  return result && result.reason.indexOf("gh_auto push") !== -1;
+}());
+ok("gh pr create suggestion", function() {
+  var result = runGate("gh pr create --title test");
+  return result && result.reason.indexOf("gh_auto pr create") !== -1;
+}());
+
+// === Edge cases ===
+ok("gh in middle of command: pass", passes("echo 'run gh pr list' > log.txt"));
+ok("leading whitespace gh: blocked", blocks("  gh pr list"));
+// Note: chained commands (cd && gh) bypass the ^gh regex — acceptable tradeoff
+// vs complex multi-command parsing. Claude rarely chains like this.
+ok("cd && gh: passes (chained, not caught by ^gh)", passes('cd /tmp && gh pr list'));
+
+console.log("\n" + pass + " passed, " + fail + " failed");
+process.exit(fail > 0 ? 1 : 0);

--- a/scripts/test/test-spec-before-code-gate.js
+++ b/scripts/test/test-spec-before-code-gate.js
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/**
+ * Test suite for spec-before-code-gate PreToolUse module.
+ * Tests that file modifications require a spec (TODO entry or recent commit).
+ */
+"use strict";
+
+var fs = require("fs");
+var path = require("path");
+var os = require("os");
+
+var pass = 0;
+var fail = 0;
+
+function ok(name, result) {
+  if (result) {
+    pass++;
+    console.log("OK: " + name);
+  } else {
+    fail++;
+    console.log("FAIL: " + name);
+  }
+}
+
+var modulePath = path.join(__dirname, "..", "..", "modules", "PreToolUse", "spec-before-code-gate.js");
+var STATE_FILE = path.join(os.homedir(), ".claude", "hooks", ".spec-before-code-state");
+
+// Save and restore state
+var origState = null;
+try { origState = fs.readFileSync(STATE_FILE, "utf-8"); } catch(e) {}
+var origProjectDir = process.env.CLAUDE_PROJECT_DIR;
+
+// Create temp project dir with TODO.md
+var tmpDir = path.join(os.tmpdir(), "spec-gate-test-" + process.pid);
+fs.mkdirSync(tmpDir, { recursive: true });
+
+function resetState(state) {
+  try {
+    if (state) {
+      fs.writeFileSync(STATE_FILE, JSON.stringify(state));
+    } else {
+      try { fs.unlinkSync(STATE_FILE); } catch(e) {}
+    }
+  } catch(e) {}
+}
+
+function runGate(input) {
+  delete require.cache[require.resolve(modulePath)];
+  // Also clear the helper cache
+  var helperPath = path.join(__dirname, "..", "..", "modules", "PreToolUse", "_file-modify-patterns.js");
+  delete require.cache[require.resolve(helperPath)];
+  var gate = require(modulePath);
+  return gate(input);
+}
+
+function blocks(input) {
+  var result = runGate(input);
+  return result && result.decision === "block";
+}
+
+function passes(input) {
+  return runGate(input) === null;
+}
+
+// === Non-file-modify tools should pass ===
+resetState(null);
+process.env.CLAUDE_PROJECT_DIR = tmpDir;
+
+ok("Read tool: passes", passes({
+  tool_name: "Read", tool_input: { file_path: "/tmp/test.js" }
+}));
+
+ok("Bash non-modify: passes (git status)", passes({
+  tool_name: "Bash", tool_input: { command: "git status" }
+}));
+
+ok("Bash non-modify: passes (ls)", passes({
+  tool_name: "Bash", tool_input: { command: "ls -la" }
+}));
+
+ok("Bash non-modify: passes (cat)", passes({
+  tool_name: "Bash", tool_input: { command: "cat file.js" }
+}));
+
+// === Spec-related files are exempt ===
+resetState(null);
+ok("Edit TODO.md: exempt", passes({
+  tool_name: "Edit", tool_input: { file_path: tmpDir + "/TODO.md", old_string: "a", new_string: "b" }
+}));
+
+ok("Write SESSION_STATE.md: exempt", passes({
+  tool_name: "Write", tool_input: { file_path: tmpDir + "/SESSION_STATE.md", content: "test" }
+}));
+
+ok("Edit CLAUDE.md: exempt", passes({
+  tool_name: "Edit", tool_input: { file_path: tmpDir + "/CLAUDE.md", old_string: "a", new_string: "b" }
+}));
+
+ok("Edit file in specs/: exempt", passes({
+  tool_name: "Edit", tool_input: { file_path: tmpDir + "/specs/feature.md", old_string: "a", new_string: "b" }
+}));
+
+// === Git commit resets state ===
+resetState({ lastCommitTs: 0, specChecked: true });
+ok("git commit resets state", passes({
+  tool_name: "Bash", tool_input: { command: 'git commit -m "test"' }
+}));
+// Verify state was reset
+try {
+  var state = JSON.parse(fs.readFileSync(STATE_FILE, "utf-8"));
+  ok("state has lastCommitTs after commit", state.lastCommitTs > 0);
+  ok("specChecked reset to false", state.specChecked === false);
+} catch(e) {
+  ok("state has lastCommitTs after commit", false);
+  ok("specChecked reset to false", false);
+}
+
+// === specChecked=true passes through ===
+resetState({ lastCommitTs: Date.now(), specChecked: true });
+ok("specChecked=true: Edit passes", passes({
+  tool_name: "Edit", tool_input: { file_path: tmpDir + "/src/app.js", old_string: "a", new_string: "b" }
+}));
+
+// === TODO.md with task marker = spec exists ===
+resetState({ lastCommitTs: 0, specChecked: false });
+fs.writeFileSync(path.join(tmpDir, "TODO.md"), "# TODO\n- [ ] T565: Add test coverage for gates\n");
+ok("TODO.md with task: Edit passes", passes({
+  tool_name: "Edit", tool_input: { file_path: tmpDir + "/src/app.js", old_string: "a", new_string: "b" }
+}));
+
+// === No spec = block ===
+resetState({ lastCommitTs: 0, specChecked: false });
+fs.writeFileSync(path.join(tmpDir, "TODO.md"), "# TODO\nNothing here\n");
+ok("no spec: Edit blocks", blocks({
+  tool_name: "Edit", tool_input: { file_path: tmpDir + "/src/app.js", old_string: "a", new_string: "b" }
+}));
+
+resetState({ lastCommitTs: 0, specChecked: false });
+ok("no spec: Write blocks", blocks({
+  tool_name: "Write", tool_input: { file_path: tmpDir + "/src/app.js", content: "test" }
+}));
+
+// === Bash file-modify patterns blocked without spec ===
+resetState({ lastCommitTs: 0, specChecked: false });
+ok("no spec: sed -i blocked", blocks({
+  tool_name: "Bash", tool_input: { command: "sed -i 's/foo/bar/' file.js" }
+}));
+
+resetState({ lastCommitTs: 0, specChecked: false });
+ok("no spec: cp blocked", blocks({
+  tool_name: "Bash", tool_input: { command: "cp src/a.js src/b.js" }
+}));
+
+// === Block message quality ===
+resetState({ lastCommitTs: 0, specChecked: false });
+fs.writeFileSync(path.join(tmpDir, "TODO.md"), "# empty\n");
+var blockResult = runGate({
+  tool_name: "Edit", tool_input: { file_path: tmpDir + "/src/app.js", old_string: "a", new_string: "b" }
+});
+ok("block message mentions TODO.md", blockResult && blockResult.reason.indexOf("TODO.md") !== -1);
+ok("block message mentions spec", blockResult && blockResult.reason.indexOf("spec") !== -1);
+
+// === No CLAUDE_PROJECT_DIR = allow (can't check) ===
+resetState({ lastCommitTs: 0, specChecked: false });
+delete process.env.CLAUDE_PROJECT_DIR;
+ok("no project dir: Edit passes", passes({
+  tool_name: "Edit", tool_input: { file_path: "/tmp/src/app.js", old_string: "a", new_string: "b" }
+}));
+
+// === Cleanup ===
+process.env.CLAUDE_PROJECT_DIR = origProjectDir || "";
+if (origState) {
+  fs.writeFileSync(STATE_FILE, origState);
+} else {
+  try { fs.unlinkSync(STATE_FILE); } catch(e) {}
+}
+try { fs.rmSync(tmpDir, { recursive: true }); } catch(e) {}
+
+console.log("\n" + pass + " passed, " + fail + " failed");
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- **gh-auto-gate** (37 tests): Validates blocking of raw `gh`/`git remote` commands, `gh_auto` bypass, `GH_TOKEN` explicit, `gh auth` exemption, suggestion message quality, edge cases
- **spec-before-code-gate** (20 tests): Non-modify passthrough, spec file exemptions, state management, TODO.md task detection, block message quality, no-project-dir fallback

57 new tests for two previously untested critical PreToolUse modules.

## Test plan
- [x] `node scripts/test/test-gh-auto-gate.js` — 37/37 passed
- [x] `node scripts/test/test-spec-before-code-gate.js` — 20/20 passed
- [x] Full suite: 98 suites, 1442 passed, 0 failed