### PR TITLE
T614: Fix README workflow module counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ The setup wizard will:
 1. Scan your current hooks and generate a styled HTML report
 2. Back up existing hooks to `~/.claude/hooks/archive/`
 3. Install the runner system
-4. Enable the `starter` workflow (with `--yes`) — 49 universally useful modules
+4. Enable the `starter` workflow (with `--yes`) — 46 universally useful modules
 
 Ready for more? Enable the full development pipeline:
 ```bash
-node setup.js --workflow enable shtd    # 110 modules: spec-first, test-first, PR discipline
+node setup.js --workflow enable shtd    # 104 modules: spec-first, test-first, PR discipline
 ```
 
 To undo everything: `node setup.js --uninstall --confirm`


### PR DESCRIPTION
## Summary
- starter: 49→46 (actual count from WORKFLOW tag grep)
- shtd: 110→104 (actual count)