### PR TITLE
T621: Add --search command for module discovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ node setup.js --health       # verify runners + modules
 node setup.js --diagnose     # diagnose settings, hooks, broken scripts (--fix, --json)
 node setup.js --sync         # sync modules from GitHub
 node setup.js --list         # catalog vs installed
+node setup.js --search <q>   # find modules by name or WHY description
 node setup.js --stats        # text summary of hook log
 node setup.js --perf         # module timing analysis
 node setup.js --export       # export module config as YAML

--- a/scripts/test/test-search.js
+++ b/scripts/test/test-search.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+"use strict";
+// Tests for --search feature (T621)
+var cp = require("child_process");
+var path = require("path");
+var setupJs = path.join(__dirname, "../../setup.js");
+
+var pass = 0, fail = 0;
+function ok(cond, msg) { if (cond) { pass++; console.log("OK: " + msg); } else { fail++; console.log("FAIL: " + msg); } }
+
+function run(args) {
+  try {
+    return cp.execSync("node " + JSON.stringify(setupJs) + " " + args + " 2>&1", { encoding: "utf8" });
+  } catch(e) {
+    return { output: (e.stdout || "") + (e.stderr || ""), status: e.status };
+  }
+}
+
+// Test 1: --search with matching name
+var r1 = run("--search git");
+ok(typeof r1 === "string" && r1.indexOf("modules matching") !== -1, "--search git shows match count");
+ok(r1.indexOf("git-destructive-guard") !== -1, "--search git finds git-destructive-guard");
+ok(r1.indexOf("git-rebase-safety") !== -1, "--search git finds git-rebase-safety");
+
+// Test 2: --search is case-insensitive
+var r2 = run("--search GIT");
+ok(typeof r2 === "string" && r2.indexOf("git-destructive-guard") !== -1, "--search GIT (uppercase) finds modules");
+
+// Test 3: --search matches WHY descriptions too
+var r3 = run("--search polling");
+ok(typeof r3 === "string" && r3.indexOf("no-polling-gate") !== -1, "--search polling finds no-polling-gate via WHY");
+
+// Test 4: --search with no matches
+var r4 = run("--search zzz_nonexistent_xyz");
+ok(typeof r4 === "string" && r4.indexOf("No modules matching") !== -1, "--search with no matches shows message");
+
+// Test 5: --search with no query shows usage
+var r5 = run("--search");
+ok(typeof r5 === "object" && r5.status === 1, "--search with no query exits with code 1");
+ok(r5.output.indexOf("Usage:") !== -1, "--search with no query shows usage");
+
+// Test 6: Results show event type prefix
+ok(r1.indexOf("PreToolUse/") !== -1, "Results include event type prefix");
+
+// Test 7: Results show install status
+ok(r1.indexOf("[installed]") !== -1 || r1.indexOf("[available]") !== -1, "Results show install status");
+
+// Test 8: Results show WHY descriptions
+ok(r1.indexOf("    ") !== -1, "Results include indented WHY descriptions");
+
+// Test 9: --search force finds force-push-gate
+var r9 = run("--search force");
+ok(typeof r9 === "string" && r9.indexOf("force-push-gate") !== -1, "--search force finds force-push-gate");
+
+// Test 10: --search secret finds secret-scan-gate
+var r10 = run("--search secret");
+ok(typeof r10 === "string" && r10.indexOf("secret-scan-gate") !== -1, "--search secret finds secret-scan-gate");
+ok(r10.indexOf("1 module") !== -1, "--search secret shows singular 'module'");
+
+// Test 11: --search with partial match finds modules
+var r11 = run("--search deploy");
+ok(typeof r11 === "string" && r11.indexOf("deploy") !== -1, "--search deploy finds deploy-related modules");
+
+console.log("\n" + pass + " passed, " + fail + " failed");
+process.exit(fail > 0 ? 1 : 0);

--- a/setup.js
+++ b/setup.js
@@ -753,6 +753,7 @@ function cmdHelp() {
   console.log("  --health        Verify runners, modules, and settings are correct");
   console.log("  --sync          Sync modules from GitHub per ~/.claude/hooks/modules.yaml");
   console.log("  --list          Show catalog vs installed modules with status (--why for descriptions)");
+  console.log("  --search <q>    Search modules by name or WHY description (case-insensitive)");
   console.log("  --stats         Quick text summary of hook log activity");
   console.log("  --lessons       Show self-analysis lessons (--project <name>, --date YYYY-MM-DD)");
   console.log("  --workflow      Manage enforceable step pipelines (list|start|status|complete|reset)");
@@ -794,6 +795,7 @@ function cmdHelp() {
   console.log("  node setup.js                    # first-time setup");
   console.log("  node setup.js --report           # see your hooks without installing");
   console.log("  node setup.js --list --why       # browse modules with descriptions");
+  console.log("  node setup.js --search git       # find git-related modules");
   console.log("  node setup.js --sync --dry-run   # preview module sync");
   console.log("  node setup.js --uninstall --dry-run  # preview removal");
 }
@@ -1192,6 +1194,58 @@ function cmdList(args) {
   }
   console.log("");
   console.log("[hook-runner] " + installedCount + " installed, " + catalogCount + " in catalog");
+}
+
+function cmdSearch(args) {
+  var queryIdx = args.indexOf("--search");
+  var query = queryIdx !== -1 && args[queryIdx + 1] ? args[queryIdx + 1] : "";
+  if (!query || query.indexOf("--") === 0) {
+    console.log("Usage: node setup.js --search <query>");
+    console.log("  Searches module names and WHY descriptions (case-insensitive)");
+    process.exit(1);
+    return;
+  }
+  var qLower = query.toLowerCase();
+  var catalogDir = path.join(REPO_DIR, "modules");
+  var liveDir = path.join(HOOKS_DIR, "run-modules");
+  var events = ["PreToolUse", "PostToolUse", "UserPromptSubmit", "Stop", "SessionStart"];
+  var results = [];
+  for (var i = 0; i < events.length; i++) {
+    var ev = events[i];
+    var evDir = path.join(catalogDir, ev);
+    var liveEvDir = path.join(liveDir, ev);
+    var files;
+    try { files = fs.readdirSync(evDir).filter(function(f) { return f.slice(-3) === ".js"; }); }
+    catch(e) { continue; }
+    var installedFiles = [];
+    try { installedFiles = fs.readdirSync(liveEvDir).filter(function(f) { return f.slice(-3) === ".js"; }); }
+    catch(e) {}
+    for (var j = 0; j < files.length; j++) {
+      var name = files[j].replace(".js", "");
+      var why = extractWhy(path.join(evDir, files[j])) || "";
+      var nameMatch = name.toLowerCase().indexOf(qLower) !== -1;
+      var whyMatch = why.toLowerCase().indexOf(qLower) !== -1;
+      if (nameMatch || whyMatch) {
+        var installed = installedFiles.indexOf(files[j]) !== -1;
+        results.push({ event: ev, name: name, why: why, installed: installed });
+      }
+    }
+  }
+  if (results.length === 0) {
+    console.log("[hook-runner] No modules matching \"" + query + "\"");
+    return;
+  }
+  console.log("[hook-runner] " + results.length + " module" + (results.length === 1 ? "" : "s") + " matching \"" + query + "\"");
+  console.log("");
+  for (var r = 0; r < results.length; r++) {
+    var m = results[r];
+    var status = m.installed ? " [installed]" : " [available]";
+    console.log("  " + m.event + "/" + m.name + status);
+    if (m.why) {
+      var desc = m.why.length > 72 ? m.why.slice(0, 69) + "..." : m.why;
+      console.log("    " + desc);
+    }
+  }
 }
 
 function cmdTest(args) {
@@ -2339,6 +2393,7 @@ function main() {
   if (args.indexOf("--export") !== -1) return cmdExport(args);
   if (args.indexOf("--perf") !== -1) return cmdPerf();
   if (args.indexOf("--list") !== -1) return cmdList(args);
+  if (args.indexOf("--search") !== -1) return cmdSearch(args);
   if (args.indexOf("--test-module") !== -1) return cmdTestModule(args);
   if (args.indexOf("--test") !== -1) return cmdTest(args);
   if (args.indexOf("--integrity") !== -1) return cmdIntegrity(args);


### PR DESCRIPTION
## Summary
- New `--search <query>` CLI command for finding modules by name or WHY description
- Case-insensitive matching across all event types
- Shows event type, install status, and WHY descriptions for matches
- 15 tests in `test-search.js`

## Examples
```
node setup.js --search git       # 8 modules matching "git"
node setup.js --search secret    # 1 module matching "secret"
node setup.js --search polling   # finds no-polling-gate via WHY description
```

## Test plan
- [x] 15/15 search tests pass
- [x] 7/7 setup wizard tests pass
- [x] 11/11 list-why tests pass
- [ ] CI green (Ubuntu + Windows)