### PR TITLE
T572: Add tests for messaging-safety-gate, pr-per-task-gate, no-passive-rules (#483)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1402,7 +1402,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T568: Version bump to v2.65.0 — CHANGELOG, package.json, GitHub release. 99 suites, 1482 tests. (PR #478)
 - [x] T569: Add tests for reflection-gate (20) and task-completion-gate (15) — hot-path modules. (PR #480)
 - [x] T570: Add tests for settings-hooks-gate (14) and no-hook-bypass (21) — security gates. (PR #481)
-- [ ] T571: Version bump to v2.66.0 — CHANGELOG, package.json, GitHub release.
+- [x] T571: Version bump to v2.66.0 — CHANGELOG, package.json, GitHub release. 103 suites, 1552 tests. (PR #482)
+- [ ] T572: Add tests for messaging-safety-gate, pr-per-task-gate, and no-passive-rules.
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog

--- a/scripts/test/test-messaging-safety-gate.js
+++ b/scripts/test/test-messaging-safety-gate.js
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+"use strict";
+// T572: Tests for messaging-safety-gate.js
+// Blocks outbound messaging (email, Teams, meetings) unless target is authorized.
+
+var path = require("path");
+var modPath = path.join(__dirname, "..", "..", "modules", "PreToolUse", "messaging-safety-gate.js");
+var passed = 0, failed = 0;
+
+function check(name, fn) {
+  try { fn(); console.log("OK: " + name); passed++; }
+  catch (e) { console.log("FAIL: " + name + " — " + e.message); failed++; }
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg || "assertion failed"); }
+
+function loadGate() {
+  delete require.cache[require.resolve(modPath)];
+  return require(modPath);
+}
+
+function makeInput(cmd) {
+  return { tool_name: "Bash", tool_input: { command: cmd } };
+}
+
+// --- Non-Bash tools pass ---
+
+check("Non-Bash tool: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: "x" } }) === null);
+});
+
+check("Read tool: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Read", tool_input: { file_path: "x" } }) === null);
+});
+
+// --- Non-messaging Bash commands pass ---
+
+check("Bash non-messaging command: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("ls -la")) === null);
+});
+
+check("Bash git command: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("git status")) === null);
+});
+
+check("Bash npm command: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("npm install lodash")) === null);
+});
+
+// --- Teams chat send: blocked without allowed chat ID ---
+
+check("teams_chat.py send to unknown chat: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput('python teams_chat.py send --chat-id "19:unknown@thread.v2" --message "hi"'));
+  assert(r && r.decision === "block", "should block");
+  assert(r.reason.indexOf("MESSAGING GATE") >= 0, "should mention messaging gate");
+});
+
+check("teams_chat.py send to allowed hackathon chat: passes", function() {
+  var gate = loadGate();
+  var r = gate(makeInput('python teams_chat.py send --chat-id "19:cf504fc638964747bff028e4ba785869@thread.v2" --message "hi"'));
+  assert(r === null, "should pass for allowed chat");
+});
+
+// --- Graph API sendMail ---
+
+check("graph_post sendMail: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput('python graph_post.py sendMail --to user@example.com'));
+  assert(r && r.decision === "block");
+});
+
+// --- Graph API messages ---
+
+check("graph_post messages to unknown chat: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput('python graph_post.py messages --chat "19:unknown@thread.v2"'));
+  assert(r && r.decision === "block");
+});
+
+check("graph_post messages to allowed chat: passes", function() {
+  var gate = loadGate();
+  var r = gate(makeInput('python graph_post.py messages --chat "19:cf504fc638964747bff028e4ba785869@thread.v2"'));
+  assert(r === null);
+});
+
+// --- Calendar events (graph_post events) ---
+
+check("graph_post events: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput('python graph_post.py events --title "standup"'));
+  assert(r && r.decision === "block");
+});
+
+// --- Meeting scheduler ---
+
+check("schedule.py create: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput('python schedule.py create --title "sync" --attendees user@example.com'));
+  assert(r && r.decision === "block");
+});
+
+// --- SMTP send ---
+
+check("smtp send: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput('python smtp_relay.py send --to user@example.com'));
+  assert(r && r.decision === "block");
+});
+
+check("SMTP Send (case insensitive): blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput('python SMTP_tool.py Send --to admin@corp.com'));
+  assert(r && r.decision === "block");
+});
+
+// --- Edge cases ---
+
+check("teams_chat.py list (not send): passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("python teams_chat.py list")) === null);
+});
+
+check("teams_chat.py read (not send): passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("python teams_chat.py read --chat-id 19:abc@thread.v2")) === null);
+});
+
+check("teams_chat.py members (not send): passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("python teams_chat.py members")) === null);
+});
+
+check("Empty command: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("")) === null);
+});
+
+check("Missing tool_input: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash" }) === null);
+});
+
+// --- Summary ---
+console.log("\n" + passed + " passed, " + failed + " failed");
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/test/test-no-passive-rules.js
+++ b/scripts/test/test-no-passive-rules.js
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+"use strict";
+// T572: Tests for no-passive-rules.js
+// Blocks creating new .md rule files in ~/.claude/rules/ (global only).
+// Editing existing rules and project-scoped rules are allowed.
+
+var path = require("path");
+var os = require("os");
+var modPath = path.join(__dirname, "..", "..", "modules", "PreToolUse", "no-passive-rules.js");
+var passed = 0, failed = 0;
+
+function check(name, fn) {
+  try { fn(); console.log("OK: " + name); passed++; }
+  catch (e) { console.log("FAIL: " + name + " — " + e.message); failed++; }
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg || "assertion failed"); }
+
+function loadGate() {
+  delete require.cache[require.resolve(modPath)];
+  return require(modPath);
+}
+
+var HOME = os.homedir().replace(/\\/g, "/");
+
+// --- Non-Write tools pass ---
+
+check("Edit tool: passes (only blocks Write)", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: HOME + "/.claude/rules/test.md" } }) === null);
+});
+
+check("Read tool: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Read", tool_input: { file_path: HOME + "/.claude/rules/test.md" } }) === null);
+});
+
+check("Bash tool: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: "ls" } }) === null);
+});
+
+// --- Write to global ~/.claude/rules/*.md: blocks ---
+
+check("Write new .md to global rules: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Write", tool_input: { file_path: HOME + "/.claude/rules/my-rule.md" } });
+  assert(r && r.decision === "block", "should block");
+  assert(r.reason.indexOf("passive") >= 0 || r.reason.indexOf("BLOCKED") >= 0, "should explain why");
+});
+
+check("Write new .md to global rules (backslashes): blocks", function() {
+  var gate = loadGate();
+  var winPath = HOME.replace(/\//g, "\\") + "\\.claude\\rules\\my-rule.md";
+  var r = gate({ tool_name: "Write", tool_input: { file_path: winPath } });
+  assert(r && r.decision === "block", "should block with backslash paths");
+});
+
+// --- Write to project .claude/rules/*.md: passes ---
+
+check("Write to project .claude/rules/: passes", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Write", tool_input: { file_path: "/projects/myapp/.claude/rules/my-rule.md" } });
+  assert(r === null, "project-scoped rules should be allowed");
+});
+
+check("Write to project .claude/rules/ (Windows path): passes", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Write", tool_input: { file_path: "C:\\Projects\\app\\.claude\\rules\\test.md" } });
+  assert(r === null, "project-scoped rules on Windows should be allowed");
+});
+
+// --- Write to global archive: passes ---
+
+check("Write to archive subdir: passes", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Write", tool_input: { file_path: HOME + "/.claude/rules/archive/old-rule.md" } });
+  assert(r === null, "archive should be exempted");
+});
+
+// --- Write non-.md files: passes ---
+
+check("Write .json to global rules: passes", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Write", tool_input: { file_path: HOME + "/.claude/rules/config.json" } });
+  assert(r === null, "only .md files are blocked");
+});
+
+check("Write .txt to global rules: passes", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Write", tool_input: { file_path: HOME + "/.claude/rules/notes.txt" } });
+  assert(r === null, "only .md files are blocked");
+});
+
+// --- Write to non-rules paths: passes ---
+
+check("Write to ~/.claude/settings.json: passes", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Write", tool_input: { file_path: HOME + "/.claude/settings.json" } });
+  assert(r === null);
+});
+
+check("Write to random path: passes", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Write", tool_input: { file_path: "/tmp/test.md" } });
+  assert(r === null);
+});
+
+// --- Write nested path (not direct child of rules/): passes ---
+
+check("Write to subdirectory of rules (not direct .md): passes", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Write", tool_input: { file_path: HOME + "/.claude/rules/sub/nested.md" } });
+  assert(r === null, "nested paths are not direct children, should pass regex");
+});
+
+// --- Edge cases ---
+
+check("Missing file_path: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Write", tool_input: {} }) === null);
+});
+
+check("Empty file_path: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Write", tool_input: { file_path: "" } }) === null);
+});
+
+// --- Summary ---
+console.log("\n" + passed + " passed, " + failed + " failed");
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/test/test-pr-per-task-gate.js
+++ b/scripts/test/test-pr-per-task-gate.js
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+"use strict";
+// T572: Tests for pr-per-task-gate.js
+// Blocks gh pr create if title doesn't include a task ID (T001, T002, etc.)
+
+var path = require("path");
+var modPath = path.join(__dirname, "..", "..", "modules", "PreToolUse", "pr-per-task-gate.js");
+var passed = 0, failed = 0;
+
+function check(name, fn) {
+  try { fn(); console.log("OK: " + name); passed++; }
+  catch (e) { console.log("FAIL: " + name + " — " + e.message); failed++; }
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg || "assertion failed"); }
+
+function loadGate() {
+  delete require.cache[require.resolve(modPath)];
+  return require(modPath);
+}
+
+function makeInput(cmd) {
+  return { tool_name: "Bash", tool_input: { command: cmd } };
+}
+
+// --- Non-Bash tools pass ---
+
+check("Non-Bash tool: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: "x" } }) === null);
+});
+
+// --- Non-PR Bash commands pass ---
+
+check("Bash non-PR command: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("git status")) === null);
+});
+
+check("gh issue create: passes (not PR)", function() {
+  var gate = loadGate();
+  assert(gate(makeInput('gh issue create --title "No task ID here"')) === null);
+});
+
+check("gh pr list: passes (not create)", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("gh pr list")) === null);
+});
+
+check("gh pr merge: passes (not create)", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("gh pr merge 42 --squash")) === null);
+});
+
+// --- gh pr create with task ID: passes ---
+
+check("PR title with T001: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput('gh pr create --title "T001: Fix the thing" --body "details"')) === null);
+});
+
+check("PR title with T572: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput('gh pr create --title "T572: Add tests" --body "x"')) === null);
+});
+
+check("PR title with task ID mid-string: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput('gh pr create --title "Fix: T123 widget alignment" --body "x"')) === null);
+});
+
+check("PR title with single quotes: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("gh pr create --title 'T042: Marketplace sync' --body 'done'")) === null);
+});
+
+// --- gh pr create without task ID: blocks ---
+
+check("PR title without task ID: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput('gh pr create --title "Fix the thing" --body "details"'));
+  assert(r && r.decision === "block", "should block");
+  assert(r.reason.indexOf("task ID") >= 0, "should mention task ID");
+});
+
+check("PR title with only numbers (no T prefix): blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput('gh pr create --title "Fix issue 42" --body "x"'));
+  assert(r && r.decision === "block");
+});
+
+check("PR title empty string: passes (regex can't capture empty)", function() {
+  var gate = loadGate();
+  // Empty title doesn't match [^"']+ so titleMatch is null — gate passes
+  assert(gate(makeInput('gh pr create --title "" --body "x"')) === null);
+});
+
+check("PR title with T but only 2 digits (T01): blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput('gh pr create --title "T01: short id" --body "x"'));
+  assert(r && r.decision === "block");
+});
+
+// --- Edge cases ---
+
+check("gh pr create without --title flag: passes (no title to check)", function() {
+  var gate = loadGate();
+  // When no --title is provided, gh prompts interactively — gate can't check
+  assert(gate(makeInput("gh pr create --body 'x'")) === null);
+});
+
+check("Empty command: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("")) === null);
+});
+
+check("Missing tool_input: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash" }) === null);
+});
+
+// --- Summary ---
+console.log("\n" + passed + " passed, " + failed + " failed");
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- **messaging-safety-gate** (19 tests): outbound messaging blocks, allowed chat ID pass-through, edge cases
- **pr-per-task-gate** (16 tests): task ID enforcement in PR titles, non-PR commands pass
- **no-passive-rules** (15 tests): global rules blocked, project-scoped allowed, archive exemption

50 new tests for 3 previously untested modules.

## Test plan
- [x] `node scripts/test/test-messaging-safety-gate.js` — 19/19 passed
- [x] `node scripts/test/test-pr-per-task-gate.js` — 16/16 passed
- [x] `node scripts/test/test-no-passive-rules.js` — 15/15 passed