### PR TITLE
T573: Add tests for no-adhoc-commands and block-local-docker (#484)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1403,7 +1403,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T569: Add tests for reflection-gate (20) and task-completion-gate (15) — hot-path modules. (PR #480)
 - [x] T570: Add tests for settings-hooks-gate (14) and no-hook-bypass (21) — security gates. (PR #481)
 - [x] T571: Version bump to v2.66.0 — CHANGELOG, package.json, GitHub release. 103 suites, 1552 tests. (PR #482)
-- [ ] T572: Add tests for messaging-safety-gate, pr-per-task-gate, and no-passive-rules.
+- [x] T572: Add tests for messaging-safety-gate (19), pr-per-task-gate (16), no-passive-rules (15). (PR #483)
+- [ ] T573: Add tests for no-adhoc-commands and block-local-docker.
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog

--- a/scripts/test/test-block-local-docker.js
+++ b/scripts/test/test-block-local-docker.js
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+"use strict";
+// T573: Tests for block-local-docker.js
+// Blocks local Docker commands except read-only inspection (ps, logs, inspect, etc.)
+
+var path = require("path");
+var modPath = path.join(__dirname, "..", "..", "modules", "PreToolUse", "block-local-docker.js");
+var passed = 0, failed = 0;
+
+function check(name, fn) {
+  try { fn(); console.log("OK: " + name); passed++; }
+  catch (e) { console.log("FAIL: " + name + " — " + e.message); failed++; }
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg || "assertion failed"); }
+
+function loadGate() {
+  delete require.cache[require.resolve(modPath)];
+  return require(modPath);
+}
+
+function makeInput(cmd) {
+  return { tool_name: "Bash", tool_input: { command: cmd } };
+}
+
+// --- Non-Bash tools pass ---
+
+check("Non-Bash tool: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: "x" } }) === null);
+});
+
+check("Read tool: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Read", tool_input: { file_path: "x" } }) === null);
+});
+
+// --- Non-docker commands pass ---
+
+check("git command: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("git status")) === null);
+});
+
+check("node command: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("node app.js")) === null);
+});
+
+// --- Docker read-only commands pass ---
+
+check("docker ps: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("docker ps")) === null);
+});
+
+check("docker images: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("docker images")) === null);
+});
+
+check("docker inspect: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("docker inspect mycontainer")) === null);
+});
+
+check("docker logs: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("docker logs mycontainer")) === null);
+});
+
+check("docker version: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("docker version")) === null);
+});
+
+check("docker info: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("docker info")) === null);
+});
+
+check("docker stats: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("docker stats")) === null);
+});
+
+// --- Docker-compose read-only commands pass ---
+
+check("docker-compose ps: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("docker-compose ps")) === null);
+});
+
+check("docker-compose logs: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("docker-compose logs web")) === null);
+});
+
+check("docker-compose config: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("docker-compose config")) === null);
+});
+
+// --- Docker state-changing commands block ---
+
+check("docker run: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("docker run -d nginx"));
+  assert(r && r.decision === "block");
+  assert(r.reason.indexOf("no-local-docker") >= 0);
+});
+
+check("docker build: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("docker build -t myimage ."));
+  assert(r && r.decision === "block");
+});
+
+check("docker pull: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("docker pull ubuntu:latest"));
+  assert(r && r.decision === "block");
+});
+
+check("docker push: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("docker push myimage:latest"));
+  assert(r && r.decision === "block");
+});
+
+check("docker stop: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("docker stop mycontainer"));
+  assert(r && r.decision === "block");
+});
+
+check("docker rm: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("docker rm mycontainer"));
+  assert(r && r.decision === "block");
+});
+
+check("docker exec: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("docker exec -it container bash"));
+  assert(r && r.decision === "block");
+});
+
+// --- Docker-compose state-changing commands block ---
+
+check("docker-compose up: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("docker-compose up -d"));
+  assert(r && r.decision === "block");
+});
+
+check("docker-compose down: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("docker-compose down"));
+  assert(r && r.decision === "block");
+});
+
+check("docker-compose build: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("docker-compose build"));
+  assert(r && r.decision === "block");
+});
+
+// --- sudo prefix: still blocks ---
+
+check("sudo docker run: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("sudo docker run -d nginx"));
+  assert(r && r.decision === "block");
+});
+
+// --- Edge cases ---
+
+check("Empty command: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("")) === null);
+});
+
+check("Missing tool_input: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash" }) === null);
+});
+
+// --- Summary ---
+console.log("\n" + passed + " passed, " + failed + " failed");
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/test/test-no-adhoc-commands.js
+++ b/scripts/test/test-no-adhoc-commands.js
@@ -1,0 +1,299 @@
+#!/usr/bin/env node
+"use strict";
+// T573: Tests for no-adhoc-commands.js
+// Blocks ad-hoc infrastructure commands (AWS, SSH, Docker, kubectl, az, terraform, etc.)
+// All operations must go through reusable scripts in scripts/.
+
+var path = require("path");
+var modPath = path.join(__dirname, "..", "..", "modules", "PreToolUse", "no-adhoc-commands.js");
+var passed = 0, failed = 0;
+
+function check(name, fn) {
+  try { fn(); console.log("OK: " + name); passed++; }
+  catch (e) { console.log("FAIL: " + name + " — " + e.message); failed++; }
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg || "assertion failed"); }
+
+function loadGate() {
+  delete require.cache[require.resolve(modPath)];
+  return require(modPath);
+}
+
+function makeInput(cmd) {
+  return { tool_name: "Bash", tool_input: { command: cmd } };
+}
+
+// --- Non-Bash tools pass ---
+
+check("Non-Bash tool: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: "x" } }) === null);
+});
+
+// --- Safe dev tools pass ---
+
+check("git status: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("git status")) === null);
+});
+
+check("npm install: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("npm install lodash")) === null);
+});
+
+check("node command: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("node setup.js --test")) === null);
+});
+
+check("python command: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("python script.py")) === null);
+});
+
+check("ls command: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("ls -la")) === null);
+});
+
+check("cat command: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("cat file.txt")) === null);
+});
+
+check("grep command: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("grep -rn 'pattern' src/")) === null);
+});
+
+check("echo command: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("echo hello world")) === null);
+});
+
+// --- Script paths pass ---
+
+check("scripts/ path: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("scripts/aws/deploy.sh")) === null);
+});
+
+check("bash scripts/ path: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("bash scripts/k8s/apply.sh")) === null);
+});
+
+check("./scripts/ path: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("./scripts/fleet/api-submit.sh")) === null);
+});
+
+check("bash ./scripts/ path: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("bash ./scripts/test/run.sh")) === null);
+});
+
+check("Absolute Windows script path: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("bash C:/Projects/myapp/scripts/deploy.sh")) === null);
+});
+
+check("source scripts/: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("source scripts/fleet/config.sh")) === null);
+});
+
+check("Generic .sh file: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("bash deploy.sh")) === null);
+});
+
+// --- AWS CLI: blocks ---
+
+check("aws ec2 describe-instances: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("aws ec2 describe-instances --profile hackathon"));
+  assert(r && r.decision === "block");
+  assert(r.reason.indexOf("AD-HOC AWS") >= 0);
+});
+
+check("aws s3 ls: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("aws s3 ls s3://mybucket"));
+  assert(r && r.decision === "block");
+});
+
+check("aws cloudformation deploy: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("aws cloudformation deploy --template-file cf.yaml"));
+  assert(r && r.decision === "block");
+});
+
+check("aws lambda invoke: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("aws lambda invoke --function-name myFunc output.json"));
+  assert(r && r.decision === "block");
+});
+
+// --- SSH/SCP: blocks ---
+
+check("ssh command: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("ssh user@host 'ls -la'"));
+  assert(r && r.decision === "block");
+  assert(r.reason.indexOf("AD-HOC SSH") >= 0);
+});
+
+check("scp command: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("scp file.txt user@host:/tmp/"));
+  assert(r && r.decision === "block");
+});
+
+// --- Docker (state-changing): blocks ---
+
+check("docker run: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("docker run -d nginx"));
+  assert(r && r.decision === "block");
+  assert(r.reason.indexOf("AD-HOC DOCKER") >= 0);
+});
+
+check("docker exec: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("docker exec -it container bash"));
+  assert(r && r.decision === "block");
+});
+
+check("docker stop: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("docker stop mycontainer"));
+  assert(r && r.decision === "block");
+});
+
+check("docker rm: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("docker rm mycontainer"));
+  assert(r && r.decision === "block");
+});
+
+// --- kubectl: blocks ---
+
+check("kubectl apply: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("kubectl apply -f deploy.yaml"));
+  assert(r && r.decision === "block");
+  assert(r.reason.indexOf("AD-HOC KUBECTL") >= 0);
+});
+
+check("kubectl get pods: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("kubectl get pods -n mynamespace"));
+  assert(r && r.decision === "block");
+});
+
+// --- az CLI: blocks ---
+
+check("az vm list: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("az vm list --output table"));
+  assert(r && r.decision === "block");
+  assert(r.reason.indexOf("AD-HOC AZ") >= 0);
+});
+
+check("az with env var prefix: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("MSYS_NO_PATHCONV=1 az storage blob list"));
+  assert(r && r.decision === "block");
+});
+
+// --- terraform: blocks ---
+
+check("terraform plan: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("terraform plan"));
+  assert(r && r.decision === "block");
+  assert(r.reason.indexOf("AD-HOC TERRAFORM") >= 0);
+});
+
+check("terraform with env prefix: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("TF_VAR_foo=bar terraform apply"));
+  assert(r && r.decision === "block");
+});
+
+// --- azcopy: blocks ---
+
+check("azcopy command: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("azcopy copy source dest"));
+  assert(r && r.decision === "block");
+  assert(r.reason.indexOf("AD-HOC AZCOPY") >= 0);
+});
+
+// --- curl: localhost passes, external blocks ---
+
+check("curl localhost: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("curl http://localhost:8080/api")) === null);
+});
+
+check("curl 127.0.0.1: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("curl http://127.0.0.1:3000/health")) === null);
+});
+
+check("curl external host: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("curl https://api.example.com/data"));
+  assert(r && r.decision === "block");
+  assert(r.reason.indexOf("AD-HOC CURL") >= 0);
+});
+
+// --- RDP/Windows infra: blocks ---
+
+check("mstsc: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("mstsc /v:10.0.0.1"));
+  assert(r && r.decision === "block");
+  assert(r.reason.indexOf("AD-HOC RDP") >= 0);
+});
+
+check("cmdkey: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("cmdkey /add:server /user:admin /pass:secret"));
+  assert(r && r.decision === "block");
+});
+
+// --- PowerShell infra: blocks ---
+
+check("powershell.exe with Set-ItemProperty: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput('powershell.exe -Command "Set-ItemProperty HKLM:\\path -Name x -Value y"'));
+  assert(r && r.decision === "block");
+  assert(r.reason.indexOf("AD-HOC POWERSHELL") >= 0);
+});
+
+check("powershell.exe simple command: passes (no infra patterns)", function() {
+  // powershell.exe without infra patterns isn't explicitly blocked by the gate
+  // It doesn't match any blocked pattern so it falls through to return null
+  var gate = loadGate();
+  assert(gate(makeInput('powershell.exe -Command "Get-Date"')) === null);
+});
+
+// --- Edge cases ---
+
+check("Empty command: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("")) === null);
+});
+
+check("Missing tool_input: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash" }) === null);
+});
+
+// --- Summary ---
+console.log("\n" + passed + " passed, " + failed + " failed");
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- **no-adhoc-commands** (42 tests): AWS, SSH, Docker, kubectl, az, terraform, azcopy, curl, RDP, PowerShell infra blocks + script paths and safe tools pass-through
- **block-local-docker** (27 tests): read-only commands (ps/logs/inspect) pass, state-changing commands blocked, sudo prefix, docker-compose variants

69 new tests for 2 previously untested modules.

## Test plan
- [x] `node scripts/test/test-no-adhoc-commands.js` — 42/42 passed
- [x] `node scripts/test/test-block-local-docker.js` — 27/27 passed