### PR TITLE
Add .claude/worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@ workflow-config.json
 scripts/test/archive/
 run-modules/
 .coconut/
+.claude/worktrees/
 scripts/hermes-message.json


### PR DESCRIPTION
Worktrees are local-only ephemeral directories. They showed as untracked in git status.