### PR TITLE
T610: Add tests for 5 untested PreToolUse modules (98 tests)

### DIFF
--- a/scripts/test/test-commit-quality-gate.js
+++ b/scripts/test/test-commit-quality-gate.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+"use strict";
+var path = require("path");
+var gate = require(path.join(__dirname, "../../modules/PreToolUse/commit-quality-gate.js"));
+
+var pass = 0, fail = 0;
+function ok(name, cond) {
+  if (cond) { pass++; console.log("OK: " + name); }
+  else { fail++; console.log("FAIL: " + name); }
+}
+function blocks(cmd) {
+  var r = gate({tool_name: "Bash", tool_input: {command: cmd}});
+  return r && r.decision === "block";
+}
+function passes(cmd) {
+  return gate({tool_name: "Bash", tool_input: {command: cmd}}) === null;
+}
+
+// Non-Bash/non-commit ignored
+ok("Read tool ignored", gate({tool_name: "Read", tool_input: {}}) === null);
+ok("non-commit Bash passes", passes("git status"));
+ok("git push passes", passes("git push origin main"));
+
+// Good commit messages pass
+ok("descriptive message passes", passes('git commit -m "Fix spec-gate cache stale hasUnchecked when tasks.md edited"'));
+ok("5-word message passes", passes('git commit -m "Add test coverage for gates"'));
+
+// Heredoc messages
+ok("heredoc message passes", passes("git commit -m \"$(cat <<'EOF'\nT608: Fix bash-write-patterns false positives on compound commands\nEOF\n)\""));
+
+// Short messages blocked
+ok("1-word blocked", blocks('git commit -m "fix"'));
+ok("2-word blocked", blocks('git commit -m "fix stuff"'));
+ok("3-word blocked", blocks('git commit -m "update the code"'));
+ok("4-word blocked", blocks('git commit -m "fix the broken thing"'));
+
+// Generic starts blocked (< 8 words)
+ok("generic 'fix' start blocked", blocks('git commit -m "fix something in the module"'));
+ok("generic 'update' start blocked", blocks('git commit -m "update the test file here"'));
+ok("generic 'wip' start blocked", blocks('git commit -m "wip adding new feature"'));
+ok("generic 'cleanup' blocked", blocks('git commit -m "cleanup old unused code"'));
+
+// Generic start with enough detail passes (>= 8 words)
+ok("generic with detail passes", passes('git commit -m "fix the spec-gate cache invalidation for tasks.md editing scenario"'));
+
+// Amend skipped
+ok("--amend skipped", passes('git commit --amend'));
+
+// Block message quality
+var r = gate({tool_name: "Bash", tool_input: {command: 'git commit -m "fix"'}});
+ok("block mentions word count", r && /words/.test(r.reason));
+ok("block mentions min", r && /min/.test(r.reason));
+
+var r2 = gate({tool_name: "Bash", tool_input: {command: 'git commit -m "update the test suite for gates"'}});
+ok("generic block mentions detail", r2 && /GENERIC/.test(r2.reason));
+
+// Edge cases
+ok("empty command passes", passes(""));
+ok("commit without -m passes", passes("git commit"));
+
+console.log("\n" + pass + "/" + (pass+fail) + " passed");
+process.exit(fail > 0 ? 1 : 0);

