### PR TITLE
T622: v2.80.0 — search docs, version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to hook-runner are documented here.
 
+## [2.80.0] — 2026-05-04
+
+### Added
+- **`--search <query>`** (T621) — Find modules by name or WHY description. Case-insensitive. Shows event type, install status, and descriptions. 15 tests.
+
+### Docs
+- README: Added `--list --why` and `--search` to CLI reference.
+- GETTING-STARTED.md: Added `--search` to day-to-day commands.
+
+### Stats
+- 193 suites, ~2869 tests
+- 118 modules in catalog, 7 workflows
+
 ## [2.79.0] — 2026-05-04
 
 ### Added

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -79,6 +79,7 @@ node setup.js --workflow disable shtd
 node setup.js --health            # is everything working?
 node setup.js --diagnose          # something broken? start here
 node setup.js --list --why        # browse modules with descriptions
+node setup.js --search git        # find modules by keyword
 node setup.js --test-module NAME  # test a module against sample inputs
 node setup.js --stats             # what are my hooks doing?
 node setup.js --report --open     # visual HTML overview

--- a/README.md
+++ b/README.md
@@ -303,6 +303,8 @@ node setup.js --uninstall [--confirm]  # remove (--confirm restores backup)
 
 # Modules
 node setup.js --list                   # catalog vs installed comparison
+node setup.js --list --why             # browse modules with descriptions
+node setup.js --search <query>         # find modules by name or description
 node setup.js --sync [--dry-run]       # sync from GitHub per modules.yaml
 node setup.js --export [file.yaml]     # export config as shareable YAML
 node setup.js --upgrade [--dry-run]    # fetch latest from GitHub

--- a/TODO.md
+++ b/TODO.md
@@ -7,9 +7,9 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 - Local skill: ~/.claude/skills/hook-runner/
 - Live hooks: ~/.claude/hooks/ (run-*.js, load-modules.js, run-modules/)
 
-## Current State (v2.79.0)
-- 118 modules in catalog, 7 workflows, 192 test suites, ~2854 tests
-- PRs: 535 merged
+## Current State (v2.80.0)
+- 118 modules in catalog, 7 workflows, 193 test suites, ~2869 tests
+- PRs: 537 merged
 - CI: fully green (Ubuntu + Windows + install)
 
 ## Open Tasks
@@ -36,7 +36,14 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 - [x] T618: Fix `--test-module` to resolve bare module names — searches all event folders. 11 tests. (PR #531)
 - [x] T619: Fix GETTING-STARTED.md (starter 49→46) + README `--test-module` examples. (PRs #532-#533)
 - [x] T620: Fix diagnose.js tilde expansion in Windows 8.3 paths — `RUNNER~1` was expanded to HOME. CI now fully green. 22 tests. (PR #535)
+- [x] T621: Add `--search <query>` — find modules by name or WHY description. 15 tests. (PR #537)
 - [ ] (deferred) Port remaining OpenClaw modules (configurable/niche: aws-tagging, deploy-gate, messaging-safety, etc.)
+
+## Session Handoff (2026-05-04, session 14)
+- T621 (PR #537): `--search <query>` — find modules by name or WHY description. Case-insensitive. 15 tests.
+- T622: README + GETTING-STARTED.md updated with `--search` and `--list --why`. v2.80.0.
+- v2.80.0. 118 catalog modules, 193 suites, ~2869 tests, 538 PRs.
+- Remaining open: T578 (marketplace sync, blocked on user), deferred OpenClaw module ports.
 
 ## Session Handoff (2026-05-04, session 13)
 - T615 (PR #527): `--list --why` flag shows `// WHY:` descriptions inline in module catalog. 11 tests.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hook-runner",
-  "version": "2.79.0",
+  "version": "2.80.0",
   "description": "Modular hook runner system for Claude Code. One runner per event, modules in folders.",
   "bin": {
     "hook-runner": "setup.js"


### PR DESCRIPTION
## Summary
- README: Added `--list --why` and `--search <query>` to CLI reference
- GETTING-STARTED.md: Added `--search` to day-to-day commands
- Version bump to v2.80.0, changelog entry
- Session 14 handoff in TODO.md

## Test plan
- [x] No code changes — docs and version only
- [ ] CI green