### PR TITLE
T608: Fix bash-write-patterns false positives on compound commands

### DIFF
--- a/modules/PreToolUse/_bash-write-patterns.js
+++ b/modules/PreToolUse/_bash-write-patterns.js
@@ -29,9 +29,13 @@ module.exports = [
   /\btruncate\s/,                   // truncate files
   /\binstall\s+-[a-zA-Z]/,          // install command (file copy variant)
   // Output redirection to files
-  /\becho\s+.*>/,                   // echo > file
-  /\bprintf\s+.*>/,                 // printf > file
-  /\bcat\s+[^|]*\s*>\s*[^&]/,      // cat ... > file (not cat | cmd)
+  // T608: Two fixes for false positives:
+  // 1. [^;|&]* prevents matching across compound operators (;, &&, ||, |).
+  //    Previously `echo x; cmd 2>/dev/null` matched because `.*` spanned `;`.
+  // 2. (?<![0-9]) excludes fd redirects like 2>/dev/null (stderr is not a write).
+  /\becho\s+[^;|&]*(?<![0-9])>/,   // echo > file (not 2>, single statement)
+  /\bprintf\s+[^;|&]*(?<![0-9])>/, // printf > file (not 2>, single statement)
+  /\bcat\s+[^;|&]*(?<![0-9])>\s*[^&]/, // cat > file (not 2>, single statement)
   // Build/package management
   /\bnpm\s+(install|ci|link|uninstall|publish)\b/,
   /\byarn\s+(add|install|remove)\b/,

--- a/scripts/test/test-_bash-write-patterns.js
+++ b/scripts/test/test-_bash-write-patterns.js
@@ -75,5 +75,20 @@ assert(!matches('powershell "[System.IO.Compression.ZipFile]::OpenRead()"'), "po
 assert(!matches("wsl -e bash -c 'python3 openclaw-checkin.py'"), "wsl python does not match");
 assert(!matches("echo hello"), "echo without redirect does not match");
 
+// === T608: Compound commands — redirect patterns must not cross statement boundaries ===
+assert(!matches('echo "=== test ==="; for mod in *.js; do ls "$mod"; done'), "echo before semicolon+for loop does not match");
+assert(!matches('echo "hello"; cat file.txt 2>/dev/null'), "echo; cat with 2>/dev/null does not match");
+assert(!matches('cat file.txt 2>/dev/null'), "cat with 2>/dev/null (stderr redirect) does not match");
+assert(!matches('echo "text" 2>/dev/null'), "echo with 2>/dev/null (stderr redirect) does not match");
+assert(!matches('printf "text" 2>/dev/null'), "printf with 2>/dev/null (stderr redirect) does not match");
+assert(!matches('echo "status" && git status'), "echo && git status does not match");
+assert(!matches('for evt in a b c; do echo "=== $evt ==="; done'), "for loop with echo (no redirect) does not match");
+assert(!matches('echo "text"; printf "more"; cat file'), "multiple echo/printf/cat without redirect does not match");
+assert(!matches('echo "info"; ls scripts/test/test-*"$base"* 2>/dev/null | head -1'), "echo; ls with 2>/dev/null pipe does not match");
+// Redirects within the same statement should still match
+assert(matches('echo "hello" > file.txt; cat other.txt'), "echo > file before semicolon still matches");
+assert(matches('printf "data" > out.log && echo done'), "printf > file before && still matches");
+assert(matches('cat in.txt > out.txt; rm tmp'), "cat > file before semicolon still matches");
+
 console.log("\n=== Results: " + passed + " passed, " + failed + " failed ===");
 process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- Fix redirect patterns (`echo`/`printf`/`cat`) matching across statement boundaries (`;`, `&&`, `||`)
- Fix redirect patterns matching stderr redirects (`2>/dev/null`) as file writes
- Uses `[^;|&]*` to constrain to single statement + `(?<![0-9])` lookbehind to exclude fd redirects

## Root cause
`/\becho\s+.*>/` — the `.*` is greedy and spans across `;` to match `>` in unrelated subcommands. A read-only `for` loop like `echo "test"; ls 2>/dev/null` was classified as a write, triggering spec-gate blocks.

## Test plan
- [x] 63/63 `test-_bash-write-patterns.js` (12 new cases for compound commands + stderr)
- [x] 20/20 `test-spec-before-code-gate.js`
- [x] 23/23 `test-_file-modify-patterns.js`