### PR TITLE
T577: Version bump to v2.67.0 (#488)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.67.0] — 2026-05-03
+
+### Added
+- **messaging-safety-gate tests** (T572) — 19 tests covering outbound messaging blocks, allowed chat ID passthrough, and edge cases.
+- **pr-per-task-gate tests** (T572) — 16 tests covering task ID enforcement in PR titles and non-PR command passthrough.
+- **no-passive-rules tests** (T572) — 15 tests covering global rules blocked, project-scoped allowed, archive exemption.
+- **no-adhoc-commands tests** (T573) — 42 tests covering AWS, SSH, Docker, kubectl, az, terraform, azcopy, curl, RDP, PowerShell infra blocks and safe tool passthrough.
+- **block-local-docker tests** (T573) — 27 tests covering read-only commands pass, state-changing commands blocked, sudo prefix, docker-compose variants.
+- **env-var-check tests** (T574) — 13 tests covering .env.required parsing, missing/present vars, comments, empty file, no project dir.
+- **aws-tagging-gate tests** (T574) — 19 tests covering hackathon profile enforcement, 8 create patterns, tag format variants.
+- **deploy-gate tests** (T575) — 14 tests covering clean/dirty tree enforcement with temp git repo.
+- **deploy-history-reminder tests** (T575) — 14 tests covering non-blocking advisory for all deploy patterns.
+- **settings-change-gate tests** (T575) — 11 tests covering non-blocking gate, settings file detection, tool filtering.
+- **remote-tracking-gate tests** (T576) — 22 tests covering branch tracking enforcement, config file exemptions, _git input injection.
+- **continuous-claude-gate tests** (T576) — 22 tests covering task tracking enforcement via specs/ and TODO.md, env var bypass, scaffolding exemptions.
+
+### Stats
+- 115 suites, 1785 tests
+- 113 modules, 7 workflows
+
 ## [2.66.0] — 2026-05-03
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Modular hook runner for Claude Code. Workflows group modules into enforceable pi
 - `workflows/` — built-in workflow definitions (YAML)
 - `specs/` — feature specs with tasks and checkpoints
 - `demo.js` — interactive demo (simulates module gates against realistic scenarios)
-- `scripts/test/` — test scripts (103 suites, 1552 tests)
+- `scripts/test/` — test scripts (115 suites, 1785 tests)
 - `package.json` — npm package (enables `npx grobomo/hook-runner`)
 
 ## Testing

--- a/TODO.md
+++ b/TODO.md
@@ -1407,7 +1407,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T573: Add tests for no-adhoc-commands (42) and block-local-docker (27). (PR #484)
 - [x] T574: Add tests for env-var-check (13) and aws-tagging-gate (19). (PR #485)
 - [x] T575: Add tests for deploy-gate (14), deploy-history-reminder (14), settings-change-gate (11). (PR #486)
-- [ ] T576: Add tests for remote-tracking-gate and continuous-claude-gate — last 2 untested PreToolUse modules.
+- [x] T576: Add tests for remote-tracking-gate (22) and continuous-claude-gate (22) — 100% PreToolUse coverage. (PR #487)
+- [ ] T577: Version bump to v2.67.0 — CHANGELOG, package.json, GitHub release.
 
 ## Architecture Notes
 - Repo contains the generic/distributable runner system + module catalog

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.66.0",
+  "version": "2.67.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
Version bump to v2.67.0. This release adds 234 new tests across 12 new test files, achieving test coverage for all PreToolUse modules.

New test suites: messaging-safety-gate, pr-per-task-gate, no-passive-rules, no-adhoc-commands, block-local-docker, env-var-check, aws-tagging-gate, deploy-gate, deploy-history-reminder, settings-change-gate, remote-tracking-gate, continuous-claude-gate.

- 115 suites, 1785 tests (up from 103/1552 in v2.66.0)

## Test plan
- [x] Full suite: 115 suites, 1785 passed, 1 failed (T042 marketplace version mismatch — expected, needs separate sync)