### PR TITLE
T587: Add tests for 7 remaining Stop modules

### DIFF
--- a/.coconut/STATUS_REPORT.md
+++ b/.coconut/STATUS_REPORT.md
@@ -1,26 +1,24 @@
 # Coconut Status Report
 
-**Updated:** 2026-05-03
+**Updated:** 2026-05-03 (session 3)
 
 ## Current Task
-- Housekeeping session — all numbered tasks complete, investigating test health
+- T587: Adding Stop module tests (chat-export, config-sync, drift-review, push-unpushed)
 
 ## Recent Completions
-- T558: Per-project lesson files for self-reflection system (PR #469)
-- T561: Add test-evidence to README PostToolUse table (PR #468)
-- T562: Fix T369 victory-gate test (PR #470)
-- T563: Version bump to v2.64.0 (PR #471)
-- Synced load-lessons + self-reflection modules to live hooks
-- Cleaned 3 stale worktrees (T546, T547, T554)
+- T581-T585: 296 new tests across 20 modules (PRs #492-#496)
+- T586: Version bump to v2.68.0 (PR #497)
 
 ## Test Suite
-- 96 suites, 1406 passed, 1 failed
-- Only failure: T042 marketplace version drift (source=2.64.0, marketplace=2.59.0)
+- 139 suites, ~2081 tests
+- PostToolUse: 14/15 tested
+- Stop: 6/13 tested (7 remaining)
+- SessionStart: 1/14 tested (13 remaining)
 
 ## Blockers
-- Marketplace sync blocked by cwd-drift gate — needs separate session in ai-skill-marketplace repo
+- None
 
 ## Next Steps
-1. T564: Marketplace sync (delegated to marketplace session)
-2. Performance monitoring of hot-path modules
-3. Deferred: Port remaining OpenClaw modules
+1. Stop module tests (this task)
+2. SessionStart module tests
+3. Marketplace sync (T578)

--- a/TODO.md
+++ b/TODO.md
@@ -1417,6 +1417,7 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T584: Add tests for Stop: test-before-done (4), log-gotchas (4), never-give-up (4), unresolved-issues-check (18), test-coverage-check (18). (PR #495)
 - [x] T585: Add tests for Stop: mark-turn-complete (7), auto-continue (7). (PR #496)
 - [x] T586: Version bump to v2.68.0 — CHANGELOG, package.json, test counts. 139 suites, ~2081 tests.
+- [ ] T587: Add tests for Stop: reflection-score, chat-export, config-sync, drift-review, push-unpushed, self-reflection, session-brain-analysis.
 
 ## Session Handoff (2026-05-03, session 3)
 - v2.68.0 released. 139 suites, ~2081 tests. 113 modules, 7 workflows.

--- a/scripts/test/test-chat-export.js
+++ b/scripts/test/test-chat-export.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+"use strict";
+// Tests for modules/Stop/chat-export.js
+// chat-export spawns a python script on session end. With HOOK_RUNNER_TEST, it returns null.
+
+var path = require("path");
+var MOD_PATH = path.join(__dirname, "..", "..", "modules", "Stop", "chat-export.js");
+
+var passed = 0;
+var failed = 0;
+
+function assert(label, condition) {
+  if (condition) { console.log("OK: " + label); passed++; }
+  else { console.log("FAIL: " + label); failed++; }
+}
+
+process.env.HOOK_RUNNER_TEST = "1";
+var mod = require(MOD_PATH);
+
+assert("Returns null in test mode", mod() === null);
+assert("Returns null regardless of input", mod({ stop_hook_active: true }) === null);
+assert("Is a function", typeof mod === "function");
+assert("Returns null with empty object", mod({}) === null);
+
+console.log("\n=== Results: " + passed + " passed, " + failed + " failed ===");
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/test/test-config-sync.js
+++ b/scripts/test/test-config-sync.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+"use strict";
+// Tests for modules/Stop/config-sync.js
+// config-sync auto-commits ~/.claude changes. With HOOK_RUNNER_TEST, it returns null.
+
+var path = require("path");
+var MOD_PATH = path.join(__dirname, "..", "..", "modules", "Stop", "config-sync.js");
+
+var passed = 0;
+var failed = 0;
+
+function assert(label, condition) {
+  if (condition) { console.log("OK: " + label); passed++; }
+  else { console.log("FAIL: " + label); failed++; }
+}
+
+process.env.HOOK_RUNNER_TEST = "1";
+var mod = require(MOD_PATH);
+
+assert("Returns null in test mode", mod() === null);
+assert("Returns null regardless of input", mod({ stop_hook_active: true }) === null);
+assert("Is a function", typeof mod === "function");
+assert("Returns null with empty object", mod({}) === null);
+
+console.log("\n=== Results: " + passed + " passed, " + failed + " failed ===");
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/test/test-drift-review.js
+++ b/scripts/test/test-drift-review.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+"use strict";
+// Tests for modules/Stop/drift-review.js
+// drift-review checks if recent work matches the active spec task.
+// With HOOK_RUNNER_TEST, it returns null.
+
+var path = require("path");
+var MOD_PATH = path.join(__dirname, "..", "..", "modules", "Stop", "drift-review.js");
+
+var passed = 0;
+var failed = 0;
+
+function assert(label, condition) {
+  if (condition) { console.log("OK: " + label); passed++; }
+  else { console.log("FAIL: " + label); failed++; }
+}
+
+process.env.HOOK_RUNNER_TEST = "1";
+var mod = require(MOD_PATH);
+
+assert("Returns null in test mode", mod() === null);
+assert("Returns null regardless of input", mod({ stop_hook_active: true }) === null);
+assert("Is a function", typeof mod === "function");
+assert("Returns null with empty object", mod({}) === null);
+
+console.log("\n=== Results: " + passed + " passed, " + failed + " failed ===");
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/test/test-push-unpushed.js
+++ b/scripts/test/test-push-unpushed.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+"use strict";
+// Tests for modules/Stop/push-unpushed.js
+// push-unpushed blocks stopping when there are unpushed commits.
+// With HOOK_RUNNER_TEST, it returns null.
+
+var path = require("path");
+var MOD_PATH = path.join(__dirname, "..", "..", "modules", "Stop", "push-unpushed.js");
+
+var passed = 0;
+var failed = 0;
+
+function assert(label, condition) {
+  if (condition) { console.log("OK: " + label); passed++; }
+  else { console.log("FAIL: " + label); failed++; }
+}
+
+process.env.HOOK_RUNNER_TEST = "1";
+var mod = require(MOD_PATH);
+
+assert("Returns null in test mode", mod() === null);
+assert("Returns null regardless of input", mod({ stop_hook_active: true }) === null);
+assert("Is a function", typeof mod === "function");
+assert("Returns null with empty object", mod({}) === null);
+
+console.log("\n=== Results: " + passed + " passed, " + failed + " failed ===");
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/test/test-reflection-score.js
+++ b/scripts/test/test-reflection-score.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+"use strict";
+// Tests for modules/Stop/reflection-score.js
+// reflection-score is a library module — the function returns null,
+// but it exports utility methods: getLevel, POINTS, LEVELS, calculateDelta, etc.
+
+var path = require("path");
+var fs = require("fs");
+var os = require("os");
+
+var MOD_PATH = path.join(__dirname, "..", "..", "modules", "Stop", "reflection-score.js");
+
+var passed = 0;
+var failed = 0;
+
+function assert(label, condition) {
+  if (condition) { console.log("OK: " + label); passed++; }
+  else { console.log("FAIL: " + label); failed++; }
+}
+
+// --- Module contract ---
+var mod = require(MOD_PATH);
+
+assert("Module function returns null", mod() === null);
+assert("Module function returns null regardless of input", mod({ stop_hook_active: true }) === null);
+assert("Exports POINTS object", typeof mod.POINTS === "object" && mod.POINTS !== null);
+assert("Exports LEVELS array", Array.isArray(mod.LEVELS) && mod.LEVELS.length > 0);
+assert("Exports REFLECTION_INTERVALS object", typeof mod.REFLECTION_INTERVALS === "object");
+assert("Exports getLevel function", typeof mod.getLevel === "function");
+assert("Exports readScore function", typeof mod.readScore === "function");
+assert("Exports writeScore function", typeof mod.writeScore === "function");
+assert("Exports updateScore function", typeof mod.updateScore === "function");
+assert("Exports formatSummary function", typeof mod.formatSummary === "function");
+assert("Exports SCORE_PATH string", typeof mod.SCORE_PATH === "string");
+
+// --- POINTS constants ---
+assert("CLEAN_REFLECTION is positive", mod.POINTS.CLEAN_REFLECTION > 0);
+assert("STREAK_BONUS is positive", mod.POINTS.STREAK_BONUS > 0);
+assert("WORKFLOW_VIOLATION is negative", mod.POINTS.WORKFLOW_VIOLATION < 0);
+assert("USER_CORRECTION is negative", mod.POINTS.USER_CORRECTION < 0);
+assert("FRUSTRATION_DETECTED is negative", mod.POINTS.FRUSTRATION_DETECTED < 0);
+assert("RAPID_INTERRUPT_CLUSTER is most negative", mod.POINTS.RAPID_INTERRUPT_CLUSTER <= mod.POINTS.FRUSTRATION_DETECTED);
+
+// --- LEVELS ---
+assert("LEVELS sorted by min ascending", (function() {
+  for (var i = 1; i < mod.LEVELS.length; i++) {
+    if (mod.LEVELS[i].min <= mod.LEVELS[i-1].min) return false;
+  }
+  return true;
+})());
+assert("First level starts at 0", mod.LEVELS[0].min === 0);
+assert("First level is Novice", mod.LEVELS[0].name === "Novice");
+assert("Last level is Master", mod.LEVELS[mod.LEVELS.length - 1].name === "Master");
+
+// --- getLevel ---
+assert("getLevel(0) is Novice", mod.getLevel(0).name === "Novice");
+assert("getLevel(49) is Novice", mod.getLevel(49).name === "Novice");
+assert("getLevel(50) is Apprentice", mod.getLevel(50).name === "Apprentice");
+assert("getLevel(149) is Apprentice", mod.getLevel(149).name === "Apprentice");
+assert("getLevel(150) is Journeyman", mod.getLevel(150).name === "Journeyman");
+assert("getLevel(300) is Expert", mod.getLevel(300).name === "Expert");
+assert("getLevel(500) is Master", mod.getLevel(500).name === "Master");
+assert("getLevel(9999) is Master", mod.getLevel(9999).name === "Master");
+
+// --- REFLECTION_INTERVALS ---
+assert("Novice interval is shortest", mod.REFLECTION_INTERVALS["Novice"] < mod.REFLECTION_INTERVALS["Apprentice"]);
+assert("Master interval is longest", mod.REFLECTION_INTERVALS["Master"] > mod.REFLECTION_INTERVALS["Expert"]);
+assert("All levels have intervals", (function() {
+  for (var i = 0; i < mod.LEVELS.length; i++) {
+    if (!mod.REFLECTION_INTERVALS[mod.LEVELS[i].name]) return false;
+  }
+  return true;
+})());
+
+// --- readScore with no file ---
+// readScore reads from SCORE_PATH which is in ~/.claude/hooks/.
+// We test the default shape by temporarily pointing to a non-existent path.
+// Actually, we can test the structure of what readScore returns in error case
+// by checking the module code — it returns a default object.
+// Since we can't easily mock the path, test that readScore returns an object.
+assert("readScore returns object", typeof mod.readScore() === "object");
+assert("readScore has total field", typeof mod.readScore().total === "number");
+assert("readScore has level field", typeof mod.readScore().level === "string");
+assert("readScore has streak field", typeof mod.readScore().streak === "number");
+assert("readScore has history array", Array.isArray(mod.readScore().history));
+
+// --- formatSummary ---
+assert("formatSummary returns string", typeof mod.formatSummary() === "string");
+assert("formatSummary contains REFLECTION SCORE", mod.formatSummary().indexOf("REFLECTION SCORE") >= 0);
+assert("formatSummary contains level name", (function() {
+  var summary = mod.formatSummary();
+  // Should contain one of the level names
+  for (var i = 0; i < mod.LEVELS.length; i++) {
+    if (summary.indexOf(mod.LEVELS[i].name) >= 0) return true;
+  }
+  return false;
+})());
+
+console.log("\n=== Results: " + passed + " passed, " + failed + " failed ===");
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/test/test-self-reflection.js
+++ b/scripts/test/test-self-reflection.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+"use strict";
+// Tests for modules/Stop/self-reflection.js
+// self-reflection is async (calls brain or claude -p). With HOOK_RUNNER_TEST, returns null.
+
+var path = require("path");
+var MOD_PATH = path.join(__dirname, "..", "..", "modules", "Stop", "self-reflection.js");
+
+var passed = 0;
+var failed = 0;
+
+function assert(label, condition) {
+  if (condition) { console.log("OK: " + label); passed++; }
+  else { console.log("FAIL: " + label); failed++; }
+}
+
+process.env.HOOK_RUNNER_TEST = "1";
+var mod = require(MOD_PATH);
+
+assert("Is a function", typeof mod === "function");
+
+// Module is async — returns a Promise
+var result = mod();
+assert("Returns a Promise", result && typeof result.then === "function");
+
+result.then(function(val) {
+  assert("Resolves to null in test mode", val === null);
+
+  return mod({ stop_hook_active: true });
+}).then(function(val2) {
+  assert("Resolves to null regardless of input", val2 === null);
+
+  console.log("\n=== Results: " + passed + " passed, " + failed + " failed ===");
+  process.exit(failed > 0 ? 1 : 0);
+}).catch(function(err) {
+  console.log("FAIL: Promise rejected: " + err.message);
+  failed++;
+  console.log("\n=== Results: " + passed + " passed, " + failed + " failed ===");
+  process.exit(1);
+});

--- a/scripts/test/test-session-brain-analysis.js
+++ b/scripts/test/test-session-brain-analysis.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+"use strict";
+// Tests for modules/Stop/session-brain-analysis.js
+// session-brain-analysis is async (calls claude -p). With HOOK_RUNNER_TEST, returns null.
+
+var path = require("path");
+var MOD_PATH = path.join(__dirname, "..", "..", "modules", "Stop", "session-brain-analysis.js");
+
+var passed = 0;
+var failed = 0;
+
+function assert(label, condition) {
+  if (condition) { console.log("OK: " + label); passed++; }
+  else { console.log("FAIL: " + label); failed++; }
+}
+
+process.env.HOOK_RUNNER_TEST = "1";
+var mod = require(MOD_PATH);
+
+assert("Is a function", typeof mod === "function");
+
+// Module is async — returns a Promise
+var result = mod();
+assert("Returns a Promise", result && typeof result.then === "function");
+
+result.then(function(val) {
+  assert("Resolves to null in test mode", val === null);
+
+  return mod({ stop_hook_active: true });
+}).then(function(val2) {
+  assert("Resolves to null regardless of input", val2 === null);
+
+  console.log("\n=== Results: " + passed + " passed, " + failed + " failed ===");
+  process.exit(failed > 0 ? 1 : 0);
+}).catch(function(err) {
+  console.log("FAIL: Promise rejected: " + err.message);
+  failed++;
+  console.log("\n=== Results: " + passed + " passed, " + failed + " failed ===");
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- reflection-score: 40 tests (getLevel, POINTS/LEVELS constants, exported API surface, formatSummary)
- chat-export, config-sync, drift-review, push-unpushed: 4 tests each (module contract)
- self-reflection, session-brain-analysis: 4 tests each (async module contract)
- Total: 64 new tests, all passing

## Coverage
- Stop modules: 13/13 tested (was 6/13)

## Test plan
- [x] All 7 suites: 64/64 pass