### PR TITLE
T570: Add tests for settings-hooks-gate and no-hook-bypass

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1401,6 +1401,7 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T567: Add tests for preserve-iterated-content gate — 18 tests covering cache, thresholds, watched dirs. (PR #476)
 - [x] T568: Version bump to v2.65.0 — CHANGELOG, package.json, GitHub release. 99 suites, 1482 tests. (PR #478)
 - [ ] T569: Add tests for reflection-gate and task-completion-gate — hot-path modules with zero coverage.
+- [ ] T570: Add tests for settings-hooks-gate and no-hook-bypass — security enforcement gates with zero coverage.
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog

--- a/scripts/test/test-no-hook-bypass.js
+++ b/scripts/test/test-no-hook-bypass.js
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+"use strict";
+// T570: Tests for no-hook-bypass.js
+// Blocks Bash file writes that bypass Write/Edit gates, and bypass language in descriptions.
+
+var path = require("path");
+var fs = require("fs");
+var os = require("os");
+var modPath = path.join(__dirname, "..", "..", "modules", "PreToolUse", "no-hook-bypass.js");
+var passed = 0, failed = 0;
+
+function check(name, fn) {
+  try { fn(); console.log("OK: " + name); passed++; }
+  catch (e) { console.log("FAIL: " + name + " — " + e.message); failed++; }
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg || "assertion failed"); }
+
+// Fresh load each time (flag file state matters)
+function loadGate() {
+  delete require.cache[require.resolve(modPath)];
+  return require(modPath);
+}
+
+function makeInput(cmd, desc) {
+  var input = { tool_name: "Bash", tool_input: { command: cmd } };
+  if (desc) input.tool_input.description = desc;
+  return input;
+}
+
+// --- Tests ---
+
+check("Non-Bash tool: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: "x" } }) === null);
+});
+
+check("Bash non-write command: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("ls -la")) === null);
+});
+
+check("Bash git command: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("git status")) === null);
+});
+
+check("Bash npm command: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("npm test")) === null);
+});
+
+check("cat > file: detected as write", function() {
+  // Without flag file, should pass (no active instruction-to-hook)
+  var gate = loadGate();
+  var r = gate(makeInput('cat > /tmp/test.txt <<EOF\nhello\nEOF'));
+  assert(r === null, "without flag should pass");
+});
+
+check("echo > file: detected as write", function() {
+  var gate = loadGate();
+  var r = gate(makeInput('echo "hello" > /tmp/test.txt'));
+  assert(r === null, "without flag should pass");
+});
+
+check("tee file: detected as write", function() {
+  var gate = loadGate();
+  var r = gate(makeInput('echo "data" | tee /tmp/out.txt'));
+  assert(r === null, "without flag should pass");
+});
+
+check("printf > file: detected as write", function() {
+  var gate = loadGate();
+  var r = gate(makeInput('printf "%s" "data" > /tmp/out.txt'));
+  assert(r === null, "without flag should pass");
+});
+
+check("cat >> file: detected as append write", function() {
+  var gate = loadGate();
+  var r = gate(makeInput('cat >> /tmp/test.txt <<EOF\nmore\nEOF'));
+  assert(r === null, "without flag should pass");
+});
+
+check("Description with 'bypass': blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput('echo "x" > /tmp/test.txt', "Bypass the write gate"));
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+  assert(r.reason.indexOf("HOOK BYPASS") !== -1);
+});
+
+check("Description with 'work around': blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput('echo "x" > /tmp/test.txt', "Work around the hook check"));
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("Description with 'circumvent': blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput('echo "x" > /tmp/test.txt', "Circumvent the gate"));
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("Description with 'avoid hook': blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput('cat > /tmp/test.txt', "Avoid the hook enforcement"));
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("Description with 'skip check': blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput('echo "y" > /tmp/test.txt', "Skip the check this time"));
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("Command with 'bypass' word: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput('echo "bypass the gate" > /tmp/test.txt'));
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("Normal write description: passes", function() {
+  var gate = loadGate();
+  var r = gate(makeInput('echo "hello" > /tmp/test.txt', "Write test data"));
+  assert(r === null, "normal desc should pass");
+});
+
+check("Empty command: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: "" } }) === null);
+});
+
+check("Empty tool_input: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: {} }) === null);
+});
+
+check("Flag file active + write to non-hook path: blocks", function() {
+  var flagPath = path.join(os.tmpdir(), ".claude-instruction-pending");
+  fs.writeFileSync(flagPath, "active");
+  try {
+    var gate = loadGate();
+    var r = gate(makeInput('cat > /tmp/random-file.txt <<EOF\nstuff\nEOF'));
+    assert(r !== null, "should block when flag active");
+    assert(r.decision === "block");
+    assert(r.reason.indexOf("instruction-to-hook") !== -1);
+  } finally {
+    try { fs.unlinkSync(flagPath); } catch(e) {}
+  }
+});
+
+check("Flag file active + write to run-modules/ path: passes (allowed)", function() {
+  var flagPath = path.join(os.tmpdir(), ".claude-instruction-pending");
+  fs.writeFileSync(flagPath, "active");
+  try {
+    var gate = loadGate();
+    var modTarget = os.homedir().replace(/\\/g, "/") + "/.claude/hooks/run-modules/PreToolUse/gate.js";
+    var r = gate(makeInput('cat > "' + modTarget + '" <<EOF\nmodule.exports=fn\nEOF'));
+    assert(r === null, "writing to run-modules should be allowed");
+  } finally {
+    try { fs.unlinkSync(flagPath); } catch(e) {}
+  }
+});
+
+check("Flag file active + write to settings.json: passes (allowed)", function() {
+  var flagPath = path.join(os.tmpdir(), ".claude-instruction-pending");
+  fs.writeFileSync(flagPath, "active");
+  try {
+    var gate = loadGate();
+    var r = gate(makeInput('echo "{}" > settings.json'));
+    assert(r === null, "writing to settings.json should be allowed");
+  } finally {
+    try { fs.unlinkSync(flagPath); } catch(e) {}
+  }
+});
+
+// Summary
+console.log("\n" + passed + " passed, " + failed + " failed");
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/test/test-settings-hooks-gate.js
+++ b/scripts/test/test-settings-hooks-gate.js
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+"use strict";
+// T570: Tests for settings-hooks-gate.js
+// Blocks adding hook entries directly to settings.json — must use module system.
+
+var path = require("path");
+var os = require("os");
+var modPath = path.join(__dirname, "..", "..", "modules", "PreToolUse", "settings-hooks-gate.js");
+var gate = require(modPath);
+var passed = 0, failed = 0;
+
+// Use dynamic home dir for test paths
+var HOME = os.homedir().replace(/\\/g, "/");
+
+function check(name, fn) {
+  try { fn(); console.log("OK: " + name); passed++; }
+  catch (e) { console.log("FAIL: " + name + " — " + e.message); failed++; }
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg || "assertion failed"); }
+
+function makeInput(file, oldStr, newStr) {
+  return { tool_name: "Edit", tool_input: { file_path: file, old_string: oldStr, new_string: newStr } };
+}
+
+// --- Tests ---
+
+check("Non-Edit tool: passes", function() {
+  assert(gate({ tool_name: "Bash", tool_input: { command: "cat settings.json" } }) === null);
+});
+
+check("Edit non-settings file: passes", function() {
+  assert(gate(makeInput("/project/src/app.js", "old", '"type": "command"')) === null);
+});
+
+check("Edit settings.json without hook patterns: passes", function() {
+  assert(gate(makeInput(HOME + "/.claude/settings.json",
+    '"theme": "dark"', '"theme": "light"')) === null);
+});
+
+check("Edit settings.json adding 'type: command': blocks", function() {
+  var r = gate(makeInput(HOME + "/.claude/settings.json",
+    '"hooks": []',
+    '"hooks": [{"type": "command", "command": "echo hi"}]'));
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+  assert(r.reason.indexOf("hook-runner module system") !== -1);
+});
+
+check("Edit settings.json adding 'command:': blocks", function() {
+  var r = gate(makeInput(HOME + "/.claude/settings.json",
+    "{}",
+    '{"command": "node gate.js"}'));
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("Edit settings.json adding 'hooks: [': blocks", function() {
+  var r = gate(makeInput(HOME + "/.claude/settings.json",
+    "{}",
+    '{"hooks": []}'));
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("Edit settings.json adding 'matcher:': blocks", function() {
+  var r = gate(makeInput(HOME + "/.claude/settings.json",
+    "{}",
+    '{"matcher": "Bash"}'));
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("Edit settings.json adding 'type: prompt': blocks", function() {
+  var r = gate(makeInput(HOME + "/.claude/settings.json",
+    "{}",
+    '{"type": "prompt", "prompt": "Remember X"}'));
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("Edit settings.json adding 'type: agent': blocks", function() {
+  var r = gate(makeInput(HOME + "/.claude/settings.json",
+    "{}",
+    '{"type": "agent", "command": "run"}'));
+  assert(r !== null, "should block");
+});
+
+check("Removing hooks (simplifying): passes", function() {
+  assert(gate(makeInput(HOME + "/.claude/settings.json",
+    '{"hooks": [{"type": "command"}]}',
+    '{"hooks": []}')) === null);
+});
+
+check("settings.local.json: same enforcement", function() {
+  var r = gate(makeInput(HOME + "/.claude/settings.local.json",
+    "{}",
+    '{"type": "command", "command": "node x.js"}'));
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("Pattern already in old_string: passes (not adding)", function() {
+  assert(gate(makeInput(HOME + "/.claude/settings.json",
+    '{"type": "command", "command": "old"}',
+    '{"type": "command", "command": "new"}')) === null);
+});
+
+check("Windows path: works", function() {
+  var winPath = HOME.replace(/\//g, "\\") + "\\.claude\\settings.json";
+  var r = gate(makeInput(winPath, "{}", '{"type": "command"}'));
+  assert(r !== null, "should block on Windows path");
+});
+
+check("Empty tool_input: passes gracefully", function() {
+  assert(gate({ tool_name: "Edit", tool_input: {} }) === null);
+});
+
+// Summary
+console.log("\n" + passed + " passed, " + failed + " failed");
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- settings-hooks-gate: 14 tests — blocks adding hooks directly to settings.json, enforces module system
- no-hook-bypass: 21 tests — blocks Bash file writes that bypass Write/Edit gates, flag file integration, bypass language detection

## Test plan
- [x] settings-hooks-gate: 14/14 passed
- [x] no-hook-bypass: 21/21 passed