### PR TITLE
T571: Version bump to v2.66.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.66.0] — 2026-05-03
+
+### Added
+- **reflection-gate tests** (T569) — 20 tests covering exempt files, self-repair paths, severity levels, log age expiry, resolved entries, and block messaging.
+- **task-completion-gate tests** (T569) — 15 tests covering PR reference enforcement, already-completed tasks, multi-task edits, and edge cases.
+- **settings-hooks-gate tests** (T570) — 14 tests covering hook pattern detection, settings.json/local enforcement, removal passthrough, and Windows paths.
+- **no-hook-bypass tests** (T570) — 21 tests covering Bash write detection, bypass language blocking, flag file integration, and allowed hook/rule paths.
+
+### Stats
+- 103 suites, 1552 tests
+- 113 modules, 7 workflows
+
 ## [2.65.0] — 2026-05-03
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Modular hook runner for Claude Code. Workflows group modules into enforceable pi
 - `workflows/` — built-in workflow definitions (YAML)
 - `specs/` — feature specs with tasks and checkpoints
 - `demo.js` — interactive demo (simulates module gates against realistic scenarios)
-- `scripts/test/` — test scripts (99 suites, 1482 tests)
+- `scripts/test/` — test scripts (103 suites, 1552 tests)
 - `package.json` — npm package (enables `npx grobomo/hook-runner`)
 
 ## Testing

--- a/TODO.md
+++ b/TODO.md
@@ -1400,8 +1400,9 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T566: Add .claude/worktrees/ to .gitignore — stops stale worktree remnants showing as untracked. (PR #475)
 - [x] T567: Add tests for preserve-iterated-content gate — 18 tests covering cache, thresholds, watched dirs. (PR #476)
 - [x] T568: Version bump to v2.65.0 — CHANGELOG, package.json, GitHub release. 99 suites, 1482 tests. (PR #478)
-- [ ] T569: Add tests for reflection-gate and task-completion-gate — hot-path modules with zero coverage.
-- [ ] T570: Add tests for settings-hooks-gate and no-hook-bypass — security enforcement gates with zero coverage.
+- [x] T569: Add tests for reflection-gate (20) and task-completion-gate (15) — hot-path modules. (PR #480)
+- [x] T570: Add tests for settings-hooks-gate (14) and no-hook-bypass (21) — security gates. (PR #481)
+- [ ] T571: Version bump to v2.66.0 — CHANGELOG, package.json, GitHub release.
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.65.0",
+  "version": "2.66.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Bump to v2.66.0
- CHANGELOG: document T569 (reflection-gate + task-completion-gate tests) and T570 (settings-hooks-gate + no-hook-bypass tests)
- CLAUDE.md: update test count to 103 suites, 1552 tests
- Mark T569 and T570 complete in TODO.md

## Test plan
- [x] reflection-gate: 20/20
- [x] task-completion-gate: 15/15
- [x] settings-hooks-gate: 14/14
- [x] no-hook-bypass: 21/21