### PR TITLE
T613: Add tunnel-check-gate module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.76.0] — 2026-05-04
+
+### Added
+- **tunnel-check-gate** (T613) — Blocks process-grep SSH tunnel checks (`tasklist | grep ssh`, `ps aux | grep ssh`, `pgrep ssh`). Suggests port connectivity test instead. Allows kill/stop/terminate (legitimate process management). 29 tests.
+
+### Stats
+- 170 suites, ~2605 tests
+- 122 modules, 7 workflows
+
 ## [2.75.0] — 2026-05-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -405,6 +405,7 @@ Full catalog in `modules/` directory:
 | `no-playwright-direct` | Blocks raw mcp__playwright__* calls, requires Blueprint Extra MCP |
 | `no-polling-gate` | Blocks LLM-driven polling (loops+sleep, log tailing, comment watching, watch) |
 | `no-rules-gate` | Blocks creation of ~/.claude/rules/ files (use hook modules instead) |
+| `tunnel-check-gate` | Blocks process-grep SSH tunnel checks, suggests port connectivity test |
 | `hook-system-reminder` | Reminds Claude that enforcement is ONLY via hook-runner modules |
 | `inter-project-priority-gate` | Blocks non-XREF work when P0 inter-project TODOs are pending |
 | `pr-first-gate` | Blocks spec/code edits on branches without an open PR |

--- a/modules/PreToolUse/tunnel-check-gate.js
+++ b/modules/PreToolUse/tunnel-check-gate.js
@@ -1,0 +1,49 @@
+// TOOLS: Bash
+// WORKFLOW: shtd
+// WHY: Claude checked SSH tunnel status by grepping processes (tasklist | grep ssh,
+// ps aux | grep ssh). Tunnel was running but detection failed — process names don't
+// reliably indicate tunnel health. User corrected: test port connectivity instead.
+// T613: Block process-grep tunnel checks, suggest port connectivity test.
+"use strict";
+
+// Pattern: process listing + grep for ssh
+var PROCESS_GREP_SSH = [
+  /\btasklist\b[^;|&]*\|\s*(?:grep|findstr)\b[^;|&]*\bssh\b/i,
+  /\bps\s+(?:aux|ef|a)\b[^;|&]*\|\s*grep\b[^;|&]*\bssh\b/i,
+  /\bpgrep\b[^;|&]*\bssh\b/i,
+  /\bwmic\s+process\b[\s\S]*\bssh\b/i,
+];
+
+// Allow: commands that also kill/stop/terminate (legitimate process management)
+var MANAGEMENT_SKIP = /\b(kill|stop|terminate|taskkill|pkill)\b/i;
+
+var BLOCK_MSG =
+  "TUNNEL CHECK: Do not grep for SSH processes to check tunnel status.\n" +
+  "Process detection is unreliable — tunnel may be running but grep misses it.\n\n" +
+  "TEST PORT CONNECTIVITY INSTEAD:\n" +
+  "  python -c \"import urllib.request,ssl; c=ssl.create_default_context(); " +
+  "c.check_hostname=False; c.verify_mode=ssl.CERT_NONE; " +
+  "print(urllib.request.urlopen('https://127.0.0.1:10448/loginPage.ddei'," +
+  "timeout=5,context=c).status)\"\n\n" +
+  "Or run: python scripts/health-check.py --quick\n\n" +
+  "If login page loads, tunnel is up. Connection refused = down.";
+
+module.exports = function(input) {
+  if (input.tool_name !== "Bash") return null;
+  var cmd = (input.tool_input || {}).command || "";
+  if (!cmd) return null;
+
+  // Skip if command involves process management (kill/stop/terminate)
+  if (MANAGEMENT_SKIP.test(cmd)) return null;
+
+  for (var i = 0; i < PROCESS_GREP_SSH.length; i++) {
+    if (PROCESS_GREP_SSH[i].test(cmd)) {
+      return {
+        decision: "block",
+        reason: BLOCK_MSG + "\n\nDETECTED: " + cmd.substring(0, 120)
+      };
+    }
+  }
+
+  return null;
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.75.0",
+  "version": "2.76.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"

--- a/scripts/test/test-tunnel-check-gate.js
+++ b/scripts/test/test-tunnel-check-gate.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+"use strict";
+var path = require("path");
+var gate = require(path.join(__dirname, "../../modules/PreToolUse/tunnel-check-gate.js"));
+
+var pass = 0, fail = 0;
+function ok(name, cond) {
+  if (cond) { pass++; console.log("OK: " + name); }
+  else { fail++; console.log("FAIL: " + name); }
+}
+function blocks(cmd) {
+  var r = gate({tool_name: "Bash", tool_input: {command: cmd}});
+  return r && r.decision === "block";
+}
+function passes(cmd) {
+  return gate({tool_name: "Bash", tool_input: {command: cmd}}) === null;
+}
+
+// === Non-Bash tools ignored ===
+ok("Read tool ignored", gate({tool_name: "Read", tool_input: {}}) === null);
+ok("Edit tool ignored", gate({tool_name: "Edit", tool_input: {}}) === null);
+ok("Write tool ignored", gate({tool_name: "Write", tool_input: {}}) === null);
+
+// === Blocks: tasklist + grep ssh ===
+ok("tasklist | grep ssh blocked", blocks("tasklist 2>/dev/null | grep -i ssh | head -10"));
+ok("tasklist | grep -i ssh blocked", blocks("tasklist | grep -i ssh"));
+ok("tasklist | findstr ssh blocked", blocks("tasklist | findstr ssh"));
+ok("tasklist | findstr /i ssh blocked", blocks("tasklist | findstr /i ssh"));
+
+// === Blocks: ps + grep ssh ===
+ok("ps aux | grep ssh blocked", blocks("ps aux | grep ssh"));
+ok("ps ef | grep ssh blocked", blocks("ps ef | grep ssh"));
+ok("ps a | grep ssh blocked", blocks("ps a | grep ssh"));
+ok("ps aux | grep -i ssh blocked", blocks("ps aux | grep -i ssh"));
+
+// === Blocks: pgrep ssh ===
+ok("pgrep ssh blocked", blocks("pgrep ssh"));
+ok("pgrep -f ssh blocked", blocks("pgrep -f ssh"));
+
+// === Blocks: wmic process ssh ===
+ok("wmic process ssh blocked", blocks("wmic process list | grep ssh"));
+
+// === Allows: process management (kill/stop/terminate) ===
+ok("taskkill ssh allowed", passes("taskkill /f /im ssh.exe"));
+ok("kill ssh allowed", passes("ps aux | grep ssh | kill"));
+ok("pkill ssh allowed", passes("pkill ssh"));
+ok("terminate in command allowed", passes("tasklist | grep ssh | terminate-process"));
+
+// === Allows: unrelated commands ===
+ok("ssh command itself allowed", passes("ssh user@host ls"));
+ok("scp allowed", passes("scp file.txt user@host:/tmp/"));
+ok("ssh-keygen allowed", passes("ssh-keygen -t ed25519"));
+ok("grep non-ssh allowed", passes("ps aux | grep python"));
+ok("tasklist non-ssh allowed", passes("tasklist | grep node"));
+ok("echo ssh allowed", passes("echo 'checking ssh'"));
+ok("empty command allowed", passes(""));
+
+// === Block message quality ===
+var r = gate({tool_name: "Bash", tool_input: {command: "tasklist | grep -i ssh"}});
+ok("block mentions port connectivity", r && /port connectivity/i.test(r.reason));
+ok("block mentions unreliable", r && /unreliable/i.test(r.reason));
+ok("block mentions health-check", r && /health-check/i.test(r.reason));
+ok("block includes detected command", r && /DETECTED/.test(r.reason));
+
+console.log("\n" + pass + "/" + (pass+fail) + " passed");
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- New PreToolUse module `tunnel-check-gate` — blocks process-grep SSH tunnel checks (`tasklist | grep ssh`, `ps aux | grep ssh`, `pgrep ssh`, `wmic process ssh`)
- Suggests port connectivity test instead (urllib to localhost:10448)
- Allows kill/stop/terminate commands (legitimate process management)
- 29 tests, all passing
- Version bump to v2.76.0

## Test plan
- [x] 29/29 unit tests pass
- [x] Full suite: 170 suites, 2485 passed, 0 failed
- [x] Module docs test (T094) passes