### PR TITLE
T594: Add tests for 3 PreToolUse helpers — 90 tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1423,6 +1423,7 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T590: Version bump to v2.69.0 — 154 suites, ~2240 tests. Stop + SessionStart at 100%.
 - [x] T591: Add test for hook-autocommit (12) — PostToolUse 15/15 (100%). (PR #502)
 - [x] T592: README update — fix workflow module counts (starter 48, shtd 113, gsd 111, 118+ total). (PR #503)
+- [ ] T594: Add tests for 3 PreToolUse helpers (_bash-write-patterns, _file-modify-patterns, _gsd-helpers).
 
 ## Session Handoff (2026-05-03, session 5)
 - v2.69.0 released. 155 suites, ~2250 tests. 118 modules, 7 workflows.

--- a/scripts/test/test-_bash-write-patterns.js
+++ b/scripts/test/test-_bash-write-patterns.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+"use strict";
+// Tests for _bash-write-patterns.js — shared regex array for detecting state-changing Bash commands.
+var path = require("path");
+var patterns = require(path.join(__dirname, "..", "..", "modules", "PreToolUse", "_bash-write-patterns.js"));
+
+var passed = 0, failed = 0;
+function assert(cond, msg) {
+  if (cond) { passed++; console.log("OK: " + msg); }
+  else { failed++; console.error("FAIL: " + msg); }
+}
+
+function matches(cmd) {
+  return patterns.some(function(rx) { return rx.test(cmd); });
+}
+
+// === Contract ===
+assert(Array.isArray(patterns), "Exports an array");
+assert(patterns.length > 0, "Array is non-empty");
+assert(patterns.every(function(p) { return p instanceof RegExp; }), "All elements are RegExp");
+
+// === File modification commands should match ===
+assert(matches("sed -i 's/foo/bar/' file.txt"), "sed -i matches");
+assert(matches("awk -i inplace '{print}' file.txt"), "awk -i matches");
+assert(matches("tee output.log"), "tee matches");
+assert(matches("cp src.txt dst.txt"), "cp matches");
+assert(matches("mv old.txt new.txt"), "mv matches");
+assert(matches("rm file.txt"), "rm matches");
+assert(matches("touch newfile.txt"), "touch matches");
+assert(matches("mkdir -p /tmp/dir"), "mkdir matches");
+assert(matches("rmdir /tmp/dir"), "rmdir matches");
+assert(matches("chmod 755 script.sh"), "chmod matches");
+assert(matches("chown user:group file"), "chown matches");
+assert(matches("ln -s target link"), "ln matches");
+assert(matches("patch < fix.diff"), "patch matches");
+assert(matches("truncate -s 0 file.log"), "truncate matches");
+assert(matches("install -m 755 bin /usr/local/bin"), "install matches");
+
+// === Output redirection ===
+assert(matches('echo "hello" > file.txt'), "echo > matches");
+assert(matches('printf "%s" > file.txt'), "printf > matches");
+assert(matches("cat input.txt > output.txt"), "cat > matches");
+
+// === Package managers ===
+assert(matches("npm install express"), "npm install matches");
+assert(matches("npm ci"), "npm ci matches");
+assert(matches("npm link"), "npm link matches");
+assert(matches("npm uninstall pkg"), "npm uninstall matches");
+assert(matches("npm publish"), "npm publish matches");
+assert(matches("yarn add react"), "yarn add matches");
+assert(matches("yarn install"), "yarn install matches");
+assert(matches("yarn remove lodash"), "yarn remove matches");
+assert(matches("pnpm add vite"), "pnpm add matches");
+assert(matches("pnpm install"), "pnpm install matches");
+assert(matches("pnpm remove pkg"), "pnpm remove matches");
+assert(matches("pip install requests"), "pip install matches");
+assert(matches("pip3 install flask"), "pip3 install matches");
+assert(matches("cargo install ripgrep"), "cargo install matches");
+assert(matches("cargo build"), "cargo build matches");
+assert(matches("conda install numpy"), "conda install matches");
+assert(matches("conda create -n env"), "conda create matches");
+assert(matches("make"), "make matches");
+
+// === Read-only commands should NOT match ===
+assert(!matches("ls -la"), "ls does not match");
+assert(!matches("cat file.txt"), "cat (no redirect) does not match");
+assert(!matches("grep pattern file"), "grep does not match");
+assert(!matches("git status"), "git status does not match");
+assert(!matches("git log --oneline"), "git log does not match");
+assert(!matches("npm list"), "npm list does not match");
+assert(!matches("npm test"), "npm test does not match");
+assert(!matches("node script.js"), "node does not match");
+assert(!matches("python script.py"), "python (no file write) does not match");
+assert(!matches('powershell "[System.IO.Compression.ZipFile]::OpenRead()"'), "powershell OpenRead does not match");
+assert(!matches("wsl -e bash -c 'python3 openclaw-checkin.py'"), "wsl python does not match");
+assert(!matches("echo hello"), "echo without redirect does not match");
+
+console.log("\n=== Results: " + passed + " passed, " + failed + " failed ===");
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/test/test-_file-modify-patterns.js
+++ b/scripts/test/test-_file-modify-patterns.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+"use strict";
+// Tests for _file-modify-patterns.js — shared regex array for detecting file modification in Bash.
+var path = require("path");
+var patterns = require(path.join(__dirname, "..", "..", "modules", "PreToolUse", "_file-modify-patterns.js"));
+
+var passed = 0, failed = 0;
+function assert(cond, msg) {
+  if (cond) { passed++; console.log("OK: " + msg); }
+  else { failed++; console.error("FAIL: " + msg); }
+}
+
+function matches(cmd) {
+  return patterns.some(function(rx) { return rx.test(cmd); });
+}
+
+// === Contract ===
+assert(Array.isArray(patterns), "Exports an array");
+assert(patterns.length > 0, "Array is non-empty");
+assert(patterns.every(function(p) { return p instanceof RegExp; }), "All elements are RegExp");
+
+// === File modification commands should match ===
+assert(matches("sed -i 's/old/new/' file.txt"), "sed -i matches");
+assert(matches("awk -i inplace '{print}' f.txt"), "awk -i matches");
+assert(matches('echo "data" > out.txt'), "echo > matches");
+assert(matches("cat src.txt > dst.txt"), "cat file > file matches");
+assert(matches("tee /tmp/log"), "tee matches");
+assert(matches('printf "x" > file'), "printf > matches");
+assert(matches("cp source dest"), "cp matches");
+assert(matches("mv old new"), "mv matches");
+
+// === Python file write pattern ===
+assert(matches("python open('file', 'w')"), "python open w matches");
+assert(matches("python3 open('f.txt', 'w')"), "python3 open w matches");
+assert(matches('python2 open("f", "w")'), "python2 open w matches");
+
+// === Read-only commands should NOT match ===
+assert(!matches("ls -la"), "ls does not match");
+assert(!matches("cat file.txt"), "cat (no redirect) does not match");
+assert(!matches("grep pattern file"), "grep does not match");
+assert(!matches("git diff"), "git diff does not match");
+assert(!matches("node script.js"), "node does not match");
+assert(!matches("python script.py"), "python (no open w) does not match");
+assert(!matches("sed 's/old/new/' file.txt"), "sed without -i does not match");
+assert(!matches("awk '{print}' file.txt"), "awk without -i does not match");
+assert(!matches("echo hello"), "echo without redirect does not match");
+
+console.log("\n=== Results: " + passed + " passed, " + failed + " failed ===");
+process.exit(failed > 0 ? 1 : 0);

--- a/scripts/test/test-_gsd-helpers.js
+++ b/scripts/test/test-_gsd-helpers.js
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+"use strict";
+// Tests for _gsd-helpers.js — getActivePhases() parses ROADMAP.md for active milestone phases.
+var path = require("path");
+var fs = require("fs");
+var os = require("os");
+var helpers = require(path.join(__dirname, "..", "..", "modules", "PreToolUse", "_gsd-helpers.js"));
+
+var passed = 0, failed = 0;
+function assert(cond, msg) {
+  if (cond) { passed++; console.log("OK: " + msg); }
+  else { failed++; console.error("FAIL: " + msg); }
+}
+
+var tmpDir;
+function setup() {
+  tmpDir = path.join(os.tmpdir(), "gsd-helpers-test-" + Date.now());
+  fs.mkdirSync(path.join(tmpDir, ".planning"), { recursive: true });
+}
+function teardown() {
+  try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch (e) {}
+}
+
+// === Contract ===
+assert(typeof helpers === "object", "Exports an object");
+assert(typeof helpers.getActivePhases === "function", "Has getActivePhases function");
+
+// === No .planning directory ===
+assert(helpers.getActivePhases("/nonexistent/path").length === 0, "Returns [] for missing dir");
+
+// === No ROADMAP.md ===
+setup();
+assert(helpers.getActivePhases(tmpDir).length === 0, "Returns [] when ROADMAP.md missing");
+teardown();
+
+// === Empty ROADMAP.md ===
+setup();
+fs.writeFileSync(path.join(tmpDir, ".planning", "ROADMAP.md"), "# Roadmap\n");
+assert(helpers.getActivePhases(tmpDir).length === 0, "Returns [] for empty roadmap");
+teardown();
+
+// === Single active phase ===
+setup();
+fs.writeFileSync(path.join(tmpDir, ".planning", "ROADMAP.md"), [
+  "# Roadmap",
+  "## Active Milestone",
+  "### Phase 1 — Setup",
+  "- Task A",
+  "## Completed",
+  "### Phase 0 — Init"
+].join("\n"));
+var result = helpers.getActivePhases(tmpDir);
+assert(result.length === 1, "Single phase: returns 1 phase");
+assert(result[0] === "1", "Single phase: phase number is '1'");
+teardown();
+
+// === Multiple active phases ===
+setup();
+fs.writeFileSync(path.join(tmpDir, ".planning", "ROADMAP.md"), [
+  "# Roadmap",
+  "## Active Milestone",
+  "### Phase 3 — Build",
+  "- Task X",
+  "### Phase 4 — Test",
+  "- Task Y",
+  "### Phase 5 — Deploy",
+  "- Task Z",
+  "## Archived"
+].join("\n"));
+result = helpers.getActivePhases(tmpDir);
+assert(result.length === 3, "Multiple phases: returns 3 phases");
+assert(result[0] === "3" && result[1] === "4" && result[2] === "5", "Multiple phases: correct numbers [3,4,5]");
+teardown();
+
+// === Phases only in Completed section (not active) ===
+setup();
+fs.writeFileSync(path.join(tmpDir, ".planning", "ROADMAP.md"), [
+  "# Roadmap",
+  "## Completed",
+  "### Phase 1 — Done",
+  "### Phase 2 — Done"
+].join("\n"));
+assert(helpers.getActivePhases(tmpDir).length === 0, "No active section: returns []");
+teardown();
+
+// === Case insensitive Active Milestone header ===
+setup();
+fs.writeFileSync(path.join(tmpDir, ".planning", "ROADMAP.md"), [
+  "# Roadmap",
+  "## active milestone",
+  "### Phase 10 — Big Feature"
+].join("\n"));
+result = helpers.getActivePhases(tmpDir);
+assert(result.length === 1, "Case insensitive: finds phase");
+assert(result[0] === "10", "Case insensitive: phase number is '10'");
+teardown();
+
+// === Stops at next H2 section ===
+setup();
+fs.writeFileSync(path.join(tmpDir, ".planning", "ROADMAP.md"), [
+  "# Roadmap",
+  "## Active Milestone",
+  "### Phase 7 — Active",
+  "## Backlog",
+  "### Phase 8 — Future"
+].join("\n"));
+result = helpers.getActivePhases(tmpDir);
+assert(result.length === 1, "Section boundary: stops at next H2");
+assert(result[0] === "7", "Section boundary: only phase 7");
+teardown();
+
+// === H3 subsections inside phases don't break parsing ===
+setup();
+fs.writeFileSync(path.join(tmpDir, ".planning", "ROADMAP.md"), [
+  "# Roadmap",
+  "## Active Milestone",
+  "### Phase 2 — Work",
+  "#### Sub-task details",
+  "- Stuff",
+  "### Phase 3 — More Work"
+].join("\n"));
+result = helpers.getActivePhases(tmpDir);
+assert(result.length === 2, "H4 subsections: still finds both phases");
+assert(result[0] === "2" && result[1] === "3", "H4 subsections: phases 2 and 3");
+teardown();
+
+console.log("\n=== Results: " + passed + " passed, " + failed + " failed ===");
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- Tests for `_bash-write-patterns.js` (51 tests): regex contract, all write commands match, read-only commands don't
- Tests for `_file-modify-patterns.js` (23 tests): regex contract, file modification patterns, python open(w)
- Tests for `_gsd-helpers.js` (16 tests): getActivePhases with real ROADMAP.md parsing, edge cases

## Test plan
- [x] 90 passed, 0 failed
- [x] Completes PreToolUse helper coverage (was last untested)