--- a/scripts/test/test-force-push-gate.js
+++ b/scripts/test/test-force-push-gate.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+"use strict";
+var path = require("path");
+var gate = require(path.join(__dirname, "../../modules/PreToolUse/force-push-gate.js"));
+
+var pass = 0, fail = 0;
+function ok(name, cond) {
+  if (cond) { pass++; console.log("OK: " + name); }
+  else { fail++; console.log("FAIL: " + name); }
+}
+function blocks(cmd) {
+  var r = gate({tool_name: "Bash", tool_input: {command: cmd}});
+  return r && r.decision === "block";
+}
+function passes(cmd) {
+  return gate({tool_name: "Bash", tool_input: {command: cmd}}) === null;
+}
+
+// Non-Bash tools ignored
+ok("Read tool ignored", gate({tool_name: "Read", tool_input: {}}) === null);
+ok("Edit tool ignored", gate({tool_name: "Edit", tool_input: {}}) === null);
+
+// Normal push allowed
+ok("git push (no force) passes", passes("git push origin main"));
+ok("git push -u passes", passes("git push -u origin feature"));
+
+// Force push to main/master blocked
+ok("--force to main blocked", blocks("git push --force origin main"));
+ok("-f to main blocked", blocks("git push -f origin main"));
+ok("--force to master blocked", blocks("git push --force origin master"));
+ok("--force-with-lease to main blocked", blocks("git push --force-with-lease origin main"));
+
+// Force push to other branches allowed
+ok("--force to feature passes", passes("git push --force origin feature-branch"));
+ok("-f to develop passes", passes("git push -f origin develop"));
+
+// Block message quality
+var r = gate({tool_name: "Bash", tool_input: {command: "git push --force origin main"}});
+ok("block mentions destructive", r && /destructive/i.test(r.reason));
+ok("block mentions revert", r && /revert/i.test(r.reason));
+
+// Edge cases
+ok("empty command passes", passes(""));
+ok("non-git command passes", passes("echo hello"));
+
+console.log("\n" + pass + "/" + (pass+fail) + " passed");
+process.exit(fail > 0 ? 1 : 0);

--- a/scripts/test/test-no-hardcoded-paths.js
+++ b/scripts/test/test-no-hardcoded-paths.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+"use strict";
+var path = require("path");
+var gate = require(path.join(__dirname, "../../modules/PreToolUse/no-hardcoded-paths.js"));
+
+var pass = 0, fail = 0;
+function ok(name, cond) {
+  if (cond) { pass++; console.log("OK: " + name); }
+  else { fail++; console.log("FAIL: " + name); }
+}
+
+// Build test paths dynamically to avoid triggering the gate on THIS file
+var WIN_PATH = ["C:", "Users", "joel", "Documents", "file.txt"].join("\\");
+var WIN_FWD = ["C:", "Users", "joel", "project"].join("/");
+var LINUX_PATH = ["", "home", "ubuntu", "data", "file.csv"].join("/");
+var MAC_PATH = ["", "Users", "joel", "Documents", "file.txt"].join("/");
+
+function writeBlocks(filePath, content) {
+  var r = gate({tool_name: "Write", tool_input: {file_path: filePath, content: content}});
+  return r && r.decision === "block";
+}
+function editBlocks(filePath, newStr) {
+  var r = gate({tool_name: "Edit", tool_input: {file_path: filePath, new_string: newStr}});
+  return r && r.decision === "block";
+}
+function writePasses(filePath, content) {
+  return gate({tool_name: "Write", tool_input: {file_path: filePath, content: content}}) === null;
+}
+
+// Non-edit tools ignored
+ok("Read tool ignored", gate({tool_name: "Read", tool_input: {}}) === null);
+ok("Bash tool ignored", gate({tool_name: "Bash", tool_input: {}}) === null);
+
+// Windows paths blocked
+ok("Write: Windows path blocked", writeBlocks("/tmp/app.js", 'var p = "' + WIN_PATH + '";'));
+ok("Edit: Windows fwd-slash path blocked", editBlocks("/tmp/app.js", 'const dir = "' + WIN_FWD + '";'));
+
+// Linux paths blocked
+ok("Linux home path blocked", writeBlocks("/tmp/app.py", 'path = "' + LINUX_PATH + '"'));
+
+// macOS paths blocked
+ok("macOS home path blocked", writeBlocks("/tmp/app.py", 'path = "' + MAC_PATH + '"'));
+
+// Comment lines skipped
+ok("JS comment line allowed", writePasses("/tmp/app.js", "// path: " + WIN_PATH));
+ok("Python comment allowed", writePasses("/tmp/app.py", "# " + LINUX_PATH));
+ok("Block comment allowed", writePasses("/tmp/app.js", "/* " + WIN_PATH + " */"));
+
+// Markdown/text files exempt
+ok(".md files exempt", writePasses("/tmp/README.md", "Install at " + WIN_PATH));
+ok(".txt files exempt", writePasses("/tmp/notes.txt", LINUX_PATH));
+ok(".html files exempt", writePasses("/tmp/page.html", WIN_PATH));
+
+// CloudFormation YAML exempt
+ok("CloudFormation yaml exempt", writePasses("/tmp/cloudformation/template.yaml", LINUX_PATH));
+
+// Dockerfile exempt
+ok("Dockerfile exempt", writePasses("/tmp/Dockerfile", "WORKDIR " + LINUX_PATH));
+
+// Clean content passes
+ok("relative path passes", writePasses("/tmp/app.js", 'var p = "./config/settings.json";'));
+ok("variable path passes", writePasses("/tmp/app.js", 'var p = path.join(__dirname, "config");'));
+ok("empty content passes", writePasses("/tmp/app.js", ""));
+
+// Block message quality
+var r = gate({tool_name: "Write", tool_input: {file_path: "/tmp/app.js", content: 'x = "' + WIN_PATH + '"'}});
+ok("block mentions HARDCODED", r && /HARDCODED/i.test(r.reason));
+ok("block mentions variable", r && /variable/i.test(r.reason));
+
+console.log("\n" + pass + "/" + (pass+fail) + " passed");
+process.exit(fail > 0 ? 1 : 0);

