### PR TITLE
T592: Update README module counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ hook-runner replaces direct `settings.json` editing. After install, you never to
 
 **1. Modules over shell commands.** Each rule is a `.js` file that receives structured input (tool name, file path, command) and returns a decision. Modules are testable, documented, and version-controlled. Drop a file in a folder and it runs — remove it and it stops.
 
-**2. Workflows over individual modules.** You don't think "I need to enable spec-gate, branch-gate, test-checkpoint-gate, and worker-loop." You think "I want the SHTD development pipeline." Workflows group related modules so you enable one name and get a complete enforcement regime. Disable it and they all go silent. This is how you manage 115+ modules without losing track.
+**2. Workflows over individual modules.** You don't think "I need to enable spec-gate, branch-gate, test-checkpoint-gate, and worker-loop." You think "I want the SHTD development pipeline." Workflows group related modules so you enable one name and get a complete enforcement regime. Disable it and they all go silent. This is how you manage 118+ modules without losing track.
 
 **3. Portability.** Export your module config as YAML (`--export`), sync it to another machine (`--sync`), or share a workflow definition. Workflows also make it easy to switch contexts — enable `customer-data-guard` during incident response, disable it after.
 
@@ -51,11 +51,11 @@ The setup wizard will:
 1. Scan your current hooks and generate a styled HTML report
 2. Back up existing hooks to `~/.claude/hooks/archive/`
 3. Install the runner system
-4. Enable the `starter` workflow (with `--yes`) — 47 universally useful modules
+4. Enable the `starter` workflow (with `--yes`) — 48 universally useful modules
 
 Ready for more? Enable the full development pipeline:
 ```bash
-node setup.js --workflow enable shtd    # 103 modules: spec-first, test-first, PR discipline
+node setup.js --workflow enable shtd    # 113 modules: spec-first, test-first, PR discipline
 ```
 
 To undo everything: `node setup.js --uninstall --confirm`
@@ -90,7 +90,7 @@ Claude reads the block message and adjusts its approach — no user intervention
 
 ## Workflows
 
-Workflows are the primary abstraction. Instead of managing 115+ individual modules, you enable a workflow and its modules activate automatically.
+Workflows are the primary abstraction. Instead of managing 118+ individual modules, you enable a workflow and its modules activate automatically.
 
 ```bash
 node setup.js --workflow list              # see available workflows
@@ -104,13 +104,13 @@ node setup.js --workflow query Edit        # which workflows affect Edit?
 
 | Workflow | Modules | What it enforces |
 |----------|---------|-----------------|
-| `starter` | 42 | **Start here.** Safe defaults for any user — blocks force-push, destructive git, secret commits, file deletion. Adds commit quality checks, test reminders, and session context. |
-| `shtd` | 101 | Spec-Hook-Test-Driven — the full development pipeline. Enforces spec → branch → test → implement → PR, plus code quality, infrastructure safety, messaging guards, session lifecycle, and self-improvement. |
-| `gsd` | 101 | GSD-driven development — replaces shtd's spec-based flow with phase-based flow (.planning/ → ROADMAP.md → phase plan → branch → execute → PR). Same safety and quality modules as shtd. |
-| `customer-data-guard` | 3 | Read-only incident response — blocks env changes, data exfil, and V1 modifications. |
-| `dispatcher-worker` | 3 | Role-aware fleet workflow. Dispatcher specs/distributes, workers implement/test/PR. |
-| `no-local-docker` | 1 | Blocks local Docker commands, forces remote infrastructure. |
-| `cross-project-reset` | 0 | Step template for cross-project context switching (cwd-drift-detector is in shtd). |
+| `starter` | 48 | **Start here.** Safe defaults for any user — blocks force-push, destructive git, secret commits, file deletion. Adds commit quality checks, test reminders, and session context. |
+| `shtd` | 113 | Spec-Hook-Test-Driven — the full development pipeline. Enforces spec → branch → test → implement → PR, plus code quality, infrastructure safety, messaging guards, session lifecycle, and self-improvement. |
+| `gsd` | 111 | GSD-driven development — replaces shtd's spec-based flow with phase-based flow (.planning/ → ROADMAP.md → phase plan → branch → execute → PR). Same safety and quality modules as shtd. |
+| `customer-data-guard` | 4 | Read-only incident response — blocks env changes, data exfil, and V1 modifications. |
+| `dispatcher-worker` | 10 | Role-aware fleet workflow. Dispatcher specs/distributes, workers implement/test/PR. |
+| `no-local-docker` | 2 | Blocks local Docker commands, forces remote infrastructure. |
+| `cross-project-reset` | 4 | Step template for cross-project context switching (cwd-drift-detector is in shtd). |
 
 ### Workflow State Machine
 

--- a/TODO.md
+++ b/TODO.md
@@ -1421,7 +1421,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T588: Add tests for SessionStart batch 1: load-instructions (8), _is-pid-running (12), terminal-title (4), reflection-score-inject (7), lesson-effectiveness (13), inter-project-priority (15). (PR #499)
 - [x] T589: Add tests for SessionStart batch 2: backup-check (5), drift-check (3), load-lessons (12), project-health (3), session-cleanup (3), session-collision-detector (3), workflow-summary (6). (PR #500)
 - [x] T590: Version bump to v2.69.0 — 154 suites, ~2240 tests. Stop + SessionStart at 100%.
-- [ ] T591: Add test for hook-autocommit (last untested PostToolUse module) + marketplace sync.
+- [x] T591: Add test for hook-autocommit (12) — PostToolUse 15/15 (100%). (PR #502)
+- [ ] T592: README update — test coverage stats, module counts, version bump notes.
 
 ## Session Handoff (2026-05-03, session 4)
 - v2.69.0 released. 154 suites, ~2240 tests. 113 modules, 7 workflows.


### PR DESCRIPTION
## Summary
- Fix stale workflow module counts in README (from YAML definitions)
- starter: 42→48, shtd: 101→113, gsd: 101→111
- customer-data-guard: 3→4, dispatcher-worker: 3→10, no-local-docker: 1→2, cross-project-reset: 0→4
- Total module references: 115→118