### PR TITLE
T611: Fix onboarding UX — workflow name, module counts, diagnose docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ node setup.js                # full setup wizard
 node setup.js --yes          # non-interactive setup + default workflows
 node setup.js --report       # HTML report
 node setup.js --health       # verify runners + modules
+node setup.js --diagnose     # diagnose settings, hooks, broken scripts (--fix, --json)
 node setup.js --sync         # sync modules from GitHub
 node setup.js --list         # catalog vs installed
 node setup.js --stats        # text summary of hook log

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ hook-runner replaces direct `settings.json` editing. After install, you never to
 
 **1. Modules over shell commands.** Each rule is a `.js` file that receives structured input (tool name, file path, command) and returns a decision. Modules are testable, documented, and version-controlled. Drop a file in a folder and it runs — remove it and it stops.
 
-**2. Workflows over individual modules.** You don't think "I need to enable spec-gate, branch-gate, test-checkpoint-gate, and worker-loop." You think "I want the SHTD development pipeline." Workflows group related modules so you enable one name and get a complete enforcement regime. Disable it and they all go silent. This is how you manage 130+ modules without losing track.
+**2. Workflows over individual modules.** You don't think "I need to enable spec-gate, branch-gate, test-checkpoint-gate, and worker-loop." You think "I want the SHTD development pipeline." Workflows group related modules so you enable one name and get a complete enforcement regime. Disable it and they all go silent. This is how you manage 120+ modules without losing track.
 
 **3. Portability.** Export your module config as YAML (`--export`), sync it to another machine (`--sync`), or share a workflow definition. Workflows also make it easy to switch contexts — enable `customer-data-guard` during incident response, disable it after.
 
@@ -51,11 +51,11 @@ The setup wizard will:
 1. Scan your current hooks and generate a styled HTML report
 2. Back up existing hooks to `~/.claude/hooks/archive/`
 3. Install the runner system
-4. Enable the `starter` workflow (with `--yes`) — 48 universally useful modules
+4. Enable the `starter` workflow (with `--yes`) — 49 universally useful modules
 
 Ready for more? Enable the full development pipeline:
 ```bash
-node setup.js --workflow enable shtd    # 113 modules: spec-first, test-first, PR discipline
+node setup.js --workflow enable shtd    # 110 modules: spec-first, test-first, PR discipline
 ```
 
 To undo everything: `node setup.js --uninstall --confirm`
@@ -104,9 +104,9 @@ node setup.js --workflow query Edit        # which workflows affect Edit?
 
 | Workflow | Modules | What it enforces |
 |----------|---------|-----------------|
-| `starter` | 48 | **Start here.** Safe defaults for any user — blocks force-push, destructive git, secret commits, file deletion. Adds commit quality checks, test reminders, and session context. |
-| `shtd` | 113 | Spec-Hook-Test-Driven — the full development pipeline. Enforces spec → branch → test → implement → PR, plus code quality, infrastructure safety, messaging guards, session lifecycle, and self-improvement. |
-| `gsd` | 111 | GSD-driven development — replaces shtd's spec-based flow with phase-based flow (.planning/ → ROADMAP.md → phase plan → branch → execute → PR). Same safety and quality modules as shtd. |
+| `starter` | 49 | **Start here.** Safe defaults for any user — blocks force-push, destructive git, secret commits, file deletion. Adds commit quality checks, test reminders, and session context. |
+| `shtd` | 110 | Spec-Hook-Test-Driven — the full development pipeline. Enforces spec → branch → test → implement → PR, plus code quality, infrastructure safety, messaging guards, session lifecycle, and self-improvement. |
+| `gsd` | 110 | GSD-driven development — replaces shtd's spec-based flow with phase-based flow (.planning/ → ROADMAP.md → phase plan → branch → execute → PR). Same safety and quality modules as shtd. |
 | `customer-data-guard` | 4 | Read-only incident response — blocks env changes, data exfil, and V1 modifications. |
 | `dispatcher-worker` | 10 | Role-aware fleet workflow. Dispatcher specs/distributes, workers implement/test/PR. |
 | `no-local-docker` | 2 | Blocks local Docker commands, forces remote infrastructure. |
@@ -504,6 +504,9 @@ Full catalog in `modules/` directory:
 | `workflow-summary` | Injects active workflow summary |
 
 ## Troubleshooting
+
+**Something broken? Run diagnostics first:**
+- `node setup.js --diagnose [project-dir]` — shows all settings files, hooks, broken scripts, and suggests fixes. Add `--fix` to auto-repair, `--json` for machine-readable output.
 
 **Module not running?**
 - Check `node setup.js --health` for load errors

--- a/setup.js
+++ b/setup.js
@@ -1484,7 +1484,7 @@ function cmdWizard(reportOnly, dryRun, openMode, autoYes, analyzeMode, deepMode,
   console.log("  Backup: " + backup.backupDir);
   console.log("  Report: " + afterReport);
   if (enableWorkflows) {
-    console.log("  Default workflows enabled: shtd");
+    console.log("  Default workflows enabled: " + defaultWorkflows.join(", "));
   }
   console.log("");
   console.log("  To add a hook module:");


### PR DESCRIPTION
## Summary
- **setup.js**: Post-install summary hardcoded "shtd" but `--yes` enables "starter" — now uses `defaultWorkflows.join()` 
- **README**: Updated workflow module counts to match `--workflow audit` (starter 49, shtd 110, gsd 110)
- **README**: Added `--diagnose` to troubleshooting section (T604 feature was undocumented)
- **CLAUDE.md**: Added `--diagnose` to CLI commands list

## Test plan
- [x] 7/7 `test-setup-wizard.sh`
- [x] 7/7 `test-T094-module-docs.sh`