--- a/scripts/test/test-no-polling-gate.js
+++ b/scripts/test/test-no-polling-gate.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+"use strict";
+var path = require("path");
+var gate = require(path.join(__dirname, "../../modules/PreToolUse/no-polling-gate.js"));
+
+var pass = 0, fail = 0;
+function ok(name, cond) {
+  if (cond) { pass++; console.log("OK: " + name); }
+  else { fail++; console.log("FAIL: " + name); }
+}
+function blocks(cmd) {
+  var r = gate({tool_name: "Bash", tool_input: {command: cmd}});
+  return r && r.decision === "block";
+}
+function passes(cmd) {
+  return gate({tool_name: "Bash", tool_input: {command: cmd}}) === null;
+}
+
+// Non-Bash ignored
+ok("Read tool ignored", gate({tool_name: "Read", tool_input: {}}) === null);
+ok("Edit tool ignored", gate({tool_name: "Edit", tool_input: {}}) === null);
+
+// Pattern 1: Loop-based polling blocked
+ok("while+sleep+curl blocked", blocks("while true; do sleep 5; curl http://api; done"));
+ok("while+sleep+gh blocked", blocks("while true; do sleep 10; gh api repos/org/repo; done"));
+ok("for+sleep+kubectl blocked", blocks("for i in 1 2 3; do sleep 30; kubectl get pods; done"));
+ok("while+sleep+aws blocked", blocks("while true; do sleep 60; aws ec2 describe-instances; done"));
+ok("while+sleep+docker blocked", blocks("while true; do sleep 5; docker ps; done"));
+
+// Pattern 5: until-based polling blocked
+ok("until+sleep blocked", blocks("until [ -f /tmp/done ]; do sleep 5; echo waiting; done"));
+
+// Pattern 2: GitHub comment polling (GET) blocked
+ok("gh api comments blocked", blocks("gh api repos/grobomo/hook-runner/pulls/1/comments"));
+
+// Pattern 2: GitHub comment POST allowed
+ok("gh api comments POST passes", passes("gh api repos/grobomo/hook-runner/pulls/1/comments --method POST -f body=hello"));
+ok("gh api comments -X POST passes", passes("gh api repos/grobomo/hook-runner/pulls/1/comments -X POST"));
+
+// Pattern 3: Log tailing blocked
+ok("journalctl -f blocked", blocks("journalctl -f -u myservice"));
+ok("journalctl --follow blocked", blocks("journalctl --follow"));
+ok("tail -f blocked", blocks("tail -f /var/log/syslog"));
+ok("tail -F blocked", blocks("tail -F /var/log/app.log"));
+ok("kubectl logs -f blocked", blocks("kubectl logs -f pod-name"));
+ok("docker logs --follow blocked", blocks("docker logs --follow container"));
+
+// Pattern 4: watch blocked
+ok("watch command blocked", blocks("watch -n 5 kubectl get pods"));
+
+// Non-polling commands pass
+ok("single curl passes", passes("curl http://api/status"));
+ok("gh api single call passes", passes("gh api repos/grobomo/hook-runner/pulls"));
+ok("kubectl get passes", passes("kubectl get pods"));
+ok("tail -n passes", passes("tail -n 50 /var/log/syslog"));
+ok("journalctl -n passes", passes("journalctl -n 100"));
+ok("docker logs (no follow) passes", passes("docker logs container --tail 50"));
+ok("git status passes", passes("git status"));
+ok("echo passes", passes("echo hello"));
+ok("empty passes", passes(""));
+
+// Block message quality
+var r = gate({tool_name: "Bash", tool_input: {command: "while true; do sleep 5; curl http://x; done"}});
+ok("block mentions tokens", r && /tokens/i.test(r.reason));
+ok("block mentions webhook", r && /webhook/i.test(r.reason));
+ok("block mentions alternatives", r && /ALTERNATIVES/i.test(r.reason));
+
+console.log("\n" + pass + "/" + (pass+fail) + " passed");
+process.exit(fail > 0 ? 1 : 0);

