### PR TITLE
T617: v2.78.0 — --list --why + windowless-spawn-gate test fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.78.0] — 2026-05-04
+
+### Added
+- **`--list --why`** (T615) — Shows `// WHY:` descriptions inline when browsing the module catalog. Truncates at 72 chars. 11 tests.
+
+### Fixed
+- **windowless-spawn-gate test env leak** (T616) — Test failed when run via `--test` because the gate checks `HOOK_RUNNER_TEST` and the runner sets it. Test now saves/clears the env var. 32/32 pass.
+
+### Stats
+- 191 suites, ~2832 tests
+- 122 modules, 7 workflows
+
 ## [2.77.0] — 2026-05-04
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.77.0",
+  "version": "2.78.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- Version bump to v2.78.0
- CHANGELOG entry for T615 (--list --why) and T616 (test env fix)

## Test plan
- [x] All prior tests pass
- [x] Version in package.json matches CHANGELOG