### PR TITLE
T623: Add --reason to context-reset calls in stop message

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -37,6 +37,7 @@ Modular hook runner system for Claude Code. One runner per event, modules in fol
 - [x] T619: Fix GETTING-STARTED.md (starter 49→46) + README `--test-module` examples. (PRs #532-#533)
 - [x] T620: Fix diagnose.js tilde expansion in Windows 8.3 paths — `RUNNER~1` was expanded to HOME. CI now fully green. 22 tests. (PR #535)
 - [x] T621: Add `--search <query>` — find modules by name or WHY description. 15 tests. (PR #537)
+- [ ] T623: Spawn-reason tracking — stop module should pass `--reason` to context_reset.py. Depends on context-reset T034 (`--reason` arg). After T034 merges, update the stop module's context-reset call to include reason string.
 - [ ] (deferred) Port remaining OpenClaw modules (configurable/niche: aws-tagging, deploy-gate, messaging-safety, etc.)
 
 ## Session Handoff (2026-05-04, session 14)

--- a/modules/Stop/stop-message.txt
+++ b/modules/Stop/stop-message.txt
@@ -7,8 +7,8 @@ DO NOT STOP. DO NOT SUMMARIZE. DO NOT LIST OPTIONS. Follow this order:
 5) Zoom out: why does this project exist, how does it integrate, what real-world value comes next? How can we share it with the team — publish, document, demo, package? Write new tasks to TODO.md then EXECUTE. No breaks. No asking. Plan then do.
 
 If context is getting long, save state to $CLAUDE_PROJECT_DIR/TODO.md (always the launch directory, not cwd), then run context-reset (ALWAYS closes this tab):
-  python "$CONTEXT_RESET_PY" --project-dir $CLAUDE_PROJECT_DIR
+  python "$CONTEXT_RESET_PY" --project-dir $CLAUDE_PROJECT_DIR --reason "<why: e.g. context full, completing T123, or user-requested>"
   (CONTEXT_RESET_PY defaults to ~/Documents/ProjectsCL1/_grobomo/context-reset/context_reset.py)
 
 CROSS-PROJECT WORK: If you created TODOs in another project's TODO.md, open a new session there (this tab keeps running):
-  python "$NEW_SESSION_PY" --project-dir <OTHER_PROJECT_DIR>
+  python "$NEW_SESSION_PY" --project-dir <OTHER_PROJECT_DIR> --reason "<why: e.g. cross-project TODO for T034>"


### PR DESCRIPTION
## Summary
- Stop message now instructs Claude to pass `--reason` when calling context_reset.py
- Enables spawn-reason tracking for autonomous session chains
- Depends on context-reset T034 (adding `--reason` arg to new_session.py)

## Context
User discovered 14 consecutive autonomous hook-runner sessions with no way to trace why they were spawned. The stop hook's "DO NOT STOP" loop caused self-perpetuating context resets with no reason logged.

## Test plan
- [x] stop-message.txt updated with `--reason` in example commands
- [x] No code changes to auto-continue.js (message is read from file)
- [ ] CI green