### PR TITLE
T581: Add tests for 4 PostToolUse modules + fix commit-msg-check regex

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1411,6 +1411,7 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T577: Version bump to v2.67.0 — CHANGELOG, package.json, GitHub release. 115 suites, 1785 tests. (PR #488)
 - [ ] T578: Marketplace sync v2.64.0 → v2.67.0 — spawned ai-skill-marketplace session.
 - [x] T579: Fix README module counts (starter: 42→47, shtd: 101→103). (PR #490)
+- [ ] T581: Add tests for PostToolUse modules: commit-msg-check, empty-output-detector, result-review-gate, test-evidence.
 
 ## Session Handoff (2026-05-03, session 2)
 - v2.67.0 released. 115 suites, 1785 tests, 0 real failures. 113 modules, 7 workflows.

--- a/modules/PostToolUse/commit-msg-check.js
+++ b/modules/PostToolUse/commit-msg-check.js
@@ -39,7 +39,7 @@ module.exports = function(input) {
   var firstLine = msg.split("\n")[0];
 
   // Check for WIP/fixup/squash prefixes
-  if (/^(wip|fixup!|squash!|tmp|temp)\b/i.test(firstLine)) {
+  if (/^(wip\b|fixup!|squash!|tmp\b|temp\b)/i.test(firstLine)) {
     warnings.push("Commit message starts with '" + firstLine.split(/\s/)[0] + "' — not suitable for final commits");
   }
 

--- a/scripts/test/test-commit-msg-check.js
+++ b/scripts/test/test-commit-msg-check.js
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+"use strict";
+// T581: Tests for commit-msg-check.js (PostToolUse)
+// Warns/blocks if git commit messages don't follow conventions.
+
+var path = require("path");
+var modPath = path.join(__dirname, "..", "..", "modules", "PostToolUse", "commit-msg-check.js");
+var passed = 0, failed = 0;
+
+function check(name, fn) {
+  try { fn(); console.log("OK: " + name); passed++; }
+  catch (e) { console.log("FAIL: " + name + " — " + e.message); failed++; }
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg || "assertion failed"); }
+
+function loadGate() {
+  delete require.cache[require.resolve(modPath)];
+  return require(modPath);
+}
+
+// --- Non-applicable inputs ---
+
+check("Non-Bash tool: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Read", tool_input: { file_path: "x" } }) === null);
+});
+
+check("Bash non-git command: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: "ls -la" } }) === null);
+});
+
+check("Bash git status (not commit): passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: "git status" } }) === null);
+});
+
+check("Bash git commit --amend: skipped", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: 'git commit --amend -m "wip stuff"' } }) === null);
+});
+
+check("No message extractable: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: "git commit" } }) === null);
+});
+
+// --- Good commit messages ---
+
+check("Task ID prefix: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: 'git commit -m "T581: Add tests for commit-msg-check"' } }) === null);
+});
+
+check("Conventional feat: prefix: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: 'git commit -m "feat: add new feature"' } }) === null);
+});
+
+check("Conventional fix(scope): prefix: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: 'git commit -m "fix(auth): resolve login issue"' } }) === null);
+});
+
+check("Conventional chore!: prefix: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: 'git commit -m "chore!: drop Node 14 support"' } }) === null);
+});
+
+// --- WIP/fixup messages ---
+
+check("WIP prefix: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: { command: 'git commit -m "wip saving progress"' } });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+  assert(r.reason.indexOf("wip") !== -1);
+});
+
+check("fixup! prefix: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: { command: 'git commit -m "fixup! previous commit"' } });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+  assert(r.reason.indexOf("fixup!") !== -1);
+});
+
+check("squash! prefix: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: { command: 'git commit -m "squash! merge these"' } });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("tmp prefix: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: { command: 'git commit -m "tmp checkpoint"' } });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("temp prefix: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: { command: 'git commit -m "temp save state"' } });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("WIP case-insensitive: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: { command: 'git commit -m "WIP fixing tests"' } });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+// --- Long first line ---
+
+check("72 chars exactly: passes", function() {
+  var gate = loadGate();
+  var msg = "T581: " + "x".repeat(66); // 6 + 66 = 72
+  assert(gate({ tool_name: "Bash", tool_input: { command: 'git commit -m "' + msg + '"' } }) === null);
+});
+
+check("73+ chars first line: blocks", function() {
+  var gate = loadGate();
+  var msg = "T581: " + "x".repeat(67); // 6 + 67 = 73
+  var r = gate({ tool_name: "Bash", tool_input: { command: 'git commit -m "' + msg + '"' } });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+  assert(r.reason.indexOf("73 chars") !== -1);
+});
+
+// --- HEREDOC pattern ---
+
+check("HEREDOC commit message: good message passes", function() {
+  var gate = loadGate();
+  var cmd = "git commit -m \"$(cat <<'EOF'\nT581: Add tests for module\nEOF\n)\"";
+  assert(gate({ tool_name: "Bash", tool_input: { command: cmd } }) === null);
+});
+
+check("HEREDOC commit message: WIP blocks", function() {
+  var gate = loadGate();
+  var cmd = "git commit -m \"$(cat <<'EOF'\nwip stuff\nEOF\n)\"";
+  var r = gate({ tool_name: "Bash", tool_input: { command: cmd } });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+// --- Multiple warnings ---
+
+check("WIP + long line: multiple warnings", function() {
+  var gate = loadGate();
+  var msg = "wip " + "x".repeat(70); // wip + 70 = 74 chars
+  var r = gate({ tool_name: "Bash", tool_input: { command: 'git commit -m "' + msg + '"' } });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+  assert(r.reason.indexOf("wip") !== -1);
+  assert(r.reason.indexOf("chars") !== -1);
+});
+
+// --- Edge cases ---
+
+check("Single-quoted message: passes good msg", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: "git commit -m 'T100: Quick fix'" } }) === null);
+});
+
+check("Empty tool_input: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: {} }) === null);
+});
+
+check("Missing tool_input: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash" }) === null);
+});
+
+// --- Summary ---
+console.log("\n=== Results: " + passed + " passed, " + failed + " failed ===");
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/test/test-empty-output-detector.js
+++ b/scripts/test/test-empty-output-detector.js
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+"use strict";
+// T581: Tests for empty-output-detector.js (PostToolUse)
+// Warns when commands that normally produce output return empty.
+
+var path = require("path");
+var modPath = path.join(__dirname, "..", "..", "modules", "PostToolUse", "empty-output-detector.js");
+var passed = 0, failed = 0;
+
+function check(name, fn) {
+  try { fn(); console.log("OK: " + name); passed++; }
+  catch (e) { console.log("FAIL: " + name + " — " + e.message); failed++; }
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg || "assertion failed"); }
+
+function loadGate() {
+  delete require.cache[require.resolve(modPath)];
+  return require(modPath);
+}
+
+// --- Non-Bash tool: passes ---
+
+check("Non-Bash tool: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Read", tool_input: { file_path: "x" }, tool_result: "" }) === null);
+});
+
+// --- Commands with output: passes ---
+
+check("ls with output: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: "ls" }, tool_result: "file1.txt\nfile2.txt" }) === null);
+});
+
+check("cat with output: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: "cat README.md" }, tool_result: "# README" }) === null);
+});
+
+check("curl with output: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: "curl https://example.com" }, tool_result: "<html>..." }) === null);
+});
+
+// --- Expected-output commands with empty output: blocks ---
+
+check("ls with empty output: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: { command: "ls screenshots/" }, tool_result: "" });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+  assert(r.reason.indexOf("EMPTY OUTPUT") !== -1);
+});
+
+check("find with empty output: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: { command: "find . -name '*.py'" }, tool_result: "" });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("cat with empty output: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: { command: "cat myfile.txt" }, tool_result: "" });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("node --test with empty output: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: { command: "node test.js --test" }, tool_result: "" });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("node setup.js --health with empty output: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: { command: "node setup.js --health" }, tool_result: "" });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("curl with empty output: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: { command: "curl -s http://localhost:8080" }, tool_result: "  " });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("kubectl get pods with empty output: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: { command: "kubectl get pods" }, tool_result: "" });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("kubectl describe with empty output: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: { command: "kubectl describe pod mypod" }, tool_result: "" });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("kubectl logs with empty output: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: { command: "kubectl logs mypod" }, tool_result: "\n" });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("az command with empty output: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: { command: "az vm list" }, tool_result: "" });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+// --- Empty-ok commands: passes even with empty output ---
+
+check("cp with empty output: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: "cp a.txt b.txt" }, tool_result: "" }) === null);
+});
+
+check("mv with empty output: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: "mv a.txt b.txt" }, tool_result: "" }) === null);
+});
+
+check("mkdir with empty output: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: "mkdir -p dir" }, tool_result: "" }) === null);
+});
+
+check("rm with empty output: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: "rm temp.txt" }, tool_result: "" }) === null);
+});
+
+check("git add with empty output: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: "git add file.txt" }, tool_result: "" }) === null);
+});
+
+check("git push with empty output: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: "git push origin main" }, tool_result: "" }) === null);
+});
+
+check("redirect with empty output: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: "echo hello > out.txt" }, tool_result: "" }) === null);
+});
+
+check("pipe to wc: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: "cat file.txt | wc -l" }, tool_result: "" }) === null);
+});
+
+check("2>&1 redirect: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: "some_cmd 2>&1" }, tool_result: "" }) === null);
+});
+
+// --- Non-expect-output commands with empty output: passes ---
+
+check("echo with empty output: passes (not in EXPECT_OUTPUT)", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: "echo hello" }, tool_result: "" }) === null);
+});
+
+check("npm install with empty output: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: "npm install" }, tool_result: "" }) === null);
+});
+
+// --- Edge cases ---
+
+check("Whitespace-only output from ls: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: { command: "ls" }, tool_result: "   \n  " });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("Missing tool_result: blocks for ls", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: { command: "ls" }, tool_result: "" });
+  assert(r !== null, "should block");
+});
+
+check("String tool_input: parses correctly", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: JSON.stringify({ command: "ls" }), tool_result: "" });
+  assert(r !== null, "should block");
+});
+
+check("Reason includes command excerpt", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: { command: "ls my-directory/" }, tool_result: "" });
+  assert(r !== null, "should block");
+  assert(r.reason.indexOf("ls my-directory/") !== -1);
+});
+
+// --- Summary ---
+console.log("\n=== Results: " + passed + " passed, " + failed + " failed ===");
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/test/test-result-review-gate.js
+++ b/scripts/test/test-result-review-gate.js
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+"use strict";
+// T581: Tests for result-review-gate.js (PostToolUse)
+// Injects a review checklist when reading report/results files.
+
+var path = require("path");
+var modPath = path.join(__dirname, "..", "..", "modules", "PostToolUse", "result-review-gate.js");
+var passed = 0, failed = 0;
+
+function check(name, fn) {
+  try { fn(); console.log("OK: " + name); passed++; }
+  catch (e) { console.log("FAIL: " + name + " — " + e.message); failed++; }
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg || "assertion failed"); }
+
+function loadGate() {
+  delete require.cache[require.resolve(modPath)];
+  return require(modPath);
+}
+
+// --- Non-Read tool: passes ---
+
+check("Non-Read tool: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: "ls" } }) === null);
+});
+
+check("Write tool: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Write", tool_input: { file_path: "/tmp/report.html" } }) === null);
+});
+
+// --- Non-report files: passes ---
+
+check("Regular source file: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Read", tool_input: { file_path: "/src/index.js" } }) === null);
+});
+
+check("README.md: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Read", tool_input: { file_path: "/project/README.md" } }) === null);
+});
+
+check("package.json: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Read", tool_input: { file_path: "/project/package.json" } }) === null);
+});
+
+check("CHANGELOG.md: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Read", tool_input: { file_path: "/project/CHANGELOG.md" } }) === null);
+});
+
+// --- Report filename patterns: blocks ---
+
+check("file.report.html: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Read", tool_input: { file_path: "/tmp/hook-runner.report.html" } });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+  assert(r.reason.indexOf("REPORT FILE READ") !== -1);
+});
+
+check("report.json: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Read", tool_input: { file_path: "/tmp/report.json" } });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("test-results.xml: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Read", tool_input: { file_path: "/tmp/test-results.xml" } });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("test_results.txt: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Read", tool_input: { file_path: "/tmp/test_results.txt" } });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("coverage.html: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Read", tool_input: { file_path: "/out/coverage.html" } });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("summary.md: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Read", tool_input: { file_path: "/tmp/summary.md" } });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("health-check.log: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Read", tool_input: { file_path: "/tmp/health-check.log" } });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("health_check.txt: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Read", tool_input: { file_path: "/tmp/health_check.txt" } });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("file.pdf: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Read", tool_input: { file_path: "/tmp/analysis.pdf" } });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("result.csv: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Read", tool_input: { file_path: "/tmp/result.csv" } });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+// --- Directory-based detection: blocks ---
+
+check("File in reports/ directory: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Read", tool_input: { file_path: "/project/reports/data.txt" } });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("File in report/ directory: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Read", tool_input: { file_path: "/project/report/output.json" } });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("File in results/ directory: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Read", tool_input: { file_path: "/project/results/test.xml" } });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("Windows backslash path in reports dir: blocks", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Read", tool_input: { file_path: "C:\\project\\reports\\data.txt" } });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+// --- Checklist in reason ---
+
+check("Reason includes checklist items", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Read", tool_input: { file_path: "/tmp/report.html" } });
+  assert(r !== null);
+  assert(r.reason.indexOf("FAIL") !== -1);
+  assert(r.reason.indexOf("WARN") !== -1);
+  assert(r.reason.indexOf("MISSING") !== -1);
+});
+
+check("Reason includes filename", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Read", tool_input: { file_path: "/tmp/my-report.html" } });
+  assert(r !== null);
+  assert(r.reason.indexOf("my-report.html") !== -1);
+});
+
+// --- Edge cases ---
+
+check("Empty file_path: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Read", tool_input: { file_path: "" } }) === null);
+});
+
+check("Missing file_path: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Read", tool_input: {} }) === null);
+});
+
+check("String tool_input: parses correctly", function() {
+  var gate = loadGate();
+  var r = gate({ tool_name: "Read", tool_input: JSON.stringify({ file_path: "/tmp/report.html" }) });
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("Missing tool_input: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Read" }) === null);
+});
+
+// --- Summary ---
+console.log("\n=== Results: " + passed + " passed, " + failed + " failed ===");
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/test/test-test-evidence.js
+++ b/scripts/test/test-test-evidence.js
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+"use strict";
+// T581: Tests for test-evidence.js (PostToolUse)
+// Detects test results in Bash output and writes evidence file for victory-declaration-gate.
+
+var path = require("path");
+var fs = require("fs");
+var os = require("os");
+var modPath = path.join(__dirname, "..", "..", "modules", "PostToolUse", "test-evidence.js");
+var passed = 0, failed = 0;
+
+function check(name, fn) {
+  try { fn(); console.log("OK: " + name); passed++; }
+  catch (e) { console.log("FAIL: " + name + " — " + e.message); failed++; }
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg || "assertion failed"); }
+
+var EVIDENCE_PATH = path.join(os.tmpdir(), ".hook-runner-test-evidence.json");
+
+function loadGate() {
+  delete require.cache[require.resolve(modPath)];
+  return require(modPath);
+}
+
+function cleanEvidence() {
+  try { fs.unlinkSync(EVIDENCE_PATH); } catch(e) {}
+}
+
+// --- Non-applicable inputs ---
+
+check("Non-Bash tool: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Read", tool_input: {}, tool_result: "5 passed, 0 failed" }) === null);
+});
+
+check("Empty tool_result: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: "node test.js" }, tool_result: "" }) === null);
+});
+
+check("No test patterns in output: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: "ls" }, tool_result: "file1.txt\nfile2.txt" }) === null);
+});
+
+// --- Always returns null (never blocks) ---
+
+check("Never blocks even with test results", function() {
+  cleanEvidence();
+  var gate = loadGate();
+  var r = gate({ tool_name: "Bash", tool_input: { command: "node test.js" }, tool_result: "10 passed, 0 failed" });
+  assert(r === null, "should always return null");
+  cleanEvidence();
+});
+
+// --- Test pattern detection + evidence writing ---
+
+check("Pattern: N passed, M failed", function() {
+  cleanEvidence();
+  var gate = loadGate();
+  gate({ tool_name: "Bash", tool_input: { command: "node test.js" }, tool_result: "OK: test1\nOK: test2\n15 passed, 2 failed" });
+  assert(fs.existsSync(EVIDENCE_PATH), "evidence file should exist");
+  var ev = JSON.parse(fs.readFileSync(EVIDENCE_PATH, "utf-8"));
+  assert(ev.passed === 15, "passed should be 15, got " + ev.passed);
+  assert(ev.failed === 2, "failed should be 2, got " + ev.failed);
+  assert(ev.summary === "15 passed, 2 failed");
+  cleanEvidence();
+});
+
+check("Pattern: N suites, M passed, K failed", function() {
+  cleanEvidence();
+  var gate = loadGate();
+  gate({ tool_name: "Bash", tool_input: { command: "node setup.js --test" }, tool_result: "=== Results: 115 suites, 1785 passed, 0 failed ===" });
+  var ev = JSON.parse(fs.readFileSync(EVIDENCE_PATH, "utf-8"));
+  assert(ev.passed === 1785, "passed should be 1785, got " + ev.passed);
+  assert(ev.failed === 0, "failed should be 0, got " + ev.failed);
+  assert(ev.suites === 115, "suites should be 115, got " + ev.suites);
+  cleanEvidence();
+});
+
+check("Pattern: Results: N passed, M failed", function() {
+  cleanEvidence();
+  var gate = loadGate();
+  gate({ tool_name: "Bash", tool_input: { command: "npm test" }, tool_result: "Results: 42 passed, 3 failed" });
+  var ev = JSON.parse(fs.readFileSync(EVIDENCE_PATH, "utf-8"));
+  assert(ev.passed === 42);
+  assert(ev.failed === 3);
+  cleanEvidence();
+});
+
+check("Pattern: Tests: N passed, M failed (jest)", function() {
+  cleanEvidence();
+  var gate = loadGate();
+  gate({ tool_name: "Bash", tool_input: { command: "npx jest" }, tool_result: "Tests: 88 passed, 1 failed" });
+  var ev = JSON.parse(fs.readFileSync(EVIDENCE_PATH, "utf-8"));
+  assert(ev.passed === 88);
+  assert(ev.failed === 1);
+  cleanEvidence();
+});
+
+check("Evidence has timestamp", function() {
+  cleanEvidence();
+  var before = Date.now();
+  var gate = loadGate();
+  gate({ tool_name: "Bash", tool_input: { command: "test" }, tool_result: "5 passed, 0 failed" });
+  var ev = JSON.parse(fs.readFileSync(EVIDENCE_PATH, "utf-8"));
+  assert(ev.ts >= before, "timestamp should be recent");
+  assert(typeof ev.iso === "string" && ev.iso.length > 0, "iso should be set");
+  cleanEvidence();
+});
+
+check("Evidence overwrites previous", function() {
+  cleanEvidence();
+  var gate = loadGate();
+  gate({ tool_name: "Bash", tool_input: { command: "test" }, tool_result: "5 passed, 0 failed" });
+  gate({ tool_name: "Bash", tool_input: { command: "test" }, tool_result: "20 passed, 1 failed" });
+  var ev = JSON.parse(fs.readFileSync(EVIDENCE_PATH, "utf-8"));
+  assert(ev.passed === 20, "should be latest result");
+  assert(ev.failed === 1);
+  cleanEvidence();
+});
+
+// --- No match: no evidence file ---
+
+check("Non-test output: no evidence written", function() {
+  cleanEvidence();
+  var gate = loadGate();
+  gate({ tool_name: "Bash", tool_input: { command: "ls" }, tool_result: "just some output" });
+  assert(!fs.existsSync(EVIDENCE_PATH), "evidence file should not exist");
+});
+
+// --- Edge cases ---
+
+check("Suites default to 0 for non-suite pattern", function() {
+  cleanEvidence();
+  var gate = loadGate();
+  gate({ tool_name: "Bash", tool_input: { command: "test" }, tool_result: "10 passed, 0 failed" });
+  var ev = JSON.parse(fs.readFileSync(EVIDENCE_PATH, "utf-8"));
+  assert(ev.suites === 0, "suites should default to 0");
+  cleanEvidence();
+});
+
+check("Missing tool_result: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: "test" } }) === null);
+});
+
+check("Null tool_result: passes", function() {
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash", tool_input: { command: "test" }, tool_result: null }) === null);
+});
+
+// --- Summary ---
+console.log("\n=== Results: " + passed + " passed, " + failed + " failed ===");
+cleanEvidence();
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- 4 new test suites for PostToolUse modules: commit-msg-check (23), empty-output-detector (29), result-review-gate (26), test-evidence (14)
- Bug fix: `commit-msg-check.js` regex `\b` after `!` never matched `fixup!`/`squash!` prefixes — changed to per-alternative word boundaries

## Test plan
- [x] All 92 new tests pass
- [x] Existing test suite unaffected (module logic unchanged except regex fix)