### PR TITLE
T568: Version bump to v2.65.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.65.0] — 2026-05-03
+
+### Added
+- **gh-auto-gate tests** (T565) — 37 tests covering all `gh` subcommands, `git push/pull/fetch`, `gh_auto` passthrough, and edge cases (chained commands, quoted strings, comments).
+- **spec-before-code-gate tests** (T565) — 20 tests covering tool filtering, exempt files, branch detection, and spec directory presence.
+- **preserve-iterated-content tests** (T567) — 18 tests covering git commit counting, cache behavior, threshold logic, and watched directory detection.
+
+### Fixed
+- **.gitignore worktrees** (T566) — Added `.claude/worktrees/` to `.gitignore` to prevent stale worktree remnants from showing as untracked.
+
+### Stats
+- 99 suites, 1482 tests
+- 113 modules, 7 workflows
+
 ## [2.64.0] — 2026-05-03
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Modular hook runner for Claude Code. Workflows group modules into enforceable pi
 - `workflows/` — built-in workflow definitions (YAML)
 - `specs/` — feature specs with tasks and checkpoints
 - `demo.js` — interactive demo (simulates module gates against realistic scenarios)
-- `scripts/test/` — test scripts (85 suites, 1206 tests)
+- `scripts/test/` — test scripts (99 suites, 1482 tests)
 - `package.json` — npm package (enables `npx grobomo/hook-runner`)
 
 ## Testing

--- a/TODO.md
+++ b/TODO.md
@@ -1399,6 +1399,7 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T565: Add test coverage for gh-auto-gate (37 tests) and spec-before-code-gate (20 tests). 57 new tests for previously untested critical PreToolUse modules. (PR #473)
 - [x] T566: Add .claude/worktrees/ to .gitignore — stops stale worktree remnants showing as untracked. (PR #475)
 - [x] T567: Add tests for preserve-iterated-content gate — 18 tests covering cache, thresholds, watched dirs. (PR #476)
+- [ ] T568: Version bump to v2.65.0 — CHANGELOG, package.json, GitHub release. 99 suites, 1482 tests.
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.64.0",
+  "version": "2.65.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Bump version to 2.65.0
- CHANGELOG: document T565-T567 (75 new tests across 3 suites, .gitignore fix)
- CLAUDE.md: update test count from 85/1206 to 99/1482
- Full suite: 99 suites, 1482 passed, 0 failed

## Test plan
- [x] `node setup.js --test` — 99 suites, 1482 passed, 0 failed