### PR TITLE
T579: Fix README module counts (#490)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ The setup wizard will:
 1. Scan your current hooks and generate a styled HTML report
 2. Back up existing hooks to `~/.claude/hooks/archive/`
 3. Install the runner system
-4. Enable the `starter` workflow (with `--yes`) — 42 universally useful modules
+4. Enable the `starter` workflow (with `--yes`) — 47 universally useful modules
 
 Ready for more? Enable the full development pipeline:
 ```bash
-node setup.js --workflow enable shtd    # 101 modules: spec-first, test-first, PR discipline
+node setup.js --workflow enable shtd    # 103 modules: spec-first, test-first, PR discipline
 ```
 
 To undo everything: `node setup.js --uninstall --confirm`

--- a/TODO.md
+++ b/TODO.md
@@ -1410,6 +1410,7 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T576: Add tests for remote-tracking-gate (22) and continuous-claude-gate (22) — 100% PreToolUse coverage. (PR #487)
 - [x] T577: Version bump to v2.67.0 — CHANGELOG, package.json, GitHub release. 115 suites, 1785 tests. (PR #488)
 - [ ] T578: Marketplace sync v2.64.0 → v2.67.0 — copy core files + modules + workflows to ai-skill-marketplace.
+- [ ] T579: Fix README module counts (starter: 42→47, shtd: 101→103).
 
 ## Session Handoff (2026-05-03)
 - v2.67.0 released. 115 suites, 1785 tests, 0 real failures. 113 modules, 7 workflows.


### PR DESCRIPTION
## Summary
Update stale module counts in README.md:
- starter workflow: 42 → 47
- shtd workflow: 101 → 103

Counts verified via `load-modules.js parseWorkflowTags`.