### PR TITLE
Bump to v2.75.0 with changelog for T609/T610

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.75.0] — 2026-05-04
+
+### Added
+- **Test suites for 5 modules** (T610) — force-push-gate (14), commit-quality-gate (21), no-hardcoded-paths (19), no-polling-gate (30), no-rules-gate (14). 98 new tests total.
+- **worktree-gate test fix** (T609) — HOOK_RUNNER_TEST env var save/restore prevents intermittent failures in batch mode.
+- **spec-gate control structures** (T609) — `for`/`while`/`if` added to BASH_ALLOW_PATTERNS fast-path.
+
+### Stats
+- 169 suites, ~2576 tests
+- 121 modules, 7 workflows
+
 ## [2.74.0] — 2026-05-04
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.74.0",
+  "version": "2.75.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Version bump to v2.75.0
- Changelog entries for T609 (worktree-gate test fix, spec-gate control structures) and T610 (98 new tests for 5 modules)

## Test plan
- [x] All test suites pass (verified in PRs #514, #515)