### PR TITLE
T586: Version bump to v2.68.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.68.0] — 2026-05-03
+
+### Added
+- **commit-msg-check tests** (T581) — 23 tests covering WIP/fixup/squash detection, length check, HEREDOC parsing.
+- **empty-output-detector tests** (T581) — 29 tests covering EXPECT_OUTPUT vs EMPTY_OK pattern matching.
+- **result-review-gate tests** (T581) — 26 tests covering report filename/directory detection, checklist injection.
+- **test-evidence tests** (T581) — 14 tests covering pattern extraction, evidence file lifecycle.
+- **rule-hygiene tests** (T582) — 22 tests covering filename validation, content length, section count, global vs project scope.
+- **background-task-audit tests** (T582) — 14 tests covering zero-output detection, timeout handling, poll tracking.
+- **disk-space-detect tests** (T582) — 16 tests covering error pattern matching, state file lifecycle.
+- **inter-project-audit tests** (T582) — 15 tests covering cross-project TODO logging, task ID extraction, path normalization.
+- **troubleshoot-detector tests** (T583) — 14 tests covering fail-fail-succeed detection, cooldown, failure expiry.
+- **settings-audit-log tests** (T583) — 21 tests covering watched path detection, Write/Edit/Bash audit logging.
+- **update-stale-docs tests** (T583) — 16 tests covering doc file exemption, code file reminders.
+- **crlf-detector tests** (T583) — 24 tests covering sensitive extension detection, CRLF counting, fix suggestion.
+- **test-before-done tests** (T584) — 4 tests covering always-block contract, message content.
+- **log-gotchas tests** (T584) — 4 tests covering always-block contract, rule file reminder.
+- **never-give-up tests** (T584) — 4 tests covering always-block contract, 3-approach requirement.
+- **unresolved-issues-check tests** (T584) — 18 tests covering stale markers, issue words, gate exemption, line numbers.
+- **test-coverage-check tests** (T584) — 18 tests covering test file detection, sibling tests, code-only filter.
+- **mark-turn-complete tests** (T585) — 7 tests covering marker file lifecycle, JSON content, project env.
+- **auto-continue tests** (T585) — 7 tests covering default block, idle flag one-shot, stop-message.txt sourcing.
+
+### Fixed
+- **commit-msg-check regex** — `\b` after `!` in `fixup!`/`squash!` never matched (non-word boundary between non-word chars). Changed to per-alternative word boundaries.
+
+### Stats
+- 139 suites, ~2081 tests (296 new)
+- 113 modules, 7 workflows
+- PostToolUse: 14/15 tested, Stop: 7/13 tested
+
 ## [2.67.0] — 2026-05-03
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Modular hook runner for Claude Code. Workflows group modules into enforceable pi
 - `workflows/` — built-in workflow definitions (YAML)
 - `specs/` — feature specs with tasks and checkpoints
 - `demo.js` — interactive demo (simulates module gates against realistic scenarios)
-- `scripts/test/` — test scripts (115 suites, 1785 tests)
+- `scripts/test/` — test scripts (139 suites, ~2081 tests)
 - `package.json` — npm package (enables `npx grobomo/hook-runner`)
 
 ## Testing

--- a/TODO.md
+++ b/TODO.md
@@ -1415,7 +1415,15 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T582: Add tests for PostToolUse: rule-hygiene (22), background-task-audit (14), disk-space-detect (16), inter-project-audit (15). (PR #493)
 - [x] T583: Add tests for PostToolUse: troubleshoot-detector (14), settings-audit-log (21), update-stale-docs (16), crlf-detector (24). (PR #494)
 - [x] T584: Add tests for Stop: test-before-done (4), log-gotchas (4), never-give-up (4), unresolved-issues-check (18), test-coverage-check (18). (PR #495)
-- [ ] T585: Add tests for Stop: mark-turn-complete, auto-continue.
+- [x] T585: Add tests for Stop: mark-turn-complete (7), auto-continue (7). (PR #496)
+- [x] T586: Version bump to v2.68.0 — CHANGELOG, package.json, test counts. 139 suites, ~2081 tests.
+
+## Session Handoff (2026-05-03, session 3)
+- v2.68.0 released. 139 suites, ~2081 tests. 113 modules, 7 workflows.
+- PRs #492-#496 merged (T581-T585): 296 new tests across 20 modules.
+- PostToolUse: 14/15 tested. Stop: 7/13 tested. SessionStart: 1/14 tested.
+- Remaining untested: 1 PostToolUse (hook-autocommit), 6 Stop, 13 SessionStart.
+- Marketplace sync still pending (T578).
 
 ## Session Handoff (2026-05-03, session 2)
 - v2.67.0 released. 115 suites, 1785 tests, 0 real failures. 113 modules, 7 workflows.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.67.0",
+  "version": "2.68.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Version bump 2.67.0 → 2.68.0
- CHANGELOG: 296 new tests across 20 modules (T581-T585), commit-msg-check regex fix
- 139 suites, ~2081 tests

## Test plan
- [x] 37 tests run as evidence (mark-turn-complete, auto-continue, commit-msg-check)