--- a/scripts/test/test-no-rules-gate.js
+++ b/scripts/test/test-no-rules-gate.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+"use strict";
+var path = require("path");
+var os = require("os");
+var gate = require(path.join(__dirname, "../../modules/PreToolUse/no-rules-gate.js"));
+
+var pass = 0, fail = 0;
+function ok(name, cond) {
+  if (cond) { pass++; console.log("OK: " + name); }
+  else { fail++; console.log("FAIL: " + name); }
+}
+
+var HOME = os.homedir().replace(/\\/g, "/");
+
+function blocks(tool, filePath) {
+  var r = gate({tool_name: tool, tool_input: {file_path: filePath}});
+  return r && r.decision === "block";
+}
+function passes(tool, filePath) {
+  return gate({tool_name: tool, tool_input: {file_path: filePath}}) === null;
+}
+
+// Non-edit tools ignored
+ok("Read ignored", passes("Read", HOME + "/.claude/rules/test.md"));
+ok("Bash ignored", passes("Bash", HOME + "/.claude/rules/test.md"));
+
+// Global rules blocked
+ok("Write to global rules blocked", blocks("Write", HOME + "/.claude/rules/test.md"));
+ok("Edit global rules blocked", blocks("Edit", HOME + "/.claude/rules/enforce.md"));
+
+// Project rules blocked
+ok("Write .claude/rules blocked", blocks("Write", "/project/.claude/rules/gate.md"));
+ok("Edit .claude/rules blocked", blocks("Edit", "/project/.claude/rules/enforce.md"));
+ok("Windows path .claude\\rules blocked", blocks("Write", "C:\\project\\.claude\\rules\\gate.md"));
+
+// Non-rules .claude paths allowed
+ok(".claude/settings.json passes", passes("Write", HOME + "/.claude/settings.json"));
+ok(".claude/hooks passes", passes("Edit", HOME + "/.claude/hooks/run-pretooluse.js"));
+
+// Other paths with 'rules' in name allowed
+ok("src/rules.js passes", passes("Write", "/project/src/rules.js"));
+ok("docs/rules/ passes", passes("Edit", "/project/docs/rules/readme.md"));
+
+// Empty path passes
+ok("empty path passes", passes("Write", ""));
+
+// Block message quality
+var r = gate({tool_name: "Write", tool_input: {file_path: HOME + "/.claude/rules/test.md"}});
+ok("block mentions hook-runner", r && /hook-runner/i.test(r.reason));
+ok("block mentions module", r && /module/i.test(r.reason));
+
+console.log("\n" + pass + "/" + (pass+fail) + " passed");
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
Add dedicated test suites for 5 PreToolUse modules that had no tests:
- **force-push-gate**: 14 tests — force flags, protected branches, non-protected pass
- **commit-quality-gate**: 21 tests — word count, generic starts, heredoc parsing, amend
- **no-hardcoded-paths**: 19 tests — Win/Linux/Mac paths, comments skip, exempt extensions
- **no-polling-gate**: 30 tests — loop polling, gh comment GET vs POST, log tailing, watch
- **no-rules-gate**: 14 tests — global/project rules blocked, non-rules paths pass

## Test plan
- [x] 14/14 force-push-gate
- [x] 21/21 commit-quality-gate
- [x] 19/19 no-hardcoded-paths
- [x] 30/30 no-polling-gate
- [x] 14/14 no-rules-gate