### PR TITLE
T575: Add tests for deploy-gate, deploy-history-reminder, settings-change-gate (#486)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1405,7 +1405,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T571: Version bump to v2.66.0 — CHANGELOG, package.json, GitHub release. 103 suites, 1552 tests. (PR #482)
 - [x] T572: Add tests for messaging-safety-gate (19), pr-per-task-gate (16), no-passive-rules (15). (PR #483)
 - [x] T573: Add tests for no-adhoc-commands (42) and block-local-docker (27). (PR #484)
-- [ ] T574: Add tests for env-var-check and aws-tagging-gate.
+- [x] T574: Add tests for env-var-check (13) and aws-tagging-gate (19). (PR #485)
+- [ ] T575: Add tests for deploy-gate, deploy-history-reminder, and settings-change-gate.
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog

--- a/scripts/test/test-deploy-gate.js
+++ b/scripts/test/test-deploy-gate.js
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+"use strict";
+// T575: Tests for deploy-gate.js
+// Blocks deploy commands when there are uncommitted git changes.
+
+var path = require("path");
+var fs = require("fs");
+var os = require("os");
+var cp = require("child_process");
+var modPath = path.join(__dirname, "..", "..", "modules", "PreToolUse", "deploy-gate.js");
+var passed = 0, failed = 0;
+
+function check(name, fn) {
+  try { fn(); console.log("OK: " + name); passed++; }
+  catch (e) { console.log("FAIL: " + name + " — " + e.message); failed++; }
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg || "assertion failed"); }
+
+function loadGate() {
+  delete require.cache[require.resolve(modPath)];
+  return require(modPath);
+}
+
+function makeInput(cmd) {
+  return { tool_name: "Bash", tool_input: { command: cmd } };
+}
+
+// Create a temp git repo for testing
+var tmpDir = path.join(os.tmpdir(), "test-deploy-gate-" + Date.now());
+fs.mkdirSync(tmpDir, { recursive: true });
+cp.execFileSync("git", ["init"], { cwd: tmpDir, windowsHide: true });
+cp.execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: tmpDir, windowsHide: true });
+cp.execFileSync("git", ["config", "user.name", "Test"], { cwd: tmpDir, windowsHide: true });
+fs.writeFileSync(path.join(tmpDir, "file.txt"), "initial");
+cp.execFileSync("git", ["add", "."], { cwd: tmpDir, windowsHide: true });
+cp.execFileSync("git", ["commit", "-m", "init"], { cwd: tmpDir, windowsHide: true });
+
+var origCwd = process.cwd();
+
+function cleanup() {
+  process.chdir(origCwd);
+  try { fs.rmSync(tmpDir, { recursive: true }); } catch(e) {}
+}
+
+// --- Non-Bash tools pass ---
+
+check("Non-Bash tool: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: "x" } }) === null);
+});
+
+// --- Non-deploy commands pass ---
+
+check("git status: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("git status")) === null);
+});
+
+check("npm install: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("npm install")) === null);
+});
+
+// --- Deploy patterns on clean tree: passes ---
+
+check("upload-and-run on clean tree: passes", function() {
+  process.chdir(tmpDir);
+  var gate = loadGate();
+  assert(gate(makeInput("bash scripts/upload-and-run.sh")) === null);
+});
+
+check("kubectl apply on clean tree: passes", function() {
+  process.chdir(tmpDir);
+  var gate = loadGate();
+  assert(gate(makeInput("kubectl apply -f deploy.yaml")) === null);
+});
+
+check("terraform apply on clean tree: passes", function() {
+  process.chdir(tmpDir);
+  var gate = loadGate();
+  assert(gate(makeInput("terraform apply")) === null);
+});
+
+check("docker push on clean tree: passes", function() {
+  process.chdir(tmpDir);
+  var gate = loadGate();
+  assert(gate(makeInput("docker push myimage:latest")) === null);
+});
+
+// --- Deploy patterns on dirty tree: blocks ---
+
+check("upload-and-run on dirty tree: blocks", function() {
+  process.chdir(tmpDir);
+  fs.writeFileSync(path.join(tmpDir, "dirty.txt"), "uncommitted");
+  var gate = loadGate();
+  var r = gate(makeInput("bash scripts/upload-and-run.sh"));
+  assert(r && r.decision === "block", "should block with uncommitted changes");
+  assert(r.reason.indexOf("DEPLOY GATE") >= 0);
+  assert(r.reason.indexOf("uncommitted") >= 0);
+  // Clean up
+  fs.unlinkSync(path.join(tmpDir, "dirty.txt"));
+});
+
+check("quick-sync on dirty tree: blocks", function() {
+  process.chdir(tmpDir);
+  fs.writeFileSync(path.join(tmpDir, "dirty2.txt"), "uncommitted");
+  var gate = loadGate();
+  var r = gate(makeInput("bash scripts/quick-sync.sh"));
+  assert(r && r.decision === "block");
+  fs.unlinkSync(path.join(tmpDir, "dirty2.txt"));
+});
+
+check("create-zip on dirty tree: blocks", function() {
+  process.chdir(tmpDir);
+  fs.writeFileSync(path.join(tmpDir, "dirty3.txt"), "uncommitted");
+  var gate = loadGate();
+  var r = gate(makeInput("bash scripts/e2e/create-zip.sh"));
+  assert(r && r.decision === "block");
+  fs.unlinkSync(path.join(tmpDir, "dirty3.txt"));
+});
+
+check("scp with remote: blocks on dirty tree", function() {
+  process.chdir(tmpDir);
+  fs.writeFileSync(path.join(tmpDir, "dirty4.txt"), "uncommitted");
+  var gate = loadGate();
+  var r = gate(makeInput("scp file.txt user@host:/tmp/"));
+  assert(r && r.decision === "block");
+  fs.unlinkSync(path.join(tmpDir, "dirty4.txt"));
+});
+
+check("aws s3 cp: blocks on dirty tree", function() {
+  process.chdir(tmpDir);
+  fs.writeFileSync(path.join(tmpDir, "dirty5.txt"), "uncommitted");
+  var gate = loadGate();
+  var r = gate(makeInput("aws s3 cp file.zip s3://bucket/"));
+  assert(r && r.decision === "block");
+  fs.unlinkSync(path.join(tmpDir, "dirty5.txt"));
+});
+
+// --- Edge cases ---
+
+check("Empty command: passes", function() {
+  process.chdir(origCwd);
+  var gate = loadGate();
+  assert(gate(makeInput("")) === null);
+});
+
+check("Missing tool_input: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash" }) === null);
+});
+
+cleanup();
+
+// --- Summary ---
+console.log("\n" + passed + " passed, " + failed + " failed");
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/test/test-deploy-history-reminder.js
+++ b/scripts/test/test-deploy-history-reminder.js
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+"use strict";
+// T575: Tests for deploy-history-reminder.js
+// Non-blocking: writes advisory to stderr when deploy command matches.
+// Reminds to check recent git history before deploying.
+
+var path = require("path");
+var fs = require("fs");
+var os = require("os");
+var cp = require("child_process");
+var modPath = path.join(__dirname, "..", "..", "modules", "PreToolUse", "deploy-history-reminder.js");
+var passed = 0, failed = 0;
+
+function check(name, fn) {
+  try { fn(); console.log("OK: " + name); passed++; }
+  catch (e) { console.log("FAIL: " + name + " — " + e.message); failed++; }
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg || "assertion failed"); }
+
+function loadGate() {
+  delete require.cache[require.resolve(modPath)];
+  return require(modPath);
+}
+
+function makeInput(cmd) {
+  return { tool_name: "Bash", tool_input: { command: cmd } };
+}
+
+// Create a temp git repo
+var tmpDir = path.join(os.tmpdir(), "test-deploy-history-" + Date.now());
+fs.mkdirSync(tmpDir, { recursive: true });
+cp.execFileSync("git", ["init"], { cwd: tmpDir, windowsHide: true });
+cp.execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: tmpDir, windowsHide: true });
+cp.execFileSync("git", ["config", "user.name", "Test"], { cwd: tmpDir, windowsHide: true });
+fs.writeFileSync(path.join(tmpDir, "file.txt"), "initial");
+cp.execFileSync("git", ["add", "."], { cwd: tmpDir, windowsHide: true });
+cp.execFileSync("git", ["commit", "-m", "init"], { cwd: tmpDir, windowsHide: true });
+
+var origCwd = process.cwd();
+
+function cleanup() {
+  process.chdir(origCwd);
+  try { fs.rmSync(tmpDir, { recursive: true }); } catch(e) {}
+}
+
+// --- Non-Bash tools pass ---
+
+check("Non-Bash tool: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: "x" } }) === null);
+});
+
+// --- Non-deploy commands: passes (no stderr) ---
+
+check("git status: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("git status")) === null);
+});
+
+check("npm install: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("npm install")) === null);
+});
+
+// --- Deploy patterns: always returns null (non-blocking) ---
+
+check("upload-and-run: returns null (advisory only)", function() {
+  process.chdir(tmpDir);
+  var gate = loadGate();
+  assert(gate(makeInput("bash scripts/upload-and-run.sh")) === null);
+});
+
+check("quick-sync: returns null", function() {
+  process.chdir(tmpDir);
+  var gate = loadGate();
+  assert(gate(makeInput("bash scripts/quick-sync.sh")) === null);
+});
+
+check("create-zip: returns null", function() {
+  process.chdir(tmpDir);
+  var gate = loadGate();
+  assert(gate(makeInput("bash scripts/e2e/create-zip.sh")) === null);
+});
+
+check("terraform apply: returns null", function() {
+  process.chdir(tmpDir);
+  var gate = loadGate();
+  assert(gate(makeInput("terraform apply")) === null);
+});
+
+check("kubectl apply: returns null", function() {
+  process.chdir(tmpDir);
+  var gate = loadGate();
+  assert(gate(makeInput("kubectl apply -f deploy.yaml")) === null);
+});
+
+check("docker push: returns null", function() {
+  process.chdir(tmpDir);
+  var gate = loadGate();
+  assert(gate(makeInput("docker push myimage:latest")) === null);
+});
+
+check("aws s3 cp: returns null", function() {
+  process.chdir(tmpDir);
+  var gate = loadGate();
+  assert(gate(makeInput("aws s3 cp file.zip s3://bucket/")) === null);
+});
+
+check("scp with remote: returns null", function() {
+  process.chdir(tmpDir);
+  var gate = loadGate();
+  assert(gate(makeInput("scp file.txt user@host:/tmp/")) === null);
+});
+
+check("rsync with remote: returns null", function() {
+  process.chdir(tmpDir);
+  var gate = loadGate();
+  assert(gate(makeInput("rsync -avz ./dist/ user@host:/opt/app/")) === null);
+});
+
+// --- Edge cases ---
+
+check("Empty command: passes", function() {
+  process.chdir(origCwd);
+  var gate = loadGate();
+  assert(gate(makeInput("")) === null);
+});
+
+check("Missing tool_input: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash" }) === null);
+});
+
+cleanup();
+
+// --- Summary ---
+console.log("\n" + passed + " passed, " + failed + " failed");
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/test/test-settings-change-gate.js
+++ b/scripts/test/test-settings-change-gate.js
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+"use strict";
+// T575: Tests for settings-change-gate.js
+// Non-blocking gate: returns null for everything (advisory — logged by audit module).
+// Tests document the gate's intent and verify it doesn't accidentally block.
+
+var path = require("path");
+var os = require("os");
+var modPath = path.join(__dirname, "..", "..", "modules", "PreToolUse", "settings-change-gate.js");
+var passed = 0, failed = 0;
+
+function check(name, fn) {
+  try { fn(); console.log("OK: " + name); passed++; }
+  catch (e) { console.log("FAIL: " + name + " — " + e.message); failed++; }
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg || "assertion failed"); }
+
+function loadGate() {
+  delete require.cache[require.resolve(modPath)];
+  return require(modPath);
+}
+
+var HOME = os.homedir().replace(/\\/g, "/");
+
+// --- Non-Edit/Write tools pass ---
+
+check("Bash tool: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: "ls" } }) === null);
+});
+
+check("Read tool: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Read", tool_input: { file_path: HOME + "/settings.json" } }) === null);
+});
+
+// --- Non-settings files: passes ---
+
+check("Edit random file: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: "/tmp/test.js" } }) === null);
+});
+
+check("Write random file: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Write", tool_input: { file_path: "/tmp/test.js", content: "x" } }) === null);
+});
+
+// --- Settings files: passes (non-blocking gate) ---
+
+check("Edit settings.json: passes (non-blocking)", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: HOME + "/.claude/settings.json" } }) === null);
+});
+
+check("Edit settings.local.json: passes (non-blocking)", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: HOME + "/.claude/settings.local.json" } }) === null);
+});
+
+check("Write to hooks/run-modules/: passes (non-blocking)", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Write", tool_input: { file_path: HOME + "/.claude/hooks/run-modules/PreToolUse/test.js", content: "x" } }) === null);
+});
+
+check("Edit run-pretooluse.js: passes (non-blocking)", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: HOME + "/.claude/hooks/run-pretooluse.js" } }) === null);
+});
+
+// --- Windows backslash paths: passes ---
+
+check("Edit settings.json with backslashes: passes", function() {
+  var gate = loadGate();
+  var winPath = HOME.replace(/\//g, "\\") + "\\.claude\\settings.json";
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: winPath } }) === null);
+});
+
+// --- Edge cases ---
+
+check("Empty file_path: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: "" } }) === null);
+});
+
+check("Missing file_path: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: {} }) === null);
+});
+
+// --- Summary ---
+console.log("\n" + passed + " passed, " + failed + " failed");
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- **deploy-gate** (14 tests): clean/dirty tree enforcement, all deploy patterns, git subprocess with temp repo
- **deploy-history-reminder** (14 tests): non-blocking advisory, all deploy patterns verified to return null
- **settings-change-gate** (11 tests): non-blocking gate, settings file detection, tool filtering

39 new tests for 3 previously untested modules.

## Test plan
- [x] `node scripts/test/test-deploy-gate.js` — 14/14 passed
- [x] `node scripts/test/test-deploy-history-reminder.js` — 14/14 passed
- [x] `node scripts/test/test-settings-change-gate.js` — 11/11 passed