### PR TITLE
T574: Add tests for env-var-check and aws-tagging-gate (#485)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1404,7 +1404,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T570: Add tests for settings-hooks-gate (14) and no-hook-bypass (21) — security gates. (PR #481)
 - [x] T571: Version bump to v2.66.0 — CHANGELOG, package.json, GitHub release. 103 suites, 1552 tests. (PR #482)
 - [x] T572: Add tests for messaging-safety-gate (19), pr-per-task-gate (16), no-passive-rules (15). (PR #483)
-- [ ] T573: Add tests for no-adhoc-commands and block-local-docker.
+- [x] T573: Add tests for no-adhoc-commands (42) and block-local-docker (27). (PR #484)
+- [ ] T574: Add tests for env-var-check and aws-tagging-gate.
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog

--- a/scripts/test/test-aws-tagging-gate.js
+++ b/scripts/test/test-aws-tagging-gate.js
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+"use strict";
+// T574: Tests for aws-tagging-gate.js
+// Enforces Project=hackathon26 tag on AWS resource creation with --profile hackathon.
+
+var path = require("path");
+var modPath = path.join(__dirname, "..", "..", "modules", "PreToolUse", "aws-tagging-gate.js");
+var passed = 0, failed = 0;
+
+function check(name, fn) {
+  try { fn(); console.log("OK: " + name); passed++; }
+  catch (e) { console.log("FAIL: " + name + " — " + e.message); failed++; }
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg || "assertion failed"); }
+
+function loadGate() {
+  delete require.cache[require.resolve(modPath)];
+  return require(modPath);
+}
+
+function makeInput(cmd) {
+  return { tool_name: "Bash", tool_input: { command: cmd } };
+}
+
+// --- Non-Bash tools pass ---
+
+check("Non-Bash tool: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: "x" } }) === null);
+});
+
+// --- Non-hackathon profile: passes ---
+
+check("AWS command without --profile hackathon: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("aws ec2 run-instances --profile default --image-id ami-123")) === null);
+});
+
+check("AWS command with no profile: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("aws s3 ls")) === null);
+});
+
+// --- Non-create commands with hackathon profile: passes ---
+
+check("aws s3 ls with hackathon: passes (not a create command)", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("aws s3 ls --profile hackathon")) === null);
+});
+
+check("aws ec2 describe-instances with hackathon: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("aws ec2 describe-instances --profile hackathon")) === null);
+});
+
+// --- Create commands WITHOUT tags: blocks ---
+
+check("ec2 run-instances without tag: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("aws ec2 run-instances --profile hackathon --image-id ami-123"));
+  assert(r && r.decision === "block");
+  assert(r.reason.indexOf("Project=hackathon26") >= 0);
+});
+
+check("cloudformation create-stack without tag: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("aws cloudformation create-stack --profile hackathon --stack-name test"));
+  assert(r && r.decision === "block");
+});
+
+check("cloudformation deploy without tag: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("aws cloudformation deploy --profile hackathon --template-file cf.yaml"));
+  assert(r && r.decision === "block");
+});
+
+check("s3api create-bucket without tag: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("aws s3api create-bucket --profile hackathon --bucket my-bucket"));
+  assert(r && r.decision === "block");
+});
+
+check("lambda create-function without tag: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("aws lambda create-function --profile hackathon --function-name test"));
+  assert(r && r.decision === "block");
+});
+
+check("ec2 create-security-group without tag: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("aws ec2 create-security-group --profile hackathon --group-name test"));
+  assert(r && r.decision === "block");
+});
+
+check("iam create-role without tag: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("aws iam create-role --profile hackathon --role-name test"));
+  assert(r && r.decision === "block");
+});
+
+check("ecs create-cluster without tag: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("aws ecs create-cluster --profile hackathon --cluster-name test"));
+  assert(r && r.decision === "block");
+});
+
+check("ecr create-repository without tag: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("aws ecr create-repository --profile hackathon --repository-name test"));
+  assert(r && r.decision === "block");
+});
+
+// --- Create commands WITH proper tag: passes ---
+
+check("ec2 run-instances with Key=Project,Value=hackathon26: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("aws ec2 run-instances --profile hackathon --image-id ami-123 --tags Key=Project,Value=hackathon26")) === null);
+});
+
+check("cloudformation deploy with Project=hackathon26 in params: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput('aws cloudformation deploy --profile hackathon --tags Project=hackathon26')) === null);
+});
+
+check("JSON-style tag: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput('aws ec2 run-instances --profile hackathon --tag-specifications \'{"Project": "hackathon26"}\'')) === null);
+});
+
+// --- Edge cases ---
+
+check("Empty command: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("")) === null);
+});
+
+check("Missing tool_input: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash" }) === null);
+});
+
+// --- Summary ---
+console.log("\n" + passed + " passed, " + failed + " failed");
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/test/test-env-var-check.js
+++ b/scripts/test/test-env-var-check.js
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+"use strict";
+// T574: Tests for env-var-check.js
+// Blocks Write/Edit/Bash when required env vars (from .env.required) are missing.
+
+var path = require("path");
+var fs = require("fs");
+var os = require("os");
+var modPath = path.join(__dirname, "..", "..", "modules", "PreToolUse", "env-var-check.js");
+var passed = 0, failed = 0;
+
+function check(name, fn) {
+  try { fn(); console.log("OK: " + name); passed++; }
+  catch (e) { console.log("FAIL: " + name + " — " + e.message); failed++; }
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg || "assertion failed"); }
+
+function loadGate() {
+  delete require.cache[require.resolve(modPath)];
+  return require(modPath);
+}
+
+// Create a temp dir with .env.required for testing
+var tmpDir = path.join(os.tmpdir(), "test-env-var-check-" + Date.now());
+fs.mkdirSync(tmpDir, { recursive: true });
+
+var origProjectDir = process.env.CLAUDE_PROJECT_DIR;
+
+function cleanup() {
+  process.env.CLAUDE_PROJECT_DIR = origProjectDir || "";
+  try { fs.rmSync(tmpDir, { recursive: true }); } catch(e) {}
+}
+
+// --- Non-gated tools pass ---
+
+check("Read tool: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Read", tool_input: { file_path: "x" } }) === null);
+});
+
+check("Glob tool: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Glob", tool_input: { pattern: "*.js" } }) === null);
+});
+
+// --- No .env.required file: passes ---
+
+check("No .env.required file: Write passes", function() {
+  process.env.CLAUDE_PROJECT_DIR = tmpDir;
+  var gate = loadGate();
+  assert(gate({ tool_name: "Write", tool_input: { file_path: "test.js", content: "x" } }) === null);
+});
+
+check("No .env.required file: Edit passes", function() {
+  process.env.CLAUDE_PROJECT_DIR = tmpDir;
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: "test.js" } }) === null);
+});
+
+check("No .env.required file: Bash passes", function() {
+  process.env.CLAUDE_PROJECT_DIR = tmpDir;
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: "echo hi" } }) === null);
+});
+
+// --- Empty .env.required: passes ---
+
+check("Empty .env.required: passes", function() {
+  var dir2 = path.join(tmpDir, "empty");
+  fs.mkdirSync(dir2, { recursive: true });
+  fs.writeFileSync(path.join(dir2, ".env.required"), "\n\n# just comments\n");
+  process.env.CLAUDE_PROJECT_DIR = dir2;
+  var gate = loadGate();
+  assert(gate({ tool_name: "Write", tool_input: { file_path: "x.js", content: "x" } }) === null);
+});
+
+// --- Missing env vars: blocks ---
+
+check("Missing required var: blocks Write", function() {
+  var dir3 = path.join(tmpDir, "missing");
+  fs.mkdirSync(dir3, { recursive: true });
+  fs.writeFileSync(path.join(dir3, ".env.required"), "TEST_MISSING_VAR_XYZ_123\n");
+  delete process.env.TEST_MISSING_VAR_XYZ_123;
+  process.env.CLAUDE_PROJECT_DIR = dir3;
+  var gate = loadGate();
+  var r = gate({ tool_name: "Write", tool_input: { file_path: "x.js", content: "x" } });
+  assert(r && r.decision === "block", "should block when var missing");
+  assert(r.reason.indexOf("TEST_MISSING_VAR_XYZ_123") >= 0, "should name the missing var");
+});
+
+check("Missing required var: blocks Edit", function() {
+  var dir3 = path.join(tmpDir, "missing");
+  process.env.CLAUDE_PROJECT_DIR = dir3;
+  delete process.env.TEST_MISSING_VAR_XYZ_123;
+  var gate = loadGate();
+  var r = gate({ tool_name: "Edit", tool_input: { file_path: "x.js" } });
+  assert(r && r.decision === "block");
+});
+
+check("Missing required var: blocks Bash", function() {
+  var dir3 = path.join(tmpDir, "missing");
+  process.env.CLAUDE_PROJECT_DIR = dir3;
+  delete process.env.TEST_MISSING_VAR_XYZ_123;
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: { command: "echo" } });
+  assert(r && r.decision === "block");
+});
+
+// --- Present env vars: passes ---
+
+check("Required var present: passes", function() {
+  var dir4 = path.join(tmpDir, "present");
+  fs.mkdirSync(dir4, { recursive: true });
+  fs.writeFileSync(path.join(dir4, ".env.required"), "HOME\n");
+  process.env.CLAUDE_PROJECT_DIR = dir4;
+  var gate = loadGate();
+  // HOME is always set
+  assert(gate({ tool_name: "Write", tool_input: { file_path: "x.js", content: "x" } }) === null);
+});
+
+// --- Comment lines and description format ---
+
+check("Comment lines ignored: passes when only comments", function() {
+  var dir5 = path.join(tmpDir, "comments");
+  fs.mkdirSync(dir5, { recursive: true });
+  fs.writeFileSync(path.join(dir5, ".env.required"), "# This is a comment\n# Another comment\nHOME # user home dir\n");
+  process.env.CLAUDE_PROJECT_DIR = dir5;
+  var gate = loadGate();
+  assert(gate({ tool_name: "Write", tool_input: { file_path: "x.js", content: "x" } }) === null);
+});
+
+// --- No CLAUDE_PROJECT_DIR: passes ---
+
+check("No CLAUDE_PROJECT_DIR: passes", function() {
+  process.env.CLAUDE_PROJECT_DIR = "";
+  var gate = loadGate();
+  assert(gate({ tool_name: "Write", tool_input: { file_path: "x.js", content: "x" } }) === null);
+});
+
+// --- Multiple missing vars ---
+
+check("Multiple missing vars: all named in reason", function() {
+  var dir6 = path.join(tmpDir, "multi");
+  fs.mkdirSync(dir6, { recursive: true });
+  fs.writeFileSync(path.join(dir6, ".env.required"), "MISSING_AAA_TEST\nMISSING_BBB_TEST\n");
+  delete process.env.MISSING_AAA_TEST;
+  delete process.env.MISSING_BBB_TEST;
+  process.env.CLAUDE_PROJECT_DIR = dir6;
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: { command: "echo" } });
+  assert(r && r.decision === "block");
+  assert(r.reason.indexOf("MISSING_AAA_TEST") >= 0);
+  assert(r.reason.indexOf("MISSING_BBB_TEST") >= 0);
+});
+
+// Cleanup
+cleanup();
+
+// --- Summary ---
+console.log("\n" + passed + " passed, " + failed + " failed");
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- **env-var-check** (13 tests): .env.required parsing, missing/present vars, comments, empty file, no project dir
- **aws-tagging-gate** (19 tests): hackathon profile enforcement, 8 create patterns blocked without tags, tag format variants pass

32 new tests for 2 previously untested modules.

## Test plan
- [x] `node scripts/test/test-env-var-check.js` — 13/13 passed
- [x] `node scripts/test/test-aws-tagging-gate.js` — 19/19 passed