### PR TITLE
T588: Add tests for 6 SessionStart modules

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1417,7 +1417,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T584: Add tests for Stop: test-before-done (4), log-gotchas (4), never-give-up (4), unresolved-issues-check (18), test-coverage-check (18). (PR #495)
 - [x] T585: Add tests for Stop: mark-turn-complete (7), auto-continue (7). (PR #496)
 - [x] T586: Version bump to v2.68.0 — CHANGELOG, package.json, test counts. 139 suites, ~2081 tests.
-- [ ] T587: Add tests for Stop: reflection-score, chat-export, config-sync, drift-review, push-unpushed, self-reflection, session-brain-analysis.
+- [x] T587: Add tests for 7 Stop modules — reflection-score (40), chat-export (4), config-sync (4), drift-review (4), push-unpushed (4), self-reflection (4), session-brain-analysis (4). (PR #498)
+- [ ] T588: Add tests for SessionStart modules batch 1: load-instructions, _is-pid-running, terminal-title, reflection-score-inject, lesson-effectiveness, inter-project-priority.
 
 ## Session Handoff (2026-05-03, session 3)
 - v2.68.0 released. 139 suites, ~2081 tests. 113 modules, 7 workflows.

--- a/scripts/test/test-_is-pid-running.js
+++ b/scripts/test/test-_is-pid-running.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+"use strict";
+// Tests for modules/SessionStart/_is-pid-running.js
+// Pure helper function — checks if a PID is running via process.kill(pid, 0).
+
+var path = require("path");
+var MOD_PATH = path.join(__dirname, "..", "..", "modules", "SessionStart", "_is-pid-running.js");
+
+var passed = 0;
+var failed = 0;
+
+function assert(label, condition) {
+  if (condition) { console.log("OK: " + label); passed++; }
+  else { console.log("FAIL: " + label); failed++; }
+}
+
+var isPidRunning = require(MOD_PATH);
+
+assert("Is a function", typeof isPidRunning === "function");
+
+// Current process should be running
+assert("Current PID is running", isPidRunning(process.pid) === true);
+
+// Parent PID should be running (we're a child of the shell)
+assert("Parent PID is running", isPidRunning(process.ppid) === true);
+
+// PID 1 may or may not exist on Windows — but shouldn't crash
+var pid1 = isPidRunning(1);
+assert("PID 1 returns boolean", typeof pid1 === "boolean");
+
+// Invalid PIDs
+assert("PID 0 returns false", isPidRunning(0) === false);
+assert("Negative PID returns false", isPidRunning(-1) === false);
+assert("NaN returns false", isPidRunning(NaN) === false);
+assert("String returns false", isPidRunning("abc") === false);
+assert("Null returns false", isPidRunning(null) === false);
+assert("Undefined returns false", isPidRunning(undefined) === false);
+assert("Float returns false", isPidRunning(1.5) === false);
+
+// Very high PID (almost certainly not running)
+assert("Very high PID returns false", isPidRunning(999999999) === false);
+
+console.log("\n=== Results: " + passed + " passed, " + failed + " failed ===");
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/test/test-inter-project-priority.js
+++ b/scripts/test/test-inter-project-priority.js
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+"use strict";
+// Tests for modules/SessionStart/inter-project-priority.js
+// inter-project-priority reads TODO.md for XREF tags from other projects
+// and surfaces them as P0 priority items.
+
+var path = require("path");
+var fs = require("fs");
+var os = require("os");
+
+var MOD_PATH = path.join(__dirname, "..", "..", "modules", "SessionStart", "inter-project-priority.js");
+
+var passed = 0;
+var failed = 0;
+
+function assert(label, condition) {
+  if (condition) { console.log("OK: " + label); passed++; }
+  else { console.log("FAIL: " + label); failed++; }
+}
+
+// Set up a temp project dir with a TODO.md
+var tmpDir = path.join(os.tmpdir(), "test-inter-proj-" + process.pid);
+try { fs.mkdirSync(tmpDir, { recursive: true }); } catch(e) {}
+
+var origProjectDir = process.env.CLAUDE_PROJECT_DIR;
+
+function setTodo(content) {
+  fs.writeFileSync(path.join(tmpDir, "TODO.md"), content);
+  process.env.CLAUDE_PROJECT_DIR = tmpDir;
+}
+
+function cleanup() {
+  process.env.CLAUDE_PROJECT_DIR = origProjectDir || "";
+}
+
+// Re-require module each test to avoid stale state
+function freshMod() {
+  delete require.cache[require.resolve(MOD_PATH)];
+  return require(MOD_PATH);
+}
+
+// --- No CLAUDE_PROJECT_DIR ---
+process.env.CLAUDE_PROJECT_DIR = "";
+var mod = freshMod();
+var r1 = mod();
+assert("Returns null when no project dir", r1 === null);
+
+// --- No TODO.md ---
+process.env.CLAUDE_PROJECT_DIR = tmpDir;
+try { fs.unlinkSync(path.join(tmpDir, "TODO.md")); } catch(e) {}
+var r2 = freshMod()();
+assert("Returns null when no TODO.md", r2 === null);
+
+// --- TODO.md with no XREF items ---
+setTodo("# TODO\n- [ ] T100: Normal task\n- [x] T99: Done task\n");
+var r3 = freshMod()();
+assert("Returns null when no XREF tags", r3 === null);
+
+// --- TODO.md with XREF items ---
+setTodo(
+  "# TODO\n" +
+  "- [ ] T200: Fix bug in module A <!-- XREF:dd-lab:T150 2026-04-20 -->\n" +
+  "- [x] T201: Already done <!-- XREF:ddei:T99 2026-04-19 -->\n" +
+  "- [ ] T202: Another cross-project issue <!-- XREF:v1-helper:T300 2026-04-21 -->\n" +
+  "- [ ] T203: Normal task without XREF\n"
+);
+var r4 = freshMod()();
+assert("Returns text when XREF items exist", r4 !== null && typeof r4 === "object");
+if (r4) {
+  assert("Text mentions INTER-PROJECT", r4.text.indexOf("INTER-PROJECT") >= 0);
+  assert("Text mentions P0", r4.text.indexOf("P0") >= 0);
+  assert("Text mentions source project dd-lab", r4.text.indexOf("dd-lab") >= 0);
+  assert("Text mentions source project v1-helper", r4.text.indexOf("v1-helper") >= 0);
+  assert("Does not include checked items", r4.text.indexOf("T201") === -1);
+  assert("Text mentions 2 pending items", r4.text.indexOf("2 pending") >= 0);
+  assert("Does not block", r4.decision === undefined);
+}
+
+// --- TODO.md with Inbound Requests section ---
+setTodo(
+  "# TODO\n- [ ] T300: Normal task\n\n" +
+  "## Inbound Requests\n" +
+  "- [ ] T301: Fix crash from email-manager\n" +
+  "- [x] T302: Done request\n"
+);
+var r5 = freshMod()();
+assert("Finds items in Inbound Requests section", r5 !== null);
+if (r5) {
+  assert("Text mentions T301", r5.text.indexOf("T301") >= 0);
+  assert("Does not mention checked T302", r5.text.indexOf("T302") === -1);
+}
+
+// --- All XREF items are checked ---
+setTodo(
+  "# TODO\n" +
+  "- [x] T400: Done <!-- XREF:dd-lab:T150 2026-04-20 -->\n" +
+  "- [x] T401: Also done <!-- XREF:v1-helper:T300 2026-04-21 -->\n"
+);
+var r6 = freshMod()();
+assert("Returns null when all XREF items are checked", r6 === null);
+
+// Cleanup
+cleanup();
+try {
+  fs.readdirSync(tmpDir).forEach(function(f) { fs.unlinkSync(path.join(tmpDir, f)); });
+  fs.rmdirSync(tmpDir);
+} catch(e) {}
+
+console.log("\n=== Results: " + passed + " passed, " + failed + " failed ===");
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/test/test-lesson-effectiveness.js
+++ b/scripts/test/test-lesson-effectiveness.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+"use strict";
+// Tests for modules/SessionStart/lesson-effectiveness.js
+// lesson-effectiveness reads JSONL lessons, clusters similar ones, and warns
+// about repeated patterns. It supports _test_lessons_path injection.
+
+var path = require("path");
+var fs = require("fs");
+var os = require("os");
+
+var MOD_PATH = path.join(__dirname, "..", "..", "modules", "SessionStart", "lesson-effectiveness.js");
+
+var passed = 0;
+var failed = 0;
+
+function assert(label, condition) {
+  if (condition) { console.log("OK: " + label); passed++; }
+  else { console.log("FAIL: " + label); failed++; }
+}
+
+var mod = require(MOD_PATH);
+
+assert("Is a function", typeof mod === "function");
+
+// --- Test with no file ---
+var tmpDir = path.join(os.tmpdir(), "test-lesson-eff-" + process.pid);
+try { fs.mkdirSync(tmpDir, { recursive: true }); } catch(e) {}
+
+var noFile = path.join(tmpDir, "nonexistent.jsonl");
+var escalationFile = path.join(tmpDir, "escalations.jsonl");
+
+var r1 = mod({ _test_lessons_path: noFile, _test_escalation_path: escalationFile });
+assert("Returns null when lessons file doesn't exist", r1 === null);
+
+// --- Test with too few lessons ---
+var fewFile = path.join(tmpDir, "few.jsonl");
+fs.writeFileSync(fewFile, '{"lesson":"test1","ts":"2026-01-01"}\n{"lesson":"test2","ts":"2026-01-02"}\n');
+var r2 = mod({ _test_lessons_path: fewFile, _test_escalation_path: escalationFile });
+assert("Returns null when fewer than threshold lessons", r2 === null);
+
+// --- Test with many unique lessons (no clusters) ---
+var uniqueFile = path.join(tmpDir, "unique.jsonl");
+var uniqueLines = [];
+for (var i = 0; i < 10; i++) {
+  uniqueLines.push(JSON.stringify({ lesson: "Completely different topic number " + i + " about " + ["dogs","cats","fish","birds","snakes","frogs","mice","deer","foxes","bears"][i], ts: "2026-01-0" + i }));
+}
+fs.writeFileSync(uniqueFile, uniqueLines.join("\n") + "\n");
+var r3 = mod({ _test_lessons_path: uniqueFile, _test_escalation_path: escalationFile });
+assert("Returns null when all lessons are unique", r3 === null);
+
+// --- Test with repeated lessons (should warn) ---
+var repeatFile = path.join(tmpDir, "repeat.jsonl");
+var repeatLines = [];
+// Same lesson 5 times (well above threshold of 3)
+for (var j = 0; j < 5; j++) {
+  repeatLines.push(JSON.stringify({
+    lesson: "Never use polling from Claude tool calls — no loop-wait, no repeated gh api calls checking status",
+    ts: "2026-01-0" + (j + 1),
+    project: "hook-runner"
+  }));
+}
+// Add some unique ones too
+repeatLines.push(JSON.stringify({ lesson: "Always verify credentials before deploying", ts: "2026-01-06" }));
+repeatLines.push(JSON.stringify({ lesson: "Check disk space before large operations", ts: "2026-01-07" }));
+fs.writeFileSync(repeatFile, repeatLines.join("\n") + "\n");
+
+var escalFile2 = path.join(tmpDir, "escalations2.jsonl");
+// Capture stderr
+var oldStderr = process.stderr.write;
+var stderrOutput = "";
+process.stderr.write = function(str) { stderrOutput += str; return true; };
+
+var r4 = mod({ _test_lessons_path: repeatFile, _test_escalation_path: escalFile2 });
+
+process.stderr.write = oldStderr; // restore
+
+assert("Returns null (non-blocking) even with repeated lessons", r4 === null);
+assert("Writes to stderr about repeated patterns", stderrOutput.indexOf("LESSON EFFECTIVENESS") >= 0);
+assert("Stderr mentions the repeat count", stderrOutput.indexOf("5x") >= 0 || stderrOutput.indexOf("repeated") >= 0);
+assert("Writes escalation file", fs.existsSync(escalFile2));
+
+if (fs.existsSync(escalFile2)) {
+  var escalContent = fs.readFileSync(escalFile2, "utf-8").trim();
+  assert("Escalation file has content", escalContent.length > 0);
+  try {
+    var escalEntry = JSON.parse(escalContent.split("\n")[0]);
+    assert("Escalation entry has count", typeof escalEntry.count === "number" && escalEntry.count >= 3);
+    assert("Escalation entry has sample", typeof escalEntry.sample === "string" && escalEntry.sample.length > 0);
+    assert("Escalation entry has projects", Array.isArray(escalEntry.projects));
+  } catch(e) {
+    assert("Escalation entry is valid JSON", false);
+  }
+}
+
+// --- Test with empty file ---
+var emptyFile = path.join(tmpDir, "empty.jsonl");
+fs.writeFileSync(emptyFile, "");
+var r5 = mod({ _test_lessons_path: emptyFile, _test_escalation_path: escalationFile });
+assert("Returns null for empty file", r5 === null);
+
+// Cleanup
+try {
+  fs.readdirSync(tmpDir).forEach(function(f) { fs.unlinkSync(path.join(tmpDir, f)); });
+  fs.rmdirSync(tmpDir);
+} catch(e) {}
+
+console.log("\n=== Results: " + passed + " passed, " + failed + " failed ===");
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/test/test-load-instructions.js
+++ b/scripts/test/test-load-instructions.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+"use strict";
+// Tests for modules/SessionStart/load-instructions.js
+// load-instructions always returns a text object with session start instructions.
+
+var path = require("path");
+var MOD_PATH = path.join(__dirname, "..", "..", "modules", "SessionStart", "load-instructions.js");
+
+var passed = 0;
+var failed = 0;
+
+function assert(label, condition) {
+  if (condition) { console.log("OK: " + label); passed++; }
+  else { console.log("FAIL: " + label); failed++; }
+}
+
+var mod = require(MOD_PATH);
+
+assert("Is a function", typeof mod === "function");
+
+var result = mod();
+assert("Returns an object", result !== null && typeof result === "object");
+assert("Returns text property", typeof result.text === "string");
+assert("Text mentions TODO.md", result.text.indexOf("TODO.md") >= 0);
+assert("Text mentions CLAUDE_PROJECT_DIR", result.text.indexOf("CLAUDE_PROJECT_DIR") >= 0);
+assert("Text mentions session handoff", result.text.indexOf("session handoff") >= 0 || result.text.indexOf("Session") >= 0);
+assert("Does not block", result.decision === undefined);
+
+var result2 = mod({ some: "input" });
+assert("Returns same result regardless of input", result2.text === result.text);
+
+console.log("\n=== Results: " + passed + " passed, " + failed + " failed ===");
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/test/test-reflection-score-inject.js
+++ b/scripts/test/test-reflection-score-inject.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+"use strict";
+// Tests for modules/SessionStart/reflection-score-inject.js
+// reflection-score-inject loads reflection-score and injects its formatSummary into context.
+
+var path = require("path");
+var MOD_PATH = path.join(__dirname, "..", "..", "modules", "SessionStart", "reflection-score-inject.js");
+
+var passed = 0;
+var failed = 0;
+
+function assert(label, condition) {
+  if (condition) { console.log("OK: " + label); passed++; }
+  else { console.log("FAIL: " + label); failed++; }
+}
+
+var mod = require(MOD_PATH);
+
+assert("Is a function", typeof mod === "function");
+
+// The module tries to load ../Stop/reflection-score which should be available
+var result = mod();
+assert("Returns a result (not null) when reflection-score is available", result !== null);
+
+if (result) {
+  // It should return a block decision with the score summary
+  assert("Returns decision: block", result.decision === "block");
+  assert("Returns reason string", typeof result.reason === "string");
+  assert("Reason mentions REFLECTION SCORE", result.reason.indexOf("REFLECTION SCORE") >= 0);
+  assert("Reason mentions a level", (function() {
+    var levels = ["Novice", "Apprentice", "Journeyman", "Expert", "Master"];
+    for (var i = 0; i < levels.length; i++) {
+      if (result.reason.indexOf(levels[i]) >= 0) return true;
+    }
+    return false;
+  })());
+  assert("Reason mentions streak", result.reason.indexOf("Streak") >= 0 || result.reason.indexOf("streak") >= 0);
+}
+
+console.log("\n=== Results: " + passed + " passed, " + failed + " failed ===");
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/test/test-terminal-title.js
+++ b/scripts/test/test-terminal-title.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+"use strict";
+// Tests for modules/SessionStart/terminal-title.js
+// terminal-title sets the terminal title via ANSI escape codes.
+// Returns null when not connected to a TTY (which is the case in tests).
+
+var path = require("path");
+var MOD_PATH = path.join(__dirname, "..", "..", "modules", "SessionStart", "terminal-title.js");
+
+var passed = 0;
+var failed = 0;
+
+function assert(label, condition) {
+  if (condition) { console.log("OK: " + label); passed++; }
+  else { console.log("FAIL: " + label); failed++; }
+}
+
+var mod = require(MOD_PATH);
+
+assert("Is a function", typeof mod === "function");
+
+// In test/CI, stdout is piped (not a TTY)
+assert("process.stdout.isTTY is falsy in test", !process.stdout.isTTY);
+
+var result = mod();
+assert("Returns null when not TTY", result === null);
+
+var result2 = mod({ some: "input" });
+assert("Returns null regardless of input", result2 === null);
+
+console.log("\n=== Results: " + passed + " passed, " + failed + " failed ===");
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- load-instructions: 8 tests (always returns text, mentions TODO.md/CLAUDE_PROJECT_DIR)
- _is-pid-running: 12 tests (current/parent PID, invalid inputs, high PID)
- terminal-title: 4 tests (returns null when not TTY)
- reflection-score-inject: 7 tests (loads reflection-score, injects formatted summary)
- lesson-effectiveness: 13 tests (file missing, few lessons, unique, repeated clusters, escalation)
- inter-project-priority: 15 tests (no dir, no file, no XREF, XREF items, Inbound section, all checked)
- Total: 59 new tests, all passing

## Coverage
- SessionStart: 7/14 tested (was 1/14)

## Test plan
- [x] All 6 suites: 59/59 pass