### PR TITLE
T610b: Add tests for 5 more modules (batch 3)

### DIFF
--- a/scripts/test/test-claude-p-pattern.js
+++ b/scripts/test/test-claude-p-pattern.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+"use strict";
+var path = require("path");
+var gate = require(path.join(__dirname, "../../modules/PreToolUse/claude-p-pattern.js"));
+
+var pass = 0, fail = 0;
+function ok(name, cond) {
+  if (cond) { pass++; console.log("OK: " + name); }
+  else { fail++; console.log("FAIL: " + name); }
+}
+function blocks(cmd) {
+  var r = gate({tool_name: "Bash", tool_input: {command: cmd}});
+  return r && r.decision === "block";
+}
+function passesBash(cmd) {
+  return gate({tool_name: "Bash", tool_input: {command: cmd}}) === null;
+}
+
+// Non-Bash/Edit/Write ignored
+ok("Read tool ignored", gate({tool_name: "Read", tool_input: {}}) === null);
+
+// === Bash gate: bad claude -p invocations ===
+ok("--no-input blocked", blocks("claude -p --no-input 'analyze this'"));
+ok("echo pipe blocked", blocks("echo 'task' | claude -p"));
+ok("arg-based prompt blocked", blocks('claude -p "analyze the file" 2>&1'));
+
+// Good claude -p invocations allowed
+ok("stdin redirect allowed", passesBash("claude -p < promptfile.txt"));
+ok("non-claude command allowed", passesBash("node setup.js"));
+ok("empty command allowed", passesBash(""));
+
+// === Edit gate: bad patterns in scripts ===
+// ANTHROPIC_API_KEY anti-pattern
+var r1 = gate({tool_name: "Edit", tool_input: {
+  file_path: "/scripts/analyze.py",
+  new_string: "api_key = os.environ['ANTHROPIC_API_KEY']"
+}});
+ok("ANTHROPIC_API_KEY blocked", r1 && r1.decision === "block");
+
+// base64 encoding anti-pattern
+var r2 = gate({tool_name: "Write", tool_input: {
+  file_path: "/scripts/review.py",
+  content: "# Send to claude -p\nencoded = base64.b64encode(open('img.png', 'rb').read())"
+}});
+ok("base64 encode image blocked", r2 && r2.decision === "block");
+
+// import anthropic SDK anti-pattern
+var r3 = gate({tool_name: "Edit", tool_input: {
+  file_path: "/scripts/checker.py",
+  new_string: "import anthropic\nclient = anthropic.Anthropic()"
+}});
+ok("import anthropic blocked", r3 && r3.decision === "block");
+
+// Self-reference (hook module files) allowed
+var r4 = gate({tool_name: "Edit", tool_input: {
+  file_path: "/run-modules/PreToolUse/claude-p-pattern.js",
+  new_string: "import anthropic"
+}});
+ok("own module file allowed", r4 === null);
+
+// Normal edits allowed
+var r5 = gate({tool_name: "Edit", tool_input: {
+  file_path: "/src/app.py",
+  new_string: "result = process_data(input)"
+}});
+ok("normal edit allowed", r5 === null);
+
+// Block message quality
+ok("bash block has correct pattern", gate({tool_name: "Bash", tool_input: {command: "claude -p --no-input x"}}).reason.indexOf("PROMPTFILE") !== -1);
+ok("edit block mentions no API key", r1 && /no.*key|doesn.*t.*need/i.test(r1.reason));
+
+console.log("\n" + pass + "/" + (pass+fail) + " passed");
+process.exit(fail > 0 ? 1 : 0);

--- a/scripts/test/test-crlf-ssh-key-check.js
+++ b/scripts/test/test-crlf-ssh-key-check.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+"use strict";
+var path = require("path");
+var gate = require(path.join(__dirname, "../../modules/PreToolUse/crlf-ssh-key-check.js"));
+
+var pass = 0, fail = 0;
+function ok(name, cond) {
+  if (cond) { pass++; console.log("OK: " + name); }
+  else { fail++; console.log("FAIL: " + name); }
+}
+function blocks(cmd) {
+  var r = gate({tool_name: "Bash", tool_input: {command: cmd}});
+  return r && r.decision === "block";
+}
+function passes(cmd) {
+  return gate({tool_name: "Bash", tool_input: {command: cmd}}) === null;
+}
+
+// Non-Bash ignored
+ok("Read tool ignored", gate({tool_name: "Read", tool_input: {}}) === null);
+
+// SSH key copy operations blocked
+ok("scp .pem blocked", blocks("scp key.pem user@host:/tmp/"));
+ok("cp .pem blocked", blocks("cp key.pem /tmp/deploy/"));
+ok("cp key blocked", blocks("cp id_rsa authorized_keys"));
+ok("aws s3 cp key blocked", blocks("aws s3 cp my-key.pem s3://bucket/keys/"));
+
+// Non-key operations allowed
+ok("scp regular file allowed", passes("scp config.yml user@host:/tmp/"));
+ok("cp regular file allowed", passes("cp readme.md /tmp/"));
+ok("echo allowed", passes("echo hello"));
+ok("empty command allowed", passes(""));
+
+// Block message quality
+var r = gate({tool_name: "Bash", tool_input: {command: "scp key.pem user@host:/tmp/"}});
+ok("block mentions CRLF", r && /CRLF|\\r\\n/.test(r.reason));
+ok("block mentions tr", r && /tr/.test(r.reason));
+
+console.log("\n" + pass + "/" + (pass+fail) + " passed");
+process.exit(fail > 0 ? 1 : 0);

--- a/scripts/test/test-no-focus-steal.js
+++ b/scripts/test/test-no-focus-steal.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+"use strict";
+var path = require("path");
+var gate = require(path.join(__dirname, "../../modules/PreToolUse/no-focus-steal.js"));
+
+var pass = 0, fail = 0;
+function ok(name, cond) {
+  if (cond) { pass++; console.log("OK: " + name); }
+  else { fail++; console.log("FAIL: " + name); }
+}
+function blocks(cmd) {
+  var r = gate({tool_name: "Bash", tool_input: {command: cmd}});
+  return r && r.decision === "block";
+}
+function passes(cmd) {
+  return gate({tool_name: "Bash", tool_input: {command: cmd}}) === null;
+}
+
+// Non-Bash ignored
+ok("Read tool ignored", gate({tool_name: "Read", tool_input: {}}) === null);
+
+if (process.platform !== "win32") {
+  // On non-Windows, everything passes
+  ok("non-win32: background node passes", passes("node script.js &"));
+  ok("non-win32: nohup passes", passes("nohup python worker.py &"));
+  console.log("\n" + pass + "/" + (pass+fail) + " passed (non-Windows: all pass)");
+  process.exit(fail > 0 ? 1 : 0);
+}
+
+// Windows tests below
+
+// Background process spawning blocked
+ok("node &amp blocked", blocks("node script.js &"));
+ok("nohup python blocked", blocks("nohup python worker.py &"));
+ok("nohup bash blocked", blocks("nohup bash deploy.sh &"));
+ok("start exe blocked", blocks('start "" python.exe script.py'));
+ok("start cmd blocked", blocks('start "" cmd /c script.bat'));
+ok("start claude blocked", blocks('start "" claude -p "test"'));
+
+// File opens allowed
+ok("start pdf allowed", passes('start "" "report.pdf"'));
+ok("start html allowed", passes('start "" "index.html"'));
+ok("start png allowed", passes('start "" "screenshot.png"'));
+ok("start txt allowed", passes('start "" "notes.txt"'));
+ok("start xlsx allowed", passes('start "" "data.xlsx"'));
+
+// Normal commands allowed
+ok("echo allowed", passes("echo hello"));
+ok("node inline allowed", passes("node -e 'console.log(1)'"));
+ok("git allowed", passes("git status"));
+ok("empty command allowed", passes(""));
+
+// Block message quality
+var r = gate({tool_name: "Bash", tool_input: {command: "node script.js &"}});
+ok("block mentions focus", r && /FOCUS/i.test(r.reason));
+ok("block mentions run_in_background", r && /run_in_background/.test(r.reason));
+
+console.log("\n" + pass + "/" + (pass+fail) + " passed");
+process.exit(fail > 0 ? 1 : 0);

--- a/scripts/test/test-no-fragile-heuristics.js
+++ b/scripts/test/test-no-fragile-heuristics.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+"use strict";
+var path = require("path");
+var gate = require(path.join(__dirname, "../../modules/PreToolUse/no-fragile-heuristics.js"));
+
+var pass = 0, fail = 0;
+function ok(name, cond) {
+  if (cond) { pass++; console.log("OK: " + name); }
+  else { fail++; console.log("FAIL: " + name); }
+}
+
+// Non-Edit/Write ignored
+ok("Read ignored", gate({tool_name: "Read", tool_input: {}}) === null);
+ok("Bash ignored", gate({tool_name: "Bash", tool_input: {}}) === null);
+
+// Heuristic patterns in verification scripts blocked
+function editVerify(content) {
+  return gate({tool_name: "Edit", tool_input: {file_path: "/review-quality.py", new_string: content}});
+}
+function writeVerify(content) {
+  return gate({tool_name: "Write", tool_input: {file_path: "/check-screenshot.py", content: content}});
+}
+
+var r1 = editVerify("white_ratio = pixels / total");
+ok("pixel ratio blocked", r1 && r1.decision === "block");
+
+var r2 = writeVerify("unique_colors = len(set(image.getdata()))");
+ok("color count blocked", r2 && r2.decision === "block");
+
+var r3 = editVerify("img.convert('RGB').getpixel((0,0))");
+ok("getpixel blocked", r3 && r3.decision === "block");
+
+var r4 = writeVerify("if white_ish > 0.95: blank = True");
+ok("white_ish blocked", r4 && r4.decision === "block");
+
+var r5 = writeVerify("colors = img.quantize(colors=16)");
+ok("quantize color blocked", r5 && r5.decision === "block");
+
+// Non-verification scripts allowed
+var r6 = gate({tool_name: "Edit", tool_input: {file_path: "/src/image-processor.py", new_string: "white_ratio = 0.5"}});
+ok("non-verify script allowed", r6 === null);
+
+// Normal content in verification scripts allowed
+var r7 = editVerify("result = analyze_report(data)");
+ok("normal content allowed", r7 === null);
+
+// Block message quality
+ok("block mentions claude -p", r1 && /claude.*-p|Anthropic SDK/i.test(r1.reason));
+ok("block mentions fragile", r1 && /fragile/i.test(r1.reason));
+
+console.log("\n" + pass + "/" + (pass+fail) + " passed");
+process.exit(fail > 0 ? 1 : 0);

--- a/scripts/test/test-why-reminder.js
+++ b/scripts/test/test-why-reminder.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+"use strict";
+var path = require("path");
+var gate = require(path.join(__dirname, "../../modules/PreToolUse/why-reminder.js"));
+
+var pass = 0, fail = 0;
+function ok(name, cond) {
+  if (cond) { pass++; console.log("OK: " + name); }
+  else { fail++; console.log("FAIL: " + name); }
+}
+
+// Non-Edit/Write ignored
+ok("Read ignored", gate({tool_name: "Read", tool_input: {}}) === null);
+ok("Bash ignored", gate({tool_name: "Bash", tool_input: {}}) === null);
+
+// Code files get reminder (non-blocking)
+var r1 = gate({tool_name: "Edit", tool_input: {file_path: "/src/gate.js", old_string: "a", new_string: "b"}});
+ok("JS file: returns text reminder", r1 && r1.text && /WHY/i.test(r1.text));
+ok("JS file: not a block", !r1 || r1.decision !== "block");
+
+var r2 = gate({tool_name: "Write", tool_input: {file_path: "/config.yaml", content: "key: val"}});
+ok("YAML file: returns reminder", r2 && r2.text);
+
+var r3 = gate({tool_name: "Edit", tool_input: {file_path: "/script.py", old_string: "a", new_string: "b"}});
+ok("Python file: returns reminder", r3 && r3.text);
+
+// Binary files skipped
+ok("PNG skipped", gate({tool_name: "Write", tool_input: {file_path: "/img.png", content: ""}}) === null);
+ok("PDF skipped", gate({tool_name: "Write", tool_input: {file_path: "/doc.pdf", content: ""}}) === null);
+ok("ZIP skipped", gate({tool_name: "Write", tool_input: {file_path: "/a.zip", content: ""}}) === null);
+
+// Non-code extensions skipped
+ok("no extension skipped", gate({tool_name: "Write", tool_input: {file_path: "/Makefile", content: ""}}) === null);
+
+// Empty path skipped
+ok("empty path skipped", gate({tool_name: "Edit", tool_input: {file_path: ""}}) === null);
+
+console.log("\n" + pass + "/" + (pass+fail) + " passed");
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- 65 new tests across 5 previously untested modules:
  - no-focus-steal (18): Windows-only background process blocking, file open exemptions
  - why-reminder (11): non-blocking reminders for code files, binary skip
  - crlf-ssh-key-check (11): SSH key copy CRLF detection
  - no-fragile-heuristics (11): pixel/color threshold blocking in verification scripts
  - claude-p-pattern (14): bad subprocess invocations, API key/base64/SDK anti-patterns

## Test plan
- [x] All 5 suites pass (65/65)