### PR TITLE
T595: Version bump to v2.70.0 — 100% test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.70.0] — 2026-05-03
+
+### Added
+- **_bash-write-patterns tests** (T594) — 51 tests covering all write-pattern regexes, read-only command exclusions, real-incident scenarios (powershell OpenRead, wsl python).
+- **_file-modify-patterns tests** (T594) — 23 tests covering file modification regexes, python open(w), read-only exclusions.
+- **_gsd-helpers tests** (T594) — 16 tests covering getActivePhases() with real ROADMAP.md parsing, section boundaries, case insensitivity, edge cases.
+- **GitHub releases** for v2.68.0 and v2.69.0 (were missing).
+
+### Stats
+- 158 suites, ~2340 tests (90 new)
+- 118 modules, 7 workflows
+- **100% test coverage**: all modules + helpers across all event types
+
 ## [2.69.0] — 2026-05-03
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Modular hook runner for Claude Code. Workflows group modules into enforceable pi
 - `workflows/` — built-in workflow definitions (YAML)
 - `specs/` — feature specs with tasks and checkpoints
 - `demo.js` — interactive demo (simulates module gates against realistic scenarios)
-- `scripts/test/` — test scripts (154 suites, ~2240 tests)
+- `scripts/test/` — test scripts (158 suites, ~2340 tests)
 - `package.json` — npm package (enables `npx grobomo/hook-runner`)
 
 ## Testing

--- a/TODO.md
+++ b/TODO.md
@@ -1423,7 +1423,8 @@ Guard module `_openclaw/tmemu-guard.js` protects production OpenClaw.
 - [x] T590: Version bump to v2.69.0 — 154 suites, ~2240 tests. Stop + SessionStart at 100%.
 - [x] T591: Add test for hook-autocommit (12) — PostToolUse 15/15 (100%). (PR #502)
 - [x] T592: README update — fix workflow module counts (starter 48, shtd 113, gsd 111, 118+ total). (PR #503)
-- [ ] T594: Add tests for 3 PreToolUse helpers (_bash-write-patterns, _file-modify-patterns, _gsd-helpers).
+- [x] T594: Add tests for 3 PreToolUse helpers — _bash-write-patterns (51), _file-modify-patterns (23), _gsd-helpers (16). (PR #505)
+- [x] T595: Version bump to v2.70.0 — 158 suites, ~2340 tests. 100% coverage all event types + helpers.
 
 ## Session Handoff (2026-05-03, session 5)
 - v2.69.0 released. 155 suites, ~2250 tests. 118 modules, 7 workflows.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.69.0",
+  "version": "2.70.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Version bump to v2.70.0
- CHANGELOG: documents T594 helper tests (90 new), GitHub releases for v2.68.0/v2.69.0
- 158 suites, ~2340 tests — 100% coverage across all event types + helpers

## Test plan
- [x] 90 passed, 0 failed (T594 helper tests)