### PR TITLE
T576: Add tests for remote-tracking-gate and continuous-claude-gate (#487)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1406,7 +1406,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T572: Add tests for messaging-safety-gate (19), pr-per-task-gate (16), no-passive-rules (15). (PR #483)
 - [x] T573: Add tests for no-adhoc-commands (42) and block-local-docker (27). (PR #484)
 - [x] T574: Add tests for env-var-check (13) and aws-tagging-gate (19). (PR #485)
-- [ ] T575: Add tests for deploy-gate, deploy-history-reminder, and settings-change-gate.
+- [x] T575: Add tests for deploy-gate (14), deploy-history-reminder (14), settings-change-gate (11). (PR #486)
+- [ ] T576: Add tests for remote-tracking-gate and continuous-claude-gate — last 2 untested PreToolUse modules.
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog

--- a/scripts/test/test-continuous-claude-gate.js
+++ b/scripts/test/test-continuous-claude-gate.js
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+"use strict";
+// T576: Tests for continuous-claude-gate.js
+// Blocks Edit/Write on implementation code unless project has tracked tasks.
+// Allows scaffolding files, config, specs. Checks specs/*/tasks.md and TODO.md.
+
+var path = require("path");
+var fs = require("fs");
+var os = require("os");
+var cp = require("child_process");
+var modPath = path.join(__dirname, "..", "..", "modules", "PreToolUse", "continuous-claude-gate.js");
+var passed = 0, failed = 0;
+
+function check(name, fn) {
+  try { fn(); console.log("OK: " + name); passed++; }
+  catch (e) { console.log("FAIL: " + name + " — " + e.message); failed++; }
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg || "assertion failed"); }
+
+function loadGate() {
+  delete require.cache[require.resolve(modPath)];
+  return require(modPath);
+}
+
+// Create temp git repos for testing
+var tmpBase = path.join(os.tmpdir(), "test-continuous-claude-" + Date.now());
+fs.mkdirSync(tmpBase, { recursive: true });
+
+function createGitRepo(name) {
+  var dir = path.join(tmpBase, name);
+  fs.mkdirSync(dir, { recursive: true });
+  cp.execFileSync("git", ["init"], { cwd: dir, windowsHide: true });
+  cp.execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: dir, windowsHide: true });
+  cp.execFileSync("git", ["config", "user.name", "Test"], { cwd: dir, windowsHide: true });
+  fs.writeFileSync(path.join(dir, "dummy.txt"), "init");
+  cp.execFileSync("git", ["add", "."], { cwd: dir, windowsHide: true });
+  cp.execFileSync("git", ["commit", "-m", "init"], { cwd: dir, windowsHide: true });
+  return dir;
+}
+
+var origProjectDir = process.env.CLAUDE_PROJECT_DIR;
+var origSkipSpec = process.env.SKIP_SPEC_GATE;
+var origContinuous = process.env.CONTINUOUS_CLAUDE;
+
+function cleanup() {
+  process.env.CLAUDE_PROJECT_DIR = origProjectDir || "";
+  if (origSkipSpec) process.env.SKIP_SPEC_GATE = origSkipSpec;
+  else delete process.env.SKIP_SPEC_GATE;
+  if (origContinuous) process.env.CONTINUOUS_CLAUDE = origContinuous;
+  else delete process.env.CONTINUOUS_CLAUDE;
+  try { fs.rmSync(tmpBase, { recursive: true }); } catch(e) {}
+}
+
+// --- Non-Edit/Write tools pass ---
+
+check("Bash tool: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: "ls" } }) === null);
+});
+
+check("Read tool: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Read", tool_input: { file_path: "x.js" } }) === null);
+});
+
+// --- SKIP_SPEC_GATE bypasses ---
+
+check("SKIP_SPEC_GATE=1: passes", function() {
+  process.env.SKIP_SPEC_GATE = "1";
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: "/tmp/app.js" } }) === null);
+  delete process.env.SKIP_SPEC_GATE;
+});
+
+// --- CONTINUOUS_CLAUDE bypasses ---
+
+check("CONTINUOUS_CLAUDE=1: passes", function() {
+  process.env.CONTINUOUS_CLAUDE = "1";
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: "/tmp/app.js" } }) === null);
+  delete process.env.CONTINUOUS_CLAUDE;
+});
+
+// --- Allowed file patterns pass ---
+
+check("Edit TODO.md: passes", function() {
+  delete process.env.SKIP_SPEC_GATE;
+  delete process.env.CONTINUOUS_CLAUDE;
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: "/project/TODO.md" } }) === null);
+});
+
+check("Edit SESSION_STATE.md: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: "/project/SESSION_STATE.md" } }) === null);
+});
+
+check("Edit CLAUDE.md: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: "/project/CLAUDE.md" } }) === null);
+});
+
+check("Edit .claude/ file: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: "/project/.claude/config.js" } }) === null);
+});
+
+check("Edit specs/ file: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: "/project/specs/feature/tasks.md" } }) === null);
+});
+
+check("Edit .planning/ file: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: "/project/.planning/PLAN.md" } }) === null);
+});
+
+check("Edit .github/ file: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: "/project/.github/workflows/ci.yml" } }) === null);
+});
+
+check("Edit .gitignore: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: "/project/.gitignore" } }) === null);
+});
+
+check("Edit package.json: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: "/project/package.json" } }) === null);
+});
+
+check("Edit scripts/test/ file: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: "/project/scripts/test/test-foo.js" } }) === null);
+});
+
+// --- Home config file: passes ---
+
+check("Edit ~/.claude/ file: passes", function() {
+  var home = (process.env.HOME || process.env.USERPROFILE || "").replace(/\\/g, "/");
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: home + "/.claude/hooks/test.js" } }) === null);
+});
+
+// --- Project WITH tracked tasks: passes ---
+
+check("Project with specs/feature/tasks.md containing T### checkboxes: passes", function() {
+  delete process.env.SKIP_SPEC_GATE;
+  delete process.env.CONTINUOUS_CLAUDE;
+  var dir = createGitRepo("with-tasks");
+  fs.mkdirSync(path.join(dir, "specs", "feature"), { recursive: true });
+  fs.writeFileSync(path.join(dir, "specs", "feature", "tasks.md"), "- [ ] T001: Do something\n- [x] T002: Done\n");
+  process.env.CLAUDE_PROJECT_DIR = dir;
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: path.join(dir, "src", "app.js") } }) === null);
+});
+
+check("Project with TODO.md containing T### checkboxes: passes", function() {
+  delete process.env.SKIP_SPEC_GATE;
+  delete process.env.CONTINUOUS_CLAUDE;
+  var dir = createGitRepo("with-todo");
+  fs.writeFileSync(path.join(dir, "TODO.md"), "- [ ] T100: Fix bug\n");
+  process.env.CLAUDE_PROJECT_DIR = dir;
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: path.join(dir, "src", "app.js") } }) === null);
+});
+
+// --- Project WITHOUT tracked tasks: blocks ---
+
+check("Project without tasks: blocks .js edit", function() {
+  delete process.env.SKIP_SPEC_GATE;
+  delete process.env.CONTINUOUS_CLAUDE;
+  var dir = createGitRepo("no-tasks");
+  process.env.CLAUDE_PROJECT_DIR = dir;
+  var gate = loadGate();
+  var r = gate({ tool_name: "Edit", tool_input: { file_path: path.join(dir, "src", "app.js") } });
+  assert(r && r.decision === "block", "should block when no tracked tasks");
+  assert(r.reason.indexOf("TRACKED WORKFLOW") >= 0);
+});
+
+check("Project with empty specs dir: blocks", function() {
+  delete process.env.SKIP_SPEC_GATE;
+  delete process.env.CONTINUOUS_CLAUDE;
+  var dir = createGitRepo("empty-specs");
+  fs.mkdirSync(path.join(dir, "specs"), { recursive: true });
+  process.env.CLAUDE_PROJECT_DIR = dir;
+  var gate = loadGate();
+  var r = gate({ tool_name: "Write", tool_input: { file_path: path.join(dir, "src", "new.js"), content: "x" } });
+  assert(r && r.decision === "block");
+});
+
+// --- No git root: passes ---
+
+check("File outside git repo: passes", function() {
+  delete process.env.SKIP_SPEC_GATE;
+  delete process.env.CONTINUOUS_CLAUDE;
+  var dir = path.join(tmpBase, "no-git");
+  fs.mkdirSync(dir, { recursive: true });
+  process.env.CLAUDE_PROJECT_DIR = dir;
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: path.join(dir, "app.js") } }) === null);
+});
+
+// --- Edge cases ---
+
+check("Empty file_path: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: { file_path: "" } }) === null);
+});
+
+check("Missing tool_input: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", tool_input: {} }) === null);
+});
+
+cleanup();
+
+// --- Summary ---
+console.log("\n" + passed + " passed, " + failed + " failed");
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/test/test-remote-tracking-gate.js
+++ b/scripts/test/test-remote-tracking-gate.js
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+"use strict";
+// T576: Tests for remote-tracking-gate.js
+// Blocks Edit/Write on feature branches without remote tracking.
+// Uses _git.branch and _git.tracking from runner input (avoids git spawn).
+
+var path = require("path");
+var modPath = path.join(__dirname, "..", "..", "modules", "PreToolUse", "remote-tracking-gate.js");
+var passed = 0, failed = 0;
+
+function check(name, fn) {
+  try { fn(); console.log("OK: " + name); passed++; }
+  catch (e) { console.log("FAIL: " + name + " — " + e.message); failed++; }
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg || "assertion failed"); }
+
+function loadGate() {
+  delete require.cache[require.resolve(modPath)];
+  return require(modPath);
+}
+
+function makeInput(tool, filePath, branch, tracking) {
+  var input = {
+    tool_name: tool,
+    tool_input: { file_path: filePath },
+    _git: { branch: branch, tracking: tracking }
+  };
+  return input;
+}
+
+// --- Non-Edit/Write tools pass ---
+
+check("Bash tool: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: "ls" }, _git: { branch: "feat", tracking: "" } }) === null);
+});
+
+check("Read tool: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Read", tool_input: { file_path: "x.js" }, _git: { branch: "feat", tracking: "" } }) === null);
+});
+
+// --- Config/spec files exempt ---
+
+check("Edit .md file: passes (config exempt)", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("Edit", "README.md", "feat", "")) === null);
+});
+
+check("Edit .json file: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("Edit", "package.json", "feat", "")) === null);
+});
+
+check("Edit .yaml file: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("Edit", "config.yaml", "feat", "")) === null);
+});
+
+check("Edit .yml file: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("Edit", "config.yml", "feat", "")) === null);
+});
+
+check("Edit specs/ file: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("Edit", "specs/feature/tasks.js", "feat", "")) === null);
+});
+
+check("Edit .claude/ file: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("Edit", ".claude/settings.js", "feat", "")) === null);
+});
+
+check("Edit .github/ file: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("Edit", ".github/workflows/ci.js", "feat", "")) === null);
+});
+
+check("Edit cloudformation/ file: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("Edit", "cloudformation/template.js", "feat", "")) === null);
+});
+
+// --- main/master branch: passes ---
+
+check("Edit on main: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("Edit", "src/app.js", "main", "")) === null);
+});
+
+check("Edit on master: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("Edit", "src/app.js", "master", "")) === null);
+});
+
+// --- No branch info: passes ---
+
+check("No branch: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("Edit", "src/app.js", "", "")) === null);
+});
+
+// --- Feature branch WITH tracking: passes ---
+
+check("Feature branch with tracking: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("Edit", "src/app.js", "feat-123", "origin")) === null);
+});
+
+check("Write on tracked branch: passes", function() {
+  var gate = loadGate();
+  assert(gate(makeInput("Write", "src/new.js", "feat-123", "origin")) === null);
+});
+
+// --- Feature branch WITHOUT tracking: blocks ---
+
+check("Edit .js on untracked branch: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("Edit", "src/app.js", "feat-untracked", ""));
+  assert(r && r.decision === "block", "should block");
+  assert(r.reason.indexOf("REMOTE TRACKING GATE") >= 0);
+  assert(r.reason.indexOf("feat-untracked") >= 0);
+});
+
+check("Write .js on untracked branch: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("Write", "src/new.js", "feat-untracked", ""));
+  assert(r && r.decision === "block");
+});
+
+check("Edit .ts on untracked branch: blocks", function() {
+  var gate = loadGate();
+  var r = gate(makeInput("Edit", "src/app.ts", "feat-xyz", ""));
+  assert(r && r.decision === "block");
+});
+
+// --- Fallback: _git.tracking is null (runner didn't provide) ---
+// In this case the module falls back to git config check.
+// We can't easily test this without a real git repo, but we can
+// verify the module handles the null case without crashing.
+
+check("_git.tracking null: falls back to git config (no crash)", function() {
+  var gate = loadGate();
+  // On main the module returns null before checking tracking
+  var input = {
+    tool_name: "Edit",
+    tool_input: { file_path: "src/app.js" },
+    _git: { branch: "main" }
+    // tracking not set — will be null
+  };
+  assert(gate(input) === null);
+});
+
+// --- Edge cases ---
+
+check("String tool_input: parsed correctly", function() {
+  var gate = loadGate();
+  var input = {
+    tool_name: "Edit",
+    tool_input: JSON.stringify({ file_path: "src/app.js" }),
+    _git: { branch: "feat", tracking: "origin" }
+  };
+  assert(gate(input) === null);
+});
+
+check("Missing tool_input on tracked branch: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Edit", _git: { branch: "feat", tracking: "origin" } }) === null);
+});
+
+check("Missing tool_input on untracked branch: blocks (no file to exempt)", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Edit", _git: { branch: "feat", tracking: "" } });
+  assert(r && r.decision === "block");
+});
+
+// --- Summary ---
+console.log("\n" + passed + " passed, " + failed + " failed");
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- **remote-tracking-gate** (22 tests): branch tracking enforcement, config/spec file exemptions, main/master bypass, _git input injection, string tool_input parsing
- **continuous-claude-gate** (22 tests): task tracking enforcement via specs/tasks.md and TODO.md, env var bypass, scaffolding file exemptions, git repo detection

44 new tests — **completes 100% PreToolUse module test coverage**.

## Test plan
- [x] `node scripts/test/test-remote-tracking-gate.js` — 22/22 passed
- [x] `node scripts/test/test-continuous-claude-gate.js` — 22/22 passed