### PR TITLE
T590: Version bump to v2.69.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.69.0] — 2026-05-03
+
+### Added
+- **reflection-score tests** (T587) — 40 tests covering getLevel, POINTS/LEVELS constants, exported API, formatSummary.
+- **chat-export tests** (T587) — 4 tests (module contract).
+- **config-sync tests** (T587) — 4 tests (module contract).
+- **drift-review tests** (T587) — 4 tests (module contract).
+- **push-unpushed tests** (T587) — 4 tests (module contract).
+- **self-reflection tests** (T587) — 4 tests (async module contract).
+- **session-brain-analysis tests** (T587) — 4 tests (async module contract).
+- **load-instructions tests** (T588) — 8 tests covering text content, TODO.md/CLAUDE_PROJECT_DIR references.
+- **_is-pid-running tests** (T588) — 12 tests covering live PIDs, invalid inputs, edge cases.
+- **terminal-title tests** (T588) — 4 tests covering non-TTY behavior.
+- **reflection-score-inject tests** (T588) — 7 tests covering score injection, level display.
+- **lesson-effectiveness tests** (T588) — 13 tests covering file missing, clusters, escalation writing.
+- **inter-project-priority tests** (T588) — 15 tests covering XREF tags, Inbound section, checked items.
+- **backup-check tests** (T589) — 5 tests (async contract, text property).
+- **drift-check tests** (T589) — 3 tests (rate-limiting, contract).
+- **load-lessons tests** (T589) — 12 tests covering self-reflection desc, JSONL injection, lessons.
+- **project-health tests** (T589) — 3 tests (health check contract).
+- **session-cleanup tests** (T589) — 3 tests (always returns null).
+- **session-collision-detector tests** (T589) — 3 tests (no collision case).
+- **workflow-summary tests** (T589) — 6 tests covering workflow engine integration.
+
+### Stats
+- 154 suites, ~2240 tests (158 new)
+- 113 modules, 7 workflows
+- Stop: 13/13 tested (100%), SessionStart: 14/14 tested (100%), PostToolUse: 14/15 tested
+
 ## [2.68.0] — 2026-05-03
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Modular hook runner for Claude Code. Workflows group modules into enforceable pi
 - `workflows/` — built-in workflow definitions (YAML)
 - `specs/` — feature specs with tasks and checkpoints
 - `demo.js` — interactive demo (simulates module gates against realistic scenarios)
-- `scripts/test/` — test scripts (139 suites, ~2081 tests)
+- `scripts/test/` — test scripts (154 suites, ~2240 tests)
 - `package.json` — npm package (enables `npx grobomo/hook-runner`)
 
 ## Testing

--- a/TODO.md
+++ b/TODO.md
@@ -1419,7 +1419,15 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T586: Version bump to v2.68.0 — CHANGELOG, package.json, test counts. 139 suites, ~2081 tests.
 - [x] T587: Add tests for 7 Stop modules — reflection-score (40), chat-export (4), config-sync (4), drift-review (4), push-unpushed (4), self-reflection (4), session-brain-analysis (4). (PR #498)
 - [x] T588: Add tests for SessionStart batch 1: load-instructions (8), _is-pid-running (12), terminal-title (4), reflection-score-inject (7), lesson-effectiveness (13), inter-project-priority (15). (PR #499)
-- [ ] T589: Add tests for SessionStart batch 2: backup-check, drift-check, load-lessons, project-health, session-cleanup, session-collision-detector, workflow-summary.
+- [x] T589: Add tests for SessionStart batch 2: backup-check (5), drift-check (3), load-lessons (12), project-health (3), session-cleanup (3), session-collision-detector (3), workflow-summary (6). (PR #500)
+- [x] T590: Version bump to v2.69.0 — 154 suites, ~2240 tests. Stop + SessionStart at 100%.
+
+## Session Handoff (2026-05-03, session 4)
+- v2.69.0 released. 154 suites, ~2240 tests. 113 modules, 7 workflows.
+- PRs #497-#500 merged (T586-T589): 158 new tests across 20 modules.
+- Stop: 13/13 tested (100%). SessionStart: 14/14 tested (100%). PostToolUse: 14/15 tested.
+- Only untested: 1 PostToolUse (hook-autocommit) + PreToolUse helpers (_bash-write-patterns, _file-modify-patterns, _gsd-helpers).
+- Marketplace sync still pending (T578).
 
 ## Session Handoff (2026-05-03, session 3)
 - v2.68.0 released. 139 suites, ~2081 tests. 113 modules, 7 workflows.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.68.0",
+  "version": "2.69.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Version bump 2.68.0 → 2.69.0
- 154 suites, ~2240 tests (158 new across T587-T589)
- Stop: 13/13 (100%), SessionStart: 14/14 (100%), PostToolUse: 14/15

## Test plan
- [x] 64 tests run as evidence (reflection-score 40, load-lessons 12, _is-pid-running 12)