### PR TITLE
T615: Add --list --why flag for module descriptions

### DIFF
--- a/scripts/test/test-list-why.js
+++ b/scripts/test/test-list-why.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+"use strict";
+// Tests for --list --why feature (T615)
+var cp = require("child_process");
+var path = require("path");
+var setupJs = path.join(__dirname, "../../setup.js");
+
+var pass = 0, fail = 0;
+function ok(cond, msg) { if (cond) { pass++; console.log("OK: " + msg); } else { fail++; console.log("FAIL: " + msg); } }
+
+// Test 1: --list without --why shows no WHY descriptions
+var r1 = cp.execSync("node " + JSON.stringify(setupJs) + " --list 2>&1", { encoding: "utf8" });
+ok(r1.indexOf("[hook-runner] Module List") !== -1, "--list shows header");
+ok(r1.indexOf("force-push-gate") !== -1, "--list shows module names");
+// WHY lines are indented with 6 spaces and start with a capital letter describing the incident
+// Check that no WHY-style description appears (they'd be on indented sub-lines)
+var lines1 = r1.split("\n").filter(function(l) { return /^      [A-Z]/.test(l); });
+ok(lines1.length === 0, "--list without --why shows no descriptions");
+
+// Test 2: --list --why shows WHY descriptions
+var r2 = cp.execSync("node " + JSON.stringify(setupJs) + " --list --why 2>&1", { encoding: "utf8" });
+ok(r2.indexOf("[hook-runner] Module List") !== -1, "--list --why shows header");
+ok(r2.indexOf("force-push-gate") !== -1, "--list --why shows module names");
+// Should have description lines (6-space indented)
+var lines2 = r2.split("\n").filter(function(l) { return /^      [A-Z]/.test(l); });
+ok(lines2.length > 10, "--list --why shows descriptions (" + lines2.length + " found)");
+
+// Test 3: WHY descriptions are truncated at 72 chars
+var longLines = lines2.filter(function(l) { return l.trim().length > 72; });
+ok(longLines.length === 0, "WHY descriptions truncated to 72 chars");
+
+// Test 4: Truncated lines end with ...
+var truncated = lines2.filter(function(l) { return l.trim().endsWith("..."); });
+ok(truncated.length > 0, "Some descriptions are truncated with ...");
+
+// Test 5: Helper modules (underscore prefix) may not have WHY
+// _bash-write-patterns has WHY, _file-modify-patterns may not — just verify no crash
+ok(r2.indexOf("_bash-write-patterns") !== -1, "Helper modules listed even with --why");
+
+// Test 6: Summary line still shows counts
+ok(/\d+ installed, \d+ in catalog/.test(r2), "--list --why still shows summary counts");
+
+// Test 7: --list --why output is longer than --list
+ok(r2.length > r1.length, "--list --why output is longer than --list");
+
+console.log("\n" + pass + " passed, " + fail + " failed");
+process.exit(fail > 0 ? 1 : 0);

--- a/setup.js
+++ b/setup.js
@@ -752,7 +752,7 @@ function cmdHelp() {
   console.log("  --analyze --input <file>  Merge pre-computed LLM analysis JSON into the report");
   console.log("  --health        Verify runners, modules, and settings are correct");
   console.log("  --sync          Sync modules from GitHub per ~/.claude/hooks/modules.yaml");
-  console.log("  --list          Show catalog vs installed modules with status");
+  console.log("  --list          Show catalog vs installed modules with status (--why for descriptions)");
   console.log("  --stats         Quick text summary of hook log activity");
   console.log("  --lessons       Show self-analysis lessons (--project <name>, --date YYYY-MM-DD)");
   console.log("  --workflow      Manage enforceable step pipelines (list|start|status|complete|reset)");
@@ -793,6 +793,7 @@ function cmdHelp() {
   console.log("Examples:");
   console.log("  node setup.js                    # first-time setup");
   console.log("  node setup.js --report           # see your hooks without installing");
+  console.log("  node setup.js --list --why       # browse modules with descriptions");
   console.log("  node setup.js --sync --dry-run   # preview module sync");
   console.log("  node setup.js --uninstall --dry-run  # preview removal");
 }
@@ -1093,7 +1094,20 @@ function cmdLessons(args) {
   if (lessons.length === 0) console.log("  No lessons match the given filters.");
 }
 
-function cmdList() {
+function extractWhy(filePath) {
+  try {
+    var content = fs.readFileSync(filePath, "utf8");
+    var lines = content.split("\n");
+    for (var i = 0; i < Math.min(lines.length, 15); i++) {
+      var match = lines[i].match(/^\/\/\s*WHY:\s*(.+)/);
+      if (match) return match[1].trim();
+    }
+  } catch(e) {}
+  return null;
+}
+
+function cmdList(args) {
+  var showWhy = args && args.indexOf("--why") !== -1;
   console.log("[hook-runner] Module List");
   console.log("========================");
   var catalogDir = path.join(REPO_DIR, "modules");
@@ -1140,7 +1154,18 @@ function cmdList() {
       var status = m.installed && m.catalog ? " [installed]" :
                    m.installed && !m.catalog ? " [installed, custom]" :
                    " [available]";
-      console.log("    " + modNames[mn].replace(".js", "") + status);
+      var line = "    " + modNames[mn].replace(".js", "") + status;
+      if (showWhy) {
+        var modFile = m.installed
+          ? path.join(liveDir, ev, modNames[mn])
+          : path.join(catalogDir, ev, modNames[mn]);
+        var why = extractWhy(modFile);
+        if (why) {
+          if (why.length > 72) why = why.slice(0, 69) + "...";
+          line += "\n      " + why;
+        }
+      }
+      console.log(line);
     }
   }
   var projScoped = [];
@@ -2292,7 +2317,7 @@ function main() {
   if (args.indexOf("--stats") !== -1) return cmdStats();
   if (args.indexOf("--export") !== -1) return cmdExport(args);
   if (args.indexOf("--perf") !== -1) return cmdPerf();
-  if (args.indexOf("--list") !== -1) return cmdList();
+  if (args.indexOf("--list") !== -1) return cmdList(args);
   if (args.indexOf("--test-module") !== -1) return cmdTestModule(args);
   if (args.indexOf("--test") !== -1) return cmdTest(args);
   if (args.indexOf("--integrity") !== -1) return cmdIntegrity(args);


### PR DESCRIPTION
## Summary
- Adds `--why` flag to `--list` command that shows `// WHY:` descriptions inline
- Extracts WHY comments from module source files, truncates at 72 chars
- No change to default `--list` behavior (descriptions only shown with `--why`)

## Test plan
- [x] 11 new tests in `test-list-why.js` — all pass
- [x] Existing `test-setup-wizard.sh` — 7/7 pass
- [x] `--list` without `--why` unchanged
- [x] `--list --why` shows 114 descriptions across all modules