### PR TITLE
T585: Add tests for mark-turn-complete and auto-continue Stop modules

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1414,7 +1414,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T581: Add tests for PostToolUse: commit-msg-check (23), empty-output-detector (29), result-review-gate (26), test-evidence (14) + fix commit-msg-check regex bug. (PR #492)
 - [x] T582: Add tests for PostToolUse: rule-hygiene (22), background-task-audit (14), disk-space-detect (16), inter-project-audit (15). (PR #493)
 - [x] T583: Add tests for PostToolUse: troubleshoot-detector (14), settings-audit-log (21), update-stale-docs (16), crlf-detector (24). (PR #494)
-- [ ] T584: Add tests for Stop modules: test-before-done, log-gotchas, never-give-up, unresolved-issues-check, test-coverage-check (PostToolUse).
+- [x] T584: Add tests for Stop: test-before-done (4), log-gotchas (4), never-give-up (4), unresolved-issues-check (18), test-coverage-check (18). (PR #495)
+- [ ] T585: Add tests for Stop: mark-turn-complete, auto-continue.
 
 ## Session Handoff (2026-05-03, session 2)
 - v2.67.0 released. 115 suites, 1785 tests, 0 real failures. 113 modules, 7 workflows.

--- a/scripts/test/test-auto-continue.js
+++ b/scripts/test/test-auto-continue.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+"use strict";
+// T585: Tests for auto-continue.js (Stop)
+// Blocks stop with "keep working" message unless preserved-tab-idle flag is set.
+
+var path = require("path");
+var fs = require("fs");
+var os = require("os");
+var modPath = path.join(__dirname, "..", "..", "modules", "Stop", "auto-continue.js");
+var passed = 0, failed = 0;
+
+function check(name, fn) {
+  try { fn(); console.log("OK: " + name); passed++; }
+  catch (e) { console.log("FAIL: " + name + " — " + e.message); failed++; }
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg || "assertion failed"); }
+
+var home = process.env.HOME || process.env.USERPROFILE || "";
+var IDLE_FLAG = path.join(home, ".claude", ".preserved-tab-idle");
+
+function loadGate() {
+  delete require.cache[require.resolve(modPath)];
+  return require(modPath);
+}
+
+function cleanIdleFlag() {
+  try { fs.unlinkSync(IDLE_FLAG); } catch(e) {}
+}
+
+// --- Normal operation: always blocks ---
+
+check("Blocks by default (no idle flag)", function() {
+  cleanIdleFlag();
+  var gate = loadGate();
+  var r = gate({});
+  assert(r !== null, "should block");
+  assert(r.decision === "block");
+});
+
+check("Block reason is non-empty", function() {
+  cleanIdleFlag();
+  var gate = loadGate();
+  var r = gate({});
+  assert(r.reason.length > 0, "reason should not be empty");
+});
+
+check("Block reason comes from stop-message.txt", function() {
+  cleanIdleFlag();
+  var gate = loadGate();
+  var r = gate({});
+  // The message file exists in the module directory
+  var msgPath = path.join(__dirname, "..", "..", "modules", "Stop", "stop-message.txt");
+  if (fs.existsSync(msgPath)) {
+    var expected = fs.readFileSync(msgPath, "utf-8").trim();
+    assert(r.reason === expected, "reason should match stop-message.txt content");
+  } else {
+    // Fallback message when file doesn't exist
+    assert(r.reason.indexOf("TODO.md") !== -1, "fallback should mention TODO.md");
+  }
+});
+
+// --- Preserved-tab-idle flag: passes ---
+
+check("With idle flag: returns null (allows stop)", function() {
+  cleanIdleFlag();
+  var dir = path.dirname(IDLE_FLAG);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(IDLE_FLAG, "");
+  var gate = loadGate();
+  var r = gate({});
+  assert(r === null, "should allow stop when idle flag is set");
+});
+
+check("Idle flag is one-shot: removed after reading", function() {
+  cleanIdleFlag();
+  var dir = path.dirname(IDLE_FLAG);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(IDLE_FLAG, "");
+  var gate = loadGate();
+  gate({});
+  assert(!fs.existsSync(IDLE_FLAG), "idle flag should be deleted after use");
+});
+
+check("Second call after idle flag: blocks again", function() {
+  cleanIdleFlag();
+  var dir = path.dirname(IDLE_FLAG);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(IDLE_FLAG, "");
+  var gate = loadGate();
+  gate({}); // first call removes flag
+  var r = gate({}); // second call should block
+  assert(r !== null, "should block on second call");
+  assert(r.decision === "block");
+});
+
+// --- Edge cases ---
+
+check("Returns same block regardless of input", function() {
+  cleanIdleFlag();
+  var gate = loadGate();
+  var r1 = gate({});
+  var r2 = gate({ tool_name: "something", stop_reason: "user" });
+  assert(r1.reason === r2.reason, "should return same message");
+});
+
+// --- Cleanup ---
+cleanIdleFlag();
+
+// --- Summary ---
+console.log("\n=== Results: " + passed + " passed, " + failed + " failed ===");
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/test/test-mark-turn-complete.js
+++ b/scripts/test/test-mark-turn-complete.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+"use strict";
+// T585: Tests for mark-turn-complete.js (Stop)
+// Writes a marker file when Claude finishes a turn normally.
+
+var path = require("path");
+var fs = require("fs");
+var os = require("os");
+var modPath = path.join(__dirname, "..", "..", "modules", "Stop", "mark-turn-complete.js");
+var passed = 0, failed = 0;
+
+function check(name, fn) {
+  try { fn(); console.log("OK: " + name); passed++; }
+  catch (e) { console.log("FAIL: " + name + " — " + e.message); failed++; }
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg || "assertion failed"); }
+
+var MARKER = path.join(os.tmpdir(), ".claude-turn-complete-" + process.ppid);
+
+function loadGate() {
+  delete require.cache[require.resolve(modPath)];
+  return require(modPath);
+}
+
+function cleanMarker() {
+  try { fs.unlinkSync(MARKER); } catch(e) {}
+}
+
+// --- Always returns null ---
+
+check("Returns null (never blocks)", function() {
+  cleanMarker();
+  var gate = loadGate();
+  var r = gate({});
+  assert(r === null, "should never block");
+});
+
+check("Returns null regardless of input", function() {
+  cleanMarker();
+  var gate = loadGate();
+  assert(gate({ tool_name: "Bash" }) === null);
+  assert(gate({ some: "data" }) === null);
+});
+
+// --- Writes marker file ---
+
+check("Creates marker file", function() {
+  cleanMarker();
+  var gate = loadGate();
+  gate({});
+  assert(fs.existsSync(MARKER), "marker file should exist");
+  cleanMarker();
+});
+
+check("Marker contains JSON with timestamp", function() {
+  cleanMarker();
+  var gate = loadGate();
+  gate({});
+  var content = JSON.parse(fs.readFileSync(MARKER, "utf-8"));
+  assert(typeof content.ts === "string", "should have ts field");
+  assert(content.ts.length > 0, "ts should not be empty");
+  // Verify it's a valid ISO date
+  assert(!isNaN(Date.parse(content.ts)), "ts should be valid ISO date");
+  cleanMarker();
+});
+
+check("Marker contains project from env", function() {
+  cleanMarker();
+  var orig = process.env.CLAUDE_PROJECT_DIR;
+  process.env.CLAUDE_PROJECT_DIR = "/test/project";
+  var gate = loadGate();
+  gate({});
+  var content = JSON.parse(fs.readFileSync(MARKER, "utf-8"));
+  assert(content.project === "/test/project", "project should match env");
+  if (orig !== undefined) process.env.CLAUDE_PROJECT_DIR = orig;
+  else delete process.env.CLAUDE_PROJECT_DIR;
+  cleanMarker();
+});
+
+check("Marker with empty project dir", function() {
+  cleanMarker();
+  var orig = process.env.CLAUDE_PROJECT_DIR;
+  delete process.env.CLAUDE_PROJECT_DIR;
+  var gate = loadGate();
+  gate({});
+  var content = JSON.parse(fs.readFileSync(MARKER, "utf-8"));
+  assert(content.project === "", "project should be empty string");
+  if (orig !== undefined) process.env.CLAUDE_PROJECT_DIR = orig;
+  cleanMarker();
+});
+
+check("Overwrites previous marker", function() {
+  cleanMarker();
+  var gate = loadGate();
+  gate({});
+  var first = JSON.parse(fs.readFileSync(MARKER, "utf-8"));
+  // Small delay to get different timestamp
+  var start = Date.now();
+  while (Date.now() - start < 5) {} // spin 5ms
+  gate({});
+  var second = JSON.parse(fs.readFileSync(MARKER, "utf-8"));
+  assert(second.ts >= first.ts, "second marker should have newer or equal timestamp");
+  cleanMarker();
+});
+
+// --- Cleanup ---
+cleanMarker();
+
+// --- Summary ---
+console.log("\n=== Results: " + passed + " passed, " + failed + " failed ===");
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- mark-turn-complete (7 tests): marker file lifecycle, JSON content, project env
- auto-continue (7 tests): default block, idle flag one-shot, stop-message.txt sourcing

## Test plan
- [x] 14/14 pass