### PR TITLE
T618: Fix --test-module to resolve bare module names

### DIFF
--- a/scripts/test/test-test-module-resolve.js
+++ b/scripts/test/test-test-module-resolve.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+"use strict";
+// Tests for --test-module path resolution (T618)
+var cp = require("child_process");
+var path = require("path");
+var setupJs = path.join(__dirname, "../../setup.js");
+
+var pass = 0, fail = 0;
+function ok(cond, msg) { if (cond) { pass++; console.log("OK: " + msg); } else { fail++; console.log("FAIL: " + msg); } }
+
+function run(modName) {
+  try {
+    return cp.execSync("node " + JSON.stringify(setupJs) + " --test-module " + modName + " 2>&1", { encoding: "utf8" });
+  } catch(e) {
+    return e.stdout || e.stderr || e.message;
+  }
+}
+
+// 1. Bare module name resolves to PreToolUse
+var r1 = run("force-push-gate");
+ok(r1.indexOf("Module:") !== -1 && r1.indexOf("PreToolUse") !== -1, "Bare name resolves to PreToolUse");
+
+// 2. Bare name with .js suffix also works
+var r2 = run("force-push-gate.js");
+ok(r2.indexOf("Module:") !== -1 && r2.indexOf("PreToolUse") !== -1, "Name with .js suffix resolves");
+
+// 3. PostToolUse module resolves
+var r3 = run("disk-space-detect");
+ok(r3.indexOf("Module:") !== -1 && r3.indexOf("PostToolUse") !== -1, "PostToolUse module resolves");
+
+// 4. Stop module resolves
+var r4 = run("auto-continue");
+ok(r4.indexOf("Module:") !== -1 && r4.indexOf("Stop") !== -1, "Stop module resolves");
+
+// 5. SessionStart module resolves
+var r5 = run("load-lessons");
+ok(r5.indexOf("Module:") !== -1 && r5.indexOf("SessionStart") !== -1, "SessionStart module resolves");
+
+// 6. Nonexistent module shows error
+var r6 = run("does-not-exist-xyz");
+ok(r6.indexOf("Module not found") !== -1, "Nonexistent module shows error");
+ok(r6.indexOf("Searched modules/") !== -1, "Error mentions search locations");
+
+// 7. Full path still works
+var fullPath = path.join(__dirname, "../../modules/PreToolUse/force-push-gate.js");
+var r7 = run(JSON.stringify(fullPath));
+ok(r7.indexOf("Module:") !== -1 && r7.indexOf("force-push-gate") !== -1, "Full path still works");
+
+// 8. Shows WHY and WORKFLOW headers
+ok(r1.indexOf("WHY comment: yes") !== -1, "Shows WHY comment status");
+ok(r1.indexOf("WORKFLOW tag:") !== -1, "Shows WORKFLOW tag");
+
+// 9. Runs sample inputs
+ok(r1.indexOf("inputs:") !== -1, "Runs sample inputs");
+
+console.log("\n" + pass + " passed, " + fail + " failed");
+process.exit(fail > 0 ? 1 : 0);

--- a/setup.js
+++ b/setup.js
@@ -762,7 +762,7 @@ function cmdHelp() {
   console.log("  --disable-all   Disable all workflow groups (--global for global scope)");
   console.log("  --export [file] Export installed modules as shareable YAML (default: modules-export.yaml)");
   console.log("  --perf          Analyze module timing data and identify bottlenecks");
-  console.log("  --test-module   Test a single module with sample inputs");
+  console.log("  --test-module   Test a module with sample inputs (name or path, e.g. force-push-gate)");
   console.log("  --test          Run all test suites (--timeout <sec>, --skip-wsl, --js-only, --sh-only)");
   console.log("  --upgrade       Fetch latest runners from GitHub and update local copies");
   console.log("  --uninstall     Remove hook-runner from settings.json and hooks dir");
@@ -1885,13 +1885,34 @@ function cmdTestModule(args) {
   var idx = args.indexOf("--test-module");
   var modPath = args[idx + 1];
   if (!modPath) {
-    console.error("Usage: node setup.js --test-module <path-to-module.js> [--input <json-file>]");
+    console.error("Usage: node setup.js --test-module <name-or-path> [--input <json-file>]");
     process.exit(1);
   }
   modPath = path.resolve(modPath);
   if (!fs.existsSync(modPath)) {
-    console.error("Module not found: " + modPath);
-    process.exit(1);
+    // Try resolving as a module name (e.g. "force-push-gate" or "force-push-gate.js")
+    var modName = path.basename(modPath);
+    if (!modName.endsWith(".js")) modName += ".js";
+    var events = ["PreToolUse", "PostToolUse", "SessionStart", "Stop", "UserPromptSubmit"];
+    var found = null;
+    for (var ei = 0; ei < events.length && !found; ei++) {
+      var candidate = path.join(REPO_DIR, "modules", events[ei], modName);
+      if (fs.existsSync(candidate)) found = candidate;
+    }
+    if (!found) {
+      // Also check live hooks dir
+      for (var ej = 0; ej < events.length && !found; ej++) {
+        var liveCandidate = path.join(HOOKS_DIR, "run-modules", events[ej], modName);
+        if (fs.existsSync(liveCandidate)) found = liveCandidate;
+      }
+    }
+    if (found) {
+      modPath = found;
+    } else {
+      console.error("Module not found: " + modPath);
+      console.error("  Searched modules/ and live hooks for: " + modName);
+      process.exit(1);
+    }
   }
   console.log("[hook-runner] Test Module");
   console.log("========================");


### PR DESCRIPTION
## Summary
- `--test-module force-push-gate` now works (previously required full path)
- Searches `modules/` across all event types, falls back to live hooks
- Helpful error message when module not found

## Test plan
- [x] 11 new tests in `test-test-module-resolve.js` — all pass
- [x] Existing `test-setup-wizard.sh` — 7/7 pass
- [x] PreToolUse, PostToolUse, Stop, SessionStart modules all resolve
- [x] Full paths still work
- [x] Nonexistent module shows helpful error