### PR TITLE
T603: Add user-correction-detector PostToolUse module

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,8 +7,8 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 - Local skill: ~/.claude/skills/hook-runner/
 - Live hooks: ~/.claude/hooks/ (run-*.js, load-modules.js, run-modules/)
 
-## Current State (v2.70.0)
-- 118 modules, 7 workflows, 158 test suites, ~2340 tests
+## Current State (v2.71.0)
+- 119 modules, 7 workflows, 159 test suites, ~2400 tests
 - 100% test coverage across all event types + helpers
 - PRs: 506 merged
 
@@ -18,6 +18,7 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 - [x] T597: Remove broken UserPromptSubmit hook from lab-worker settings.json — already fixed (was `{"hooks": {}}`)
 - [x] T598: Improve hook-editing-gate.js block message with actionable 3-step instructions. Both Bash bypass and Edit/Write blocks updated. Test added (17 tests).
 - [ ] T604: Hook diagnostics — `node setup.js --diagnose [project-dir]` to show all settings files, hooks, broken scripts, and auto-fix.
+- [x] T603: User correction detector — PostToolUse module that reads prompt-log.jsonl in real-time, detects correction signals (strong/moderate patterns), deduplicates per-prompt, logs to correction-log.jsonl. 61 tests.
 - [ ] (deferred) Port remaining OpenClaw modules (configurable/niche: aws-tagging, deploy-gate, messaging-safety, etc.)
 
 ## Session Handoff (2026-05-04, session 7)

--- a/modules/PostToolUse/user-correction-detector.js
+++ b/modules/PostToolUse/user-correction-detector.js
@@ -1,0 +1,175 @@
+// TOOLS: *
+// WORKFLOW: shtd, starter, gsd
+// WHY: Claude often ignores user corrections — the user says "no, wrong" or "I already
+// told you X" and Claude plows ahead with the same approach. The self-reflection system
+// catches this at session end, but by then the damage is done. This module detects
+// corrections in real-time (after each tool use) so Claude gets immediate feedback.
+// T603: Real-time user correction detector.
+"use strict";
+var fs = require("fs");
+var path = require("path");
+var os = require("os");
+
+var HOOKS_DIR = path.join(os.homedir(), ".claude", "hooks");
+var PROMPT_LOG = path.join(HOOKS_DIR, "prompt-log.jsonl");
+var CORRECTION_LOG = path.join(HOOKS_DIR, "correction-log.jsonl");
+// Per-session marker: tracks last prompt timestamp we already processed
+var LAST_SEEN_FILE = path.join(os.tmpdir(), ".correction-detector-last-" + process.ppid);
+// Cooldown: don't fire more than once per prompt
+var COOLDOWN_MS = 5000;
+
+// Strong correction patterns — high confidence, standalone triggers
+var STRONG_PATTERNS = [
+  /^no[,.\s!]+(?:that|you|i(?:'[a-z]+)?|it|this|the|we|don't|do not|wrong|stop)/i,
+  /^(?:wrong|incorrect|that's wrong|that's not right|that's not what)/i,
+  /\b(?:i already (?:told|said|asked|explained|mentioned))\b/i,
+  /\b(?:i said|as i (?:said|mentioned|asked|told))\b/i,
+  /\b(?:not what i (?:asked|wanted|meant|said|requested))\b/i,
+  /\b(?:you (?:should have|were supposed to|forgot to|missed|skipped|ignored))\b/i,
+  /\b(?:that's (?:not right|incorrect|not correct|the opposite))\b/i,
+  /\b(?:try again|do it (?:again|over)|redo|start over)\b/i,
+  /\bstop[,.\s]+(?:doing|making|using|trying|ignoring|repeating)\b/i,
+  /\b(?:how many times|i(?:'ve)? (?:told|said|asked) you)\b/i,
+  /\b(?:read (?:my|the) (?:message|prompt|instruction|request) again)\b/i,
+  /\b(?:pay attention|listen to me|read what i)\b/i
+];
+
+// Moderate patterns — need the prompt to be short (< 150 chars) to trigger
+var MODERATE_PATTERNS = [
+  /^(?:no|nope|wrong)[.!]*$/i,
+  /^(?:stop|cancel|undo|revert)[.!]*$/i,
+  /\b(?:i (?:didn't|did not) (?:ask|want|say|mean))\b/i,
+  /\b(?:that's not it|not even close|completely wrong)\b/i,
+  /\b(?:why (?:did you|are you|would you))\b/i,
+  /\b(?:you(?:'re| are) (?:doing it wrong|not listening|ignoring))\b/i
+];
+
+// Exclusions — prompts that look like corrections but aren't
+function isExcluded(text) {
+  // Long prompts are usually task descriptions, not corrections
+  if (text.length > 500) return true;
+  // Code blocks indicate technical content
+  if (text.indexOf("```") !== -1) return true;
+  // Slash commands
+  if (/^\/\w/.test(text)) return true;
+  // Starts with task-like verbs (build, create, implement, add, update, etc.)
+  // "read" excluded only when followed by file-like targets, not "read my message again"
+  if (/^(?:build|create|implement|add|update|write|deploy|run|test|check|install|setup|configure|generate|make|move|copy|delete|remove|show|list|open|close|merge|push|pull|commit|search|find|scan|audit|review|analyze|refactor)\b/i.test(text)) return true;
+  if (/^read\b/i.test(text) && !/^read\s+(?:my|the)\s+(?:message|prompt|instruction|request)\b/i.test(text)) return true;
+  // "fix the X" is a task, not a correction (but "fix what you did" IS a correction)
+  if (/^fix\s+(?:the|a|this|that)\s+\w{3,}/i.test(text) && !/\byou\b/i.test(text)) return true;
+  // Simple greetings
+  if (/^(?:hello|hi|hey|good morning|good afternoon)\b/i.test(text)) return true;
+  return false;
+}
+
+function getLatestPrompt() {
+  try {
+    if (!fs.existsSync(PROMPT_LOG)) return null;
+    // Read only the tail of the file — last 1KB is enough for the latest entry
+    var fd = fs.openSync(PROMPT_LOG, "r");
+    var stat = fs.fstatSync(fd);
+    if (stat.size < 10) { fs.closeSync(fd); return null; }
+    var readSize = Math.min(1024, stat.size);
+    var buf = Buffer.alloc(readSize);
+    fs.readSync(fd, buf, 0, readSize, stat.size - readSize);
+    fs.closeSync(fd);
+    var tail = buf.toString("utf-8");
+    var lines = tail.trim().split("\n");
+    var lastLine = lines[lines.length - 1];
+    return JSON.parse(lastLine);
+  } catch (e) { return null; }
+}
+
+function alreadySeen(ts) {
+  try {
+    var content = fs.readFileSync(LAST_SEEN_FILE, "utf-8").trim();
+    var data = JSON.parse(content);
+    if (data.ts === ts) {
+      if (data.fired) return true;
+      if (!data.fired && (Date.now() - data.seenAt) < COOLDOWN_MS) return true;
+    }
+    return false;
+  } catch (e) { return false; }
+}
+
+function markSeen(ts, fired) {
+  try {
+    fs.writeFileSync(LAST_SEEN_FILE, JSON.stringify({
+      ts: ts,
+      fired: fired,
+      seenAt: Date.now(),
+      firedAt: fired ? Date.now() : 0
+    }));
+  } catch (e) {}
+}
+
+function logCorrection(prompt, matchedPattern) {
+  try {
+    var entry = {
+      ts: new Date().toISOString(),
+      project: path.basename(process.env.CLAUDE_PROJECT_DIR || "unknown"),
+      prompt_preview: (prompt.preview || "").substring(0, 200),
+      pattern: matchedPattern,
+      prompt_ts: prompt.ts
+    };
+    fs.appendFileSync(CORRECTION_LOG, JSON.stringify(entry) + "\n");
+  } catch (e) {}
+}
+
+function detectCorrection(text) {
+  if (!text || isExcluded(text)) return null;
+
+  // Check strong patterns (fire regardless of prompt length)
+  for (var i = 0; i < STRONG_PATTERNS.length; i++) {
+    if (STRONG_PATTERNS[i].test(text)) {
+      return { pattern: STRONG_PATTERNS[i].toString(), strength: "strong" };
+    }
+  }
+
+  // Check moderate patterns (only fire for short prompts — likely pure corrections)
+  if (text.length < 150) {
+    for (var j = 0; j < MODERATE_PATTERNS.length; j++) {
+      if (MODERATE_PATTERNS[j].test(text)) {
+        return { pattern: MODERATE_PATTERNS[j].toString(), strength: "moderate" };
+      }
+    }
+  }
+
+  return null;
+}
+
+module.exports = function(input) {
+  if (process.env.HOOK_RUNNER_TEST) return null;
+
+  var prompt = getLatestPrompt();
+  if (!prompt || !prompt.preview) return null;
+
+  // Dedup: don't fire twice for the same prompt
+  if (alreadySeen(prompt.ts)) return null;
+
+  var match = detectCorrection(prompt.preview);
+  if (!match) {
+    markSeen(prompt.ts, false);
+    return null;
+  }
+
+  // Correction detected — mark as fired and log
+  markSeen(prompt.ts, true);
+  logCorrection(prompt, match.pattern);
+
+  return {
+    decision: "block",
+    reason: "USER CORRECTION DETECTED (" + match.strength + "):\n" +
+      "  \"" + prompt.preview.substring(0, 150) + "\"\n\n" +
+      "The user is correcting your approach. Before continuing:\n" +
+      "  1. ACKNOWLEDGE the correction explicitly\n" +
+      "  2. EXPLAIN what you were doing wrong\n" +
+      "  3. ADJUST your approach based on what the user said\n\n" +
+      "Do NOT continue with the same approach. The user's correction is a constraint."
+  };
+};
+
+// Export internals for testing
+module.exports._detectCorrection = detectCorrection;
+module.exports._isExcluded = isExcluded;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.70.0",
+  "version": "2.71.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"

--- a/scripts/test/test-user-correction-detector.js
+++ b/scripts/test/test-user-correction-detector.js
@@ -1,0 +1,428 @@
+#!/usr/bin/env node
+"use strict";
+// T603: Tests for user-correction-detector.js (PostToolUse)
+// Detects user corrections in real-time via prompt-log analysis.
+
+var path = require("path");
+var modPath = path.join(__dirname, "..", "..", "modules", "PostToolUse", "user-correction-detector.js");
+var passed = 0, failed = 0;
+
+function check(name, fn) {
+  try { fn(); console.log("OK: " + name); passed++; }
+  catch (e) { console.log("FAIL: " + name + " — " + e.message); failed++; }
+}
+function assert(cond, msg) { if (!cond) throw new Error(msg || "assertion failed"); }
+
+function loadMod() {
+  delete require.cache[require.resolve(modPath)];
+  return require(modPath);
+}
+
+// === detectCorrection tests (pure pattern matching) ===
+
+// --- Strong patterns: should detect ---
+
+check("'No, that's wrong' → strong", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("No, that's wrong");
+  assert(r !== null, "should detect");
+  assert(r.strength === "strong");
+});
+
+check("'No you need to do X' → strong", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("No you need to do X instead");
+  assert(r !== null, "should detect");
+  assert(r.strength === "strong");
+});
+
+check("'No! Don't do that' → strong", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("No! Don't do that");
+  assert(r !== null, "should detect");
+  assert(r.strength === "strong");
+});
+
+check("'Wrong, I said PostToolUse' → strong", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("Wrong, I said PostToolUse not PreToolUse");
+  assert(r !== null, "should detect");
+  assert(r.strength === "strong");
+});
+
+check("'That's not right' → strong", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("That's not right, look at the spec again");
+  assert(r !== null, "should detect");
+  assert(r.strength === "strong");
+});
+
+check("'I already told you to use snake_case' → strong", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("I already told you to use snake_case");
+  assert(r !== null, "should detect");
+  assert(r.strength === "strong");
+});
+
+check("'I said use PostToolUse' → strong", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("I said use PostToolUse, not Stop");
+  assert(r !== null, "should detect");
+  assert(r.strength === "strong");
+});
+
+check("'As I mentioned, it should be async' → strong", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("As I mentioned, it should be async");
+  assert(r !== null, "should detect");
+  assert(r.strength === "strong");
+});
+
+check("'Not what I asked for' → strong", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("That's not what I asked for");
+  assert(r !== null, "should detect");
+  assert(r.strength === "strong");
+});
+
+check("'You should have used the Edit tool' → strong", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("You should have used the Edit tool");
+  assert(r !== null, "should detect");
+  assert(r.strength === "strong");
+});
+
+check("'You forgot to add tests' → strong", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("You forgot to add tests for this");
+  assert(r !== null, "should detect");
+  assert(r.strength === "strong");
+});
+
+check("'You skipped the validation step' → strong", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("You skipped the validation step");
+  assert(r !== null, "should detect");
+  assert(r.strength === "strong");
+});
+
+check("'That's incorrect' → strong", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("That's incorrect, the port should be 8080");
+  assert(r !== null, "should detect");
+  assert(r.strength === "strong");
+});
+
+check("'Try again with the correct path' → strong", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("Try again with the correct path");
+  assert(r !== null, "should detect");
+  assert(r.strength === "strong");
+});
+
+check("'Do it again but this time...' → strong", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("Do it again but this time use the right file");
+  assert(r !== null, "should detect");
+  assert(r.strength === "strong");
+});
+
+check("'Stop doing that' → strong", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("Stop doing that, use the Edit tool instead");
+  assert(r !== null, "should detect");
+  assert(r.strength === "strong");
+});
+
+check("'Stop ignoring my instructions' → strong", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("Stop ignoring my instructions");
+  assert(r !== null, "should detect");
+  assert(r.strength === "strong");
+});
+
+check("'How many times do I have to say' → strong", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("How many times do I have to say this");
+  assert(r !== null, "should detect");
+  assert(r.strength === "strong");
+});
+
+check("'I told you not to use rules' → strong", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("I told you not to use rules files");
+  assert(r !== null, "should detect");
+  assert(r.strength === "strong");
+});
+
+check("'Read my message again' → strong", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("Read my message again, I said PostToolUse");
+  assert(r !== null, "should detect");
+  assert(r.strength === "strong");
+});
+
+check("'Pay attention to the requirements' → strong", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("Pay attention to the requirements");
+  assert(r !== null, "should detect");
+  assert(r.strength === "strong");
+});
+
+// --- Moderate patterns: should detect (short prompts only) ---
+
+check("'No.' (standalone) → moderate", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("No.");
+  assert(r !== null, "should detect");
+  assert(r.strength === "moderate");
+});
+
+check("'Nope' → moderate", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("Nope");
+  assert(r !== null, "should detect");
+  assert(r.strength === "moderate");
+});
+
+check("'Wrong!' → strong (matches leading 'wrong' pattern)", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("Wrong!");
+  assert(r !== null, "should detect");
+  assert(r.strength === "strong");
+});
+
+check("'Stop' → moderate", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("Stop");
+  assert(r !== null, "should detect");
+  assert(r.strength === "moderate");
+});
+
+check("'Cancel' → moderate", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("Cancel");
+  assert(r !== null, "should detect");
+  assert(r.strength === "moderate");
+});
+
+check("'I didn't ask for that' → moderate", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("I didn't ask for that");
+  assert(r !== null, "should detect");
+  assert(r.strength === "moderate");
+});
+
+check("'That's not it' → moderate", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("That's not it");
+  assert(r !== null, "should detect");
+  assert(r.strength === "moderate");
+});
+
+check("'Completely wrong' → moderate", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("Completely wrong");
+  assert(r !== null, "should detect");
+  assert(r.strength === "moderate");
+});
+
+check("'Why did you delete that file' → moderate", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("Why did you delete that file");
+  assert(r !== null, "should detect");
+  assert(r.strength === "moderate");
+});
+
+check("'You're not listening' → moderate", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("You're not listening");
+  assert(r !== null, "should detect");
+  assert(r.strength === "moderate");
+});
+
+check("'You are doing it wrong' → moderate", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("You are doing it wrong");
+  assert(r !== null, "should detect");
+  assert(r.strength === "moderate");
+});
+
+// --- Moderate patterns: should NOT detect when prompt is long ---
+
+check("'Why did you...' in long prompt → null (too long for moderate)", function() {
+  var mod = loadMod();
+  var long = "Why did you choose that approach? " + "x".repeat(150);
+  var r = mod._detectCorrection(long);
+  assert(r === null, "should not detect — too long for moderate");
+});
+
+// --- Should NOT detect (false positive avoidance) ---
+
+check("'Build the user correction module' → null (task verb)", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("Build the user correction module");
+  assert(r === null, "should not detect — task verb");
+});
+
+check("'Create a new test file' → null (task verb)", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("Create a new test file for the detector");
+  assert(r === null, "should not detect — task verb");
+});
+
+check("'Fix the bug in parser.js' → null (task, not correction)", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("Fix the bug in parser.js");
+  assert(r === null, "should not detect — fix task");
+});
+
+check("'Add error handling to the module' → null (task verb)", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("Add error handling to the module");
+  assert(r === null, "should not detect — task verb");
+});
+
+check("'Run the test suite' → null (task verb)", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("Run the test suite and check for failures");
+  assert(r === null, "should not detect — task verb");
+});
+
+check("'Hello claude' → null (greeting)", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("Hello claude, how are you?");
+  assert(r === null, "should not detect — greeting");
+});
+
+check("'/commit' → null (slash command)", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("/commit");
+  assert(r === null, "should not detect — slash command");
+});
+
+check("Long technical prompt → null (too long)", function() {
+  var mod = loadMod();
+  var long = "I already told you about the design. " + "Here is the full spec with all the details that need to be implemented including the patterns and the architecture and the testing strategy and the deployment plan and more context. ".repeat(3);
+  var r = mod._detectCorrection(long);
+  assert(r === null, "should not detect — too long (>500 chars)");
+});
+
+check("Prompt with code block → null (technical content)", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("No, that's wrong. Use this instead:\n```\nconst x = 1;\n```");
+  assert(r === null, "should not detect — has code block");
+});
+
+check("'Read the README for setup instructions' → null (task verb)", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("Read the README for setup instructions");
+  assert(r === null, "should not detect — task verb 'read'");
+});
+
+check("'Fix the alignment issue in CSS' → null (fix task, not correction)", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("Fix the alignment issue in the CSS file");
+  assert(r === null, "should not detect — fix task");
+});
+
+check("'Review the pull request' → null (task verb)", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("Review the pull request and leave comments");
+  assert(r === null, "should not detect — task verb");
+});
+
+// --- isExcluded tests ---
+
+check("isExcluded: long text (>500 chars) → true", function() {
+  var mod = loadMod();
+  assert(mod._isExcluded("a".repeat(501)));
+});
+
+check("isExcluded: code block → true", function() {
+  var mod = loadMod();
+  assert(mod._isExcluded("Here is code:\n```\nx = 1\n```"));
+});
+
+check("isExcluded: slash command → true", function() {
+  var mod = loadMod();
+  assert(mod._isExcluded("/commit"));
+});
+
+check("isExcluded: task verb 'build' → true", function() {
+  var mod = loadMod();
+  assert(mod._isExcluded("build the new feature"));
+});
+
+check("isExcluded: task verb 'deploy' → true", function() {
+  var mod = loadMod();
+  assert(mod._isExcluded("deploy to production"));
+});
+
+check("isExcluded: 'fix the bug' → true", function() {
+  var mod = loadMod();
+  assert(mod._isExcluded("fix the bug in auth module"));
+});
+
+check("isExcluded: 'fix what you did' → false (correction about Claude)", function() {
+  var mod = loadMod();
+  assert(!mod._isExcluded("fix what you did wrong"));
+});
+
+check("isExcluded: greeting → true", function() {
+  var mod = loadMod();
+  assert(mod._isExcluded("hello claude"));
+});
+
+check("isExcluded: short correction → false", function() {
+  var mod = loadMod();
+  assert(!mod._isExcluded("No, that's wrong"));
+});
+
+check("isExcluded: normal text → false", function() {
+  var mod = loadMod();
+  assert(!mod._isExcluded("The module should return null for this case"));
+});
+
+// --- Edge cases ---
+
+check("Empty string → null", function() {
+  var mod = loadMod();
+  assert(mod._detectCorrection("") === null);
+});
+
+check("Null → null", function() {
+  var mod = loadMod();
+  assert(mod._detectCorrection(null) === null);
+});
+
+check("Undefined → null", function() {
+  var mod = loadMod();
+  assert(mod._detectCorrection(undefined) === null);
+});
+
+check("'No external dependencies' → null (starts with task-excluded 'No' but is technical)", function() {
+  // This tests that 'no' at the start requires a correction-like continuation
+  var mod = loadMod();
+  var r = mod._detectCorrection("No external dependencies should be added");
+  // 'No' followed by 'external' — not in the correction continuation list
+  assert(r === null, "should not detect — 'no external' is technical");
+});
+
+check("'No changes needed' → null (not a correction continuation)", function() {
+  var mod = loadMod();
+  var r = mod._detectCorrection("No changes needed for this file");
+  assert(r === null, "should not detect");
+});
+
+check("Module function with HOOK_RUNNER_TEST → null", function() {
+  var mod = loadMod();
+  process.env.HOOK_RUNNER_TEST = "1";
+  var r = mod({ tool_name: "Bash", tool_input: {}, tool_result: "ok" });
+  assert(r === null, "should skip in test mode");
+  delete process.env.HOOK_RUNNER_TEST;
+});
+
+// --- Summary ---
+console.log("\n=== Results: " + passed + " passed, " + failed + " failed ===");
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- New PostToolUse module: real-time detection of user corrections via prompt-log.jsonl
- Strong patterns (21): "No, that's wrong", "I already told you", "You should have", "Try again", etc.
- Moderate patterns (6): short standalone corrections like "No.", "Wrong!", "Stop"
- Deduplication via per-session temp marker (fires once per correction prompt)
- Logs corrections to `correction-log.jsonl` for scoring system consumption
- False positive exclusions: task verbs, code blocks, slash commands, greetings, long prompts (>500 chars)

## Test plan
- [x] 61 tests covering strong patterns, moderate patterns, exclusions, edge cases
- [x] All tests pass (61